### PR TITLE
Feat: Create placeholder pages and connect all dashboard links

### DIFF
--- a/src/Web/NexaCRM.WebClient/Pages/ContactsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/ContactsPage.razor
@@ -1,0 +1,25 @@
+@page "/contacts"
+
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+    <div class="layout-container flex h-full grow flex-col">
+        <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-10 py-3">
+            <div class="flex items-center gap-8">
+                <div class="flex items-center gap-4 text-[#0e131b]">
+                    <div class="size-4">
+                        <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path fill-rule="evenodd" clip-rule="evenodd" d="M24 18.4228L42 11.475V34.3663C42 34.7796 41.7457 35.1504 41.3601 35.2992L24 42V18.4228Z" fill="currentColor"></path>
+                            <path fill-rule="evenodd" clip-rule="evenodd" d="M24 8.18819L33.4123 11.574L24 15.2071L14.5877 11.574L24 8.18819ZM9 15.8487L21 20.4805V37.6263L9 32.9945V15.8487ZM27 37.6263V20.4805L39 15.8487V32.9945L27 37.6263ZM25.354 2.29885C24.4788 1.98402 23.5212 1.98402 22.646 2.29885L4.98454 8.65208C3.7939 9.08038 3 10.2097 3 11.475V34.3663C3 36.0196 4.01719 37.5026 5.55962 38.098L22.9197 44.7987C23.6149 45.0671 24.3851 45.0671 25.0803 44.7987L42.4404 38.098C43.9828 37.5026 45 36.0196 45 34.3663V11.475C45 10.2097 44.2061 9.08038 43.0155 8.65208L25.354 2.29885Z" fill="currentColor"></path>
+                        </svg>
+                    </div>
+                    <h2 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em]">NexaCRM</h2>
+                </div>
+            </div>
+        </header>
+        <div class="px-40 flex flex-1 justify-center py-5">
+            <div class="layout-content-container flex flex-col max-w-[960px] flex-1">
+                <h1 class="text-4xl font-bold">Contacts</h1>
+                <p class="text-lg text-gray-500">This page is under construction.</p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Web/NexaCRM.WebClient/Pages/SalesManagerDashboard.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SalesManagerDashboard.razor
@@ -22,9 +22,9 @@
             <div class="flex items-center gap-9">
               <a class="text-[#0e131b] text-sm font-medium leading-normal" href="/main-dashboard">Dashboard</a>
               <a class="text-[#0e131b] text-sm font-medium leading-normal" href="/sales-pipeline-page">Deals</a>
-              <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">Contacts</a>
+              <a class="text-[#0e131b] text-sm font-medium leading-normal" href="/contacts">Contacts</a>
               <a class="text-[#0e131b] text-sm font-medium leading-normal" href="/reports-page">Reports</a>
-              <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">Tools</a>
+              <a class="text-[#0e131b] text-sm font-medium leading-normal" href="/tools">Tools</a>
             </div>
           </div>
           <div class="flex flex-1 justify-end gap-8">

--- a/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor
@@ -25,9 +25,9 @@
         </div>
         <div class="flex items-center gap-9">
             <a class="text-[#0e131b] text-sm font-medium leading-normal" href="/main-dashboard">Dashboard</a>
-            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">Contacts</a>
+            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="/contacts">Contacts</a>
             <a class="text-[#0e131b] text-sm font-medium leading-normal" href="/sales-pipeline-page">Deals</a>
-            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">Tasks</a>
+            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="/tasks">Tasks</a>
             <a class="text-[#0e131b] text-sm font-medium leading-normal" href="/reports-page">Reports</a>
         </div>
         </div>

--- a/src/Web/NexaCRM.WebClient/Pages/TasksPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/TasksPage.razor
@@ -1,0 +1,25 @@
+@page "/tasks"
+
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+    <div class="layout-container flex h-full grow flex-col">
+        <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-10 py-3">
+            <div class="flex items-center gap-8">
+                <div class="flex items-center gap-4 text-[#0e131b]">
+                    <div class="size-4">
+                        <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path fill-rule="evenodd" clip-rule="evenodd" d="M24 18.4228L42 11.475V34.3663C42 34.7796 41.7457 35.1504 41.3601 35.2992L24 42V18.4228Z" fill="currentColor"></path>
+                            <path fill-rule="evenodd" clip-rule="evenodd" d="M24 8.18819L33.4123 11.574L24 15.2071L14.5877 11.574L24 8.18819ZM9 15.8487L21 20.4805V37.6263L9 32.9945V15.8487ZM27 37.6263V20.4805L39 15.8487V32.9945L27 37.6263ZM25.354 2.29885C24.4788 1.98402 23.5212 1.98402 22.646 2.29885L4.98454 8.65208C3.7939 9.08038 3 10.2097 3 11.475V34.3663C3 36.0196 4.01719 37.5026 5.55962 38.098L22.9197 44.7987C23.6149 45.0671 24.3851 45.0671 25.0803 44.7987L42.4404 38.098C43.9828 37.5026 45 36.0196 45 34.3663V11.475C45 10.2097 44.2061 9.08038 43.0155 8.65208L25.354 2.29885Z" fill="currentColor"></path>
+                        </svg>
+                    </div>
+                    <h2 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em]">NexaCRM</h2>
+                </div>
+            </div>
+        </header>
+        <div class="px-40 flex flex-1 justify-center py-5">
+            <div class="layout-content-container flex flex-col max-w-[960px] flex-1">
+                <h1 class="text-4xl font-bold">Tasks</h1>
+                <p class="text-lg text-gray-500">This page is under construction.</p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Web/NexaCRM.WebClient/Pages/ToolsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/ToolsPage.razor
@@ -1,0 +1,25 @@
+@page "/tools"
+
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+    <div class="layout-container flex h-full grow flex-col">
+        <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-10 py-3">
+            <div class="flex items-center gap-8">
+                <div class="flex items-center gap-4 text-[#0e131b]">
+                    <div class="size-4">
+                        <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path fill-rule="evenodd" clip-rule="evenodd" d="M24 18.4228L42 11.475V34.3663C42 34.7796 41.7457 35.1504 41.3601 35.2992L24 42V18.4228Z" fill="currentColor"></path>
+                            <path fill-rule="evenodd" clip-rule="evenodd" d="M24 8.18819L33.4123 11.574L24 15.2071L14.5877 11.574L24 8.18819ZM9 15.8487L21 20.4805V37.6263L9 32.9945V15.8487ZM27 37.6263V20.4805L39 15.8487V32.9945L27 37.6263ZM25.354 2.29885C24.4788 1.98402 23.5212 1.98402 22.646 2.29885L4.98454 8.65208C3.7939 9.08038 3 10.2097 3 11.475V34.3663C3 36.0196 4.01719 37.5026 5.55962 38.098L22.9197 44.7987C23.6149 45.0671 24.3851 45.0671 25.0803 44.7987L42.4404 38.098C43.9828 37.5026 45 36.0196 45 34.3663V11.475C45 10.2097 44.2061 9.08038 43.0155 8.65208L25.354 2.29885Z" fill="currentColor"></path>
+                        </svg>
+                    </div>
+                    <h2 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em]">NexaCRM</h2>
+                </div>
+            </div>
+        </header>
+        <div class="px-40 flex flex-1 justify-center py-5">
+            <div class="layout-content-container flex flex-col max-w-[960px] flex-1">
+                <h1 class="text-4xl font-bold">Tools</h1>
+                <p class="text-lg text-gray-500">This page is under construction.</p>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
This commit creates new placeholder pages for Contacts, Tools, and Tasks, and connects all links in the main, sales, and manager dashboards to their corresponding pages.

- Created `ContactsPage.razor`, `ToolsPage.razor`, and `TasksPage.razor`.
- Updated `SalesManagerDashboard.razor` to link Contacts to `/contacts` and Tools to `/tools`.
- Updated `SalesPipelinePage.razor` to link Contacts to `/contacts` and Tasks to `/tasks`.
- All other existing links in the dashboards are now connected.