### PR TITLE
Fix: Update dashboard navigation links

### DIFF
--- a/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor
@@ -23,16 +23,27 @@
                 </div>
                 <p class="text-[#0e131b] text-sm font-medium leading-normal">Dashboard</p>
                 </div>
-                <div class="flex items-center gap-3 px-3 py-2">
-                <div class="text-[#0e131b]" data-icon="CurrencyDollar" data-size="24px" data-weight="regular">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
-                    <path
-                        d="M152,120H136V56h8a32,32,0,0,1,32,32,8,8,0,0,0,16,0,48.05,48.05,0,0,0-48-48h-8V24a8,8,0,0,0-16,0V40h-8a48,48,0,0,0,0,96h8v64H104a32,32,0,0,1-32-32,8,8,0,0,0-16,0,48.05,48.05,0,0,0,48,48h16v16a8,8,0,0,0,16,0V216h16a48,48,0,0,0,0-96Zm-40,0a32,32,0,0,1,0-64h8v64Zm40,80H136V136h16a32,32,0,0,1,0,64Z"
-                    ></path>
-                    </svg>
-                </div>
-                <p class="text-[#0e131b] text-sm font-medium leading-normal">Sales</p>
-                </div>
+                <AuthorizeView>
+                    <Authorized>
+                        @{
+                            var salesLink = "/sales-pipeline-page";
+                            if (context.User.IsInRole("Manager"))
+                            {
+                                salesLink = "/sales-manager-dashboard";
+                            }
+                        }
+                        <a href="@salesLink" class="flex items-center gap-3 px-3 py-2">
+                            <div class="text-[#0e131b]" data-icon="CurrencyDollar" data-size="24px" data-weight="regular">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                                <path
+                                    d="M152,120H136V56h8a32,32,0,0,1,32,32,8,8,0,0,0,16,0,48.05,48.05,0,0,0-48-48h-8V24a8,8,0,0,0-16,0V40h-8a48,48,0,0,0,0,96h8v64H104a32,32,0,0,1-32-32,8,8,0,0,0-16,0,48.05,48.05,0,0,0,48,48h16v16a8,8,0,0,0,16,0V216h16a48,48,0,0,0,0-96Zm-40,0a32,32,0,0,1,0-64h8v64Zm40,80H136V136h16a32,32,0,0,1,0,64Z"
+                                ></path>
+                                </svg>
+                            </div>
+                            <p class="text-[#0e131b] text-sm font-medium leading-normal">Sales</p>
+                        </a>
+                    </Authorized>
+                </AuthorizeView>
                 <div class="flex items-center gap-3 px-3 py-2">
                 <div class="text-[#0e131b]" data-icon="Megaphone" data-size="24px" data-weight="regular">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">

--- a/src/Web/NexaCRM.WebClient/Pages/SalesManagerDashboard.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SalesManagerDashboard.razor
@@ -20,7 +20,7 @@
               <h2 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em]">Sales CRM</h2>
             </div>
             <div class="flex items-center gap-9">
-              <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">Dashboard</a>
+              <a class="text-[#0e131b] text-sm font-medium leading-normal" href="/main-dashboard">Dashboard</a>
               <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">Deals</a>
               <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">Contacts</a>
               <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">Reports</a>

--- a/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor
@@ -24,7 +24,7 @@
             <h2 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em]">SalesPro</h2>
         </div>
         <div class="flex items-center gap-9">
-            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">Dashboard</a>
+            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="/main-dashboard">Dashboard</a>
             <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">Contacts</a>
             <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">Deals</a>
             <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">Tasks</a>


### PR DESCRIPTION
This commit updates the navigation links on the main, sales, and manager dashboards.

- The "Sales" link on the main dashboard now dynamically points to the sales manager dashboard for managers and the sales pipeline page for sales users.
- The "Dashboard" link on the sales manager and sales pipeline pages now correctly navigates back to the main dashboard.