### PR TITLE
Fix build errors and warnings

### DIFF
--- a/src/Web/NexaCRM.WebClient/Pages/ContactsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/ContactsPage.razor
@@ -59,9 +59,9 @@
 </div>
 
 @code {
-    private IEnumerable<Contact> contacts;
+    private IEnumerable<Contact>? contacts;
 
-    protected override async Task OnInitializedAsync()
+    protected override async System.Threading.Tasks.Task OnInitializedAsync()
     {
         contacts = await ContactService.GetContactsAsync();
     }

--- a/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor
@@ -158,7 +158,7 @@
         <div class="flex flex-wrap justify-between gap-3 p-4">
             <AuthorizeView>
                 <Authorized>
-                    <p class="text-[#0e131b] tracking-light text-[32px] font-bold leading-tight min-w-72">@Localizer["WelcomeBack", @context.User.Identity?.Name]</p>
+                    <p class="text-[#0e131b] tracking-light text-[32px] font-bold leading-tight min-w-72">@Localizer["WelcomeBack", @context.User.Identity?.Name ?? ""]</p>
                 </Authorized>
             </AuthorizeView>
         </div>

--- a/src/Web/NexaCRM.WebClient/Pages/SalesManagerDashboard.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SalesManagerDashboard.razor
@@ -74,7 +74,7 @@
               <div class="flex min-w-72 flex-col gap-3">
                 <AuthorizeView>
                     <Authorized>
-                        <p class="text-[#0e131b] tracking-light text-[32px] font-bold leading-tight">@Localizer["Welcome", @context.User.Identity?.Name]</p>
+                        <p class="text-[#0e131b] tracking-light text-[32px] font-bold leading-tight">@Localizer["Welcome", @context.User.Identity?.Name ?? ""]</p>
                     </Authorized>
                 </AuthorizeView>
                 <p class="text-[#4d6a99] text-sm font-normal leading-normal">@Localizer["Overview"]</p>

--- a/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor
@@ -157,8 +157,8 @@
                                 <td class="table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-120 h-[72px] px-4 py-2 w-[400px] text-[#0e131b] text-sm font-normal leading-normal">
                                 @stage.Key
                                 </td>
-                                <td class="table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-240 h-[72px] px-4 py-2 w-[400px] text-[#4d6a99] text-sm font-normal leading-normal">@stage.Value.Count()</td>
-                                <td class="table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-360 h-[72px] px-4 py-2 w-[400px] text-[#4d6a99] text-sm font-normal leading-normal">@stage.Value.Sum(d => d.Amount).ToString("C")</td>
+                                <td class="table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-240 h-[72px] px-4 py-2 w-[400px] text-[#4d6a99] text-sm font-normal leading-normal">@stage.Count()</td>
+                                <td class="table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-360 h-[72px] px-4 py-2 w-[400px] text-[#4d6a99] text-sm font-normal leading-normal">@stage.Sum(d => d.Amount).ToString("C")</td>
                             </tr>
                         }
                     }
@@ -172,11 +172,11 @@
 </div>
 
 @code {
-    private IGrouping<string, Deal>[] dealsByStage;
+    private IGrouping<string, Deal>[]? dealsByStage;
 
-    protected override async Task OnInitializedAsync()
+    protected override async System.Threading.Tasks.Task OnInitializedAsync()
     {
         var deals = await DealService.GetDealsAsync();
-        dealsByStage = deals.GroupBy(d => d.Stage).ToArray();
+        dealsByStage = deals.Where(d => !string.IsNullOrEmpty(d.Stage)).GroupBy(d => d.Stage!).ToArray();
     }
 }

--- a/src/Web/NexaCRM.WebClient/RedirectToLogin.razor
+++ b/src/Web/NexaCRM.WebClient/RedirectToLogin.razor
@@ -1,9 +1,0 @@
-@inject NavigationManager NavigationManager
-
-@code {
-    protected override void OnInitialized()
-    {
-        // 컴포넌트가 초기화될 때 로그인 페이지로 즉시 이동시킵니다.
-        NavigationManager.NavigateTo("/login");
-    }
-}

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IMarketingCampaignService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IMarketingCampaignService.cs
@@ -1,15 +1,14 @@
 using NexaCRM.WebClient.Models;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace NexaCRM.WebClient.Services.Interfaces
 {
     public interface IMarketingCampaignService
     {
-        Task<IEnumerable<MarketingCampaign>> GetCampaignsAsync();
-        Task<MarketingCampaign> GetCampaignByIdAsync(int id);
-        Task CreateCampaignAsync(MarketingCampaign campaign);
-        Task UpdateCampaignAsync(MarketingCampaign campaign);
-        Task DeleteCampaignAsync(int id);
+        System.Threading.Tasks.Task<IEnumerable<MarketingCampaign>> GetCampaignsAsync();
+        System.Threading.Tasks.Task<MarketingCampaign?> GetCampaignByIdAsync(int id);
+        System.Threading.Tasks.Task CreateCampaignAsync(MarketingCampaign campaign);
+        System.Threading.Tasks.Task UpdateCampaignAsync(MarketingCampaign campaign);
+        System.Threading.Tasks.Task DeleteCampaignAsync(int id);
     }
 }

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/ISupportTicketService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/ISupportTicketService.cs
@@ -1,16 +1,15 @@
 using NexaCRM.WebClient.Models;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace NexaCRM.WebClient.Services.Interfaces
 {
     public interface ISupportTicketService
     {
-        Task<IEnumerable<SupportTicket>> GetTicketsAsync();
-        Task<SupportTicket> GetTicketByIdAsync(int id);
-        Task<IEnumerable<SupportTicket>> GetLiveInteractionsAsync();
-        Task CreateTicketAsync(SupportTicket ticket);
-        Task UpdateTicketAsync(SupportTicket ticket);
-        Task DeleteTicketAsync(int id);
+        System.Threading.Tasks.Task<IEnumerable<SupportTicket>> GetTicketsAsync();
+        System.Threading.Tasks.Task<SupportTicket?> GetTicketByIdAsync(int id);
+        System.Threading.Tasks.Task<IEnumerable<SupportTicket>> GetLiveInteractionsAsync();
+        System.Threading.Tasks.Task CreateTicketAsync(SupportTicket ticket);
+        System.Threading.Tasks.Task UpdateTicketAsync(SupportTicket ticket);
+        System.Threading.Tasks.Task DeleteTicketAsync(int id);
     }
 }

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/ITaskService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/ITaskService.cs
@@ -1,15 +1,14 @@
 using NexaCRM.WebClient.Models;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace NexaCRM.WebClient.Services.Interfaces
 {
     public interface ITaskService
     {
-        Task<IEnumerable<Models.Task>> GetTasksAsync();
-        Task<Models.Task> GetTaskByIdAsync(int id);
-        Task CreateTaskAsync(Models.Task task);
-        Task UpdateTaskAsync(Models.Task task);
-        Task DeleteTaskAsync(int id);
+        System.Threading.Tasks.Task<IEnumerable<Models.Task>> GetTasksAsync();
+        System.Threading.Tasks.Task<Models.Task?> GetTaskByIdAsync(int id);
+        System.Threading.Tasks.Task CreateTaskAsync(Models.Task task);
+        System.Threading.Tasks.Task UpdateTaskAsync(Models.Task task);
+        System.Threading.Tasks.Task DeleteTaskAsync(int id);
     }
 }

--- a/src/Web/NexaCRM.WebClient/Services/Mock/MockActivityService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Mock/MockActivityService.cs
@@ -2,7 +2,6 @@ using NexaCRM.WebClient.Models;
 using NexaCRM.WebClient.Services.Interfaces;
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace NexaCRM.WebClient.Services.Mock
 {
@@ -20,9 +19,9 @@ namespace NexaCRM.WebClient.Services.Mock
             };
         }
 
-        public Task<IEnumerable<Activity>> GetRecentActivitiesAsync()
+        public System.Threading.Tasks.Task<IEnumerable<Activity>> GetRecentActivitiesAsync()
         {
-            return Task.FromResult<IEnumerable<Activity>>(_activities);
+            return System.Threading.Tasks.Task.FromResult<IEnumerable<Activity>>(_activities);
         }
     }
 }

--- a/src/Web/NexaCRM.WebClient/Services/Mock/MockAgentService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Mock/MockAgentService.cs
@@ -1,7 +1,6 @@
 using NexaCRM.WebClient.Models;
 using NexaCRM.WebClient.Services.Interfaces;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace NexaCRM.WebClient.Services.Mock
 {
@@ -21,9 +20,9 @@ namespace NexaCRM.WebClient.Services.Mock
             };
         }
 
-        public Task<IEnumerable<Agent>> GetAgentsAsync()
+        public System.Threading.Tasks.Task<IEnumerable<Agent>> GetAgentsAsync()
         {
-            return Task.FromResult<IEnumerable<Agent>>(_agents);
+            return System.Threading.Tasks.Task.FromResult<IEnumerable<Agent>>(_agents);
         }
     }
 }

--- a/src/Web/NexaCRM.WebClient/Services/Mock/MockContactService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Mock/MockContactService.cs
@@ -1,13 +1,12 @@
 using NexaCRM.WebClient.Models;
 using NexaCRM.WebClient.Services.Interfaces;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace NexaCRM.WebClient.Services.Mock
 {
     public class MockContactService : IContactService
     {
-        public Task<IEnumerable<Contact>> GetContactsAsync()
+        public System.Threading.Tasks.Task<IEnumerable<Contact>> GetContactsAsync()
         {
             var contacts = new List<Contact>
             {
@@ -15,7 +14,7 @@ namespace NexaCRM.WebClient.Services.Mock
                 new Contact { Id = 2, FirstName = "Jane", LastName = "Smith", Email = "jane.smith@example.com", PhoneNumber = "098-765-4321" },
                 new Contact { Id = 3, FirstName = "Peter", LastName = "Jones", Email = "peter.jones@example.com", PhoneNumber = "111-222-3333" }
             };
-            return Task.FromResult<IEnumerable<Contact>>(contacts);
+            return System.Threading.Tasks.Task.FromResult<IEnumerable<Contact>>(contacts);
         }
     }
 }

--- a/src/Web/NexaCRM.WebClient/Services/Mock/MockDealService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Mock/MockDealService.cs
@@ -1,13 +1,12 @@
 using NexaCRM.WebClient.Models;
 using NexaCRM.WebClient.Services.Interfaces;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace NexaCRM.WebClient.Services.Mock
 {
     public class MockDealService : IDealService
     {
-        public Task<IEnumerable<Deal>> GetDealsAsync()
+        public System.Threading.Tasks.Task<IEnumerable<Deal>> GetDealsAsync()
         {
             var deals = new List<Deal>
             {
@@ -17,7 +16,7 @@ namespace NexaCRM.WebClient.Services.Mock
                 new Deal { Id = 4, Name = "Deal 4", Stage = "Negotiation", Amount = 15000, Company = "Company D", ContactPerson = "Mary Johnson" },
                 new Deal { Id = 5, Name = "Deal 5", Stage = "Closed (Won)", Amount = 10000, Company = "Company E", ContactPerson = "David Williams" }
             };
-            return Task.FromResult<IEnumerable<Deal>>(deals);
+            return System.Threading.Tasks.Task.FromResult<IEnumerable<Deal>>(deals);
         }
     }
 }

--- a/src/Web/NexaCRM.WebClient/Services/Mock/MockMarketingCampaignService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Mock/MockMarketingCampaignService.cs
@@ -4,7 +4,6 @@ using NexaCRM.WebClient.Services.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace NexaCRM.WebClient.Services.Mock
 {
@@ -24,25 +23,25 @@ namespace NexaCRM.WebClient.Services.Mock
             };
         }
 
-        public Task<IEnumerable<MarketingCampaign>> GetCampaignsAsync()
+        public System.Threading.Tasks.Task<IEnumerable<MarketingCampaign>> GetCampaignsAsync()
         {
-            return Task.FromResult<IEnumerable<MarketingCampaign>>(_campaigns);
+            return System.Threading.Tasks.Task.FromResult<IEnumerable<MarketingCampaign>>(_campaigns);
         }
 
-        public Task<MarketingCampaign> GetCampaignByIdAsync(int id)
+        public System.Threading.Tasks.Task<MarketingCampaign?> GetCampaignByIdAsync(int id)
         {
             var campaign = _campaigns.FirstOrDefault(c => c.Id == id);
-            return Task.FromResult(campaign);
+            return System.Threading.Tasks.Task.FromResult(campaign);
         }
 
-        public Task CreateCampaignAsync(MarketingCampaign campaign)
+        public System.Threading.Tasks.Task CreateCampaignAsync(MarketingCampaign campaign)
         {
             campaign.Id = _campaigns.Max(c => c.Id) + 1;
             _campaigns.Add(campaign);
-            return Task.CompletedTask;
+            return System.Threading.Tasks.Task.CompletedTask;
         }
 
-        public Task UpdateCampaignAsync(MarketingCampaign campaign)
+        public System.Threading.Tasks.Task UpdateCampaignAsync(MarketingCampaign campaign)
         {
             var existingCampaign = _campaigns.FirstOrDefault(c => c.Id == campaign.Id);
             if (existingCampaign != null)
@@ -55,17 +54,17 @@ namespace NexaCRM.WebClient.Services.Mock
                 existingCampaign.Budget = campaign.Budget;
                 existingCampaign.ROI = campaign.ROI;
             }
-            return Task.CompletedTask;
+            return System.Threading.Tasks.Task.CompletedTask;
         }
 
-        public Task DeleteCampaignAsync(int id)
+        public System.Threading.Tasks.Task DeleteCampaignAsync(int id)
         {
             var campaign = _campaigns.FirstOrDefault(c => c.Id == id);
             if (campaign != null)
             {
                 _campaigns.Remove(campaign);
             }
-            return Task.CompletedTask;
+            return System.Threading.Tasks.Task.CompletedTask;
         }
     }
 }

--- a/src/Web/NexaCRM.WebClient/Services/Mock/MockReportService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Mock/MockReportService.cs
@@ -1,13 +1,12 @@
 using NexaCRM.WebClient.Models;
 using NexaCRM.WebClient.Services.Interfaces;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace NexaCRM.WebClient.Services.Mock
 {
     public class MockReportService : IReportService
     {
-        public Task<ReportData> GetQuarterlyPerformanceAsync()
+        public System.Threading.Tasks.Task<ReportData> GetQuarterlyPerformanceAsync()
         {
             var data = new ReportData
             {
@@ -20,10 +19,10 @@ namespace NexaCRM.WebClient.Services.Mock
                     { "Q4", 30000 }
                 }
             };
-            return Task.FromResult(data);
+            return System.Threading.Tasks.Task.FromResult(data);
         }
 
-        public Task<ReportData> GetLeadSourceAnalyticsAsync()
+        public System.Threading.Tasks.Task<ReportData> GetLeadSourceAnalyticsAsync()
         {
             var data = new ReportData
             {
@@ -36,10 +35,10 @@ namespace NexaCRM.WebClient.Services.Mock
                     { "Email Campaign", 60 }
                 }
             };
-            return Task.FromResult(data);
+            return System.Threading.Tasks.Task.FromResult(data);
         }
 
-        public Task<ReportData> GetTicketVolumeAsync()
+        public System.Threading.Tasks.Task<ReportData> GetTicketVolumeAsync()
         {
             var data = new ReportData
             {
@@ -49,10 +48,10 @@ namespace NexaCRM.WebClient.Services.Mock
                     { "Total", 125 }
                 }
             };
-            return Task.FromResult(data);
+            return System.Threading.Tasks.Task.FromResult(data);
         }
 
-        public Task<ReportData> GetResolutionRateAsync()
+        public System.Threading.Tasks.Task<ReportData> GetResolutionRateAsync()
         {
             var data = new ReportData
             {
@@ -62,10 +61,10 @@ namespace NexaCRM.WebClient.Services.Mock
                     { "Rate", 0.85 }
                 }
             };
-            return Task.FromResult(data);
+            return System.Threading.Tasks.Task.FromResult(data);
         }
 
-        public Task<ReportData> GetTicketsByCategoryAsync()
+        public System.Threading.Tasks.Task<ReportData> GetTicketsByCategoryAsync()
         {
             var data = new ReportData
             {
@@ -78,7 +77,7 @@ namespace NexaCRM.WebClient.Services.Mock
                     { "Feedback", 70 }
                 }
             };
-            return Task.FromResult(data);
+            return System.Threading.Tasks.Task.FromResult(data);
         }
     }
 }

--- a/src/Web/NexaCRM.WebClient/Services/Mock/MockSupportTicketService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Mock/MockSupportTicketService.cs
@@ -4,7 +4,6 @@ using NexaCRM.WebClient.Services.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace NexaCRM.WebClient.Services.Mock
 {
@@ -24,30 +23,30 @@ namespace NexaCRM.WebClient.Services.Mock
             };
         }
 
-        public Task<IEnumerable<SupportTicket>> GetTicketsAsync()
+        public System.Threading.Tasks.Task<IEnumerable<SupportTicket>> GetTicketsAsync()
         {
-            return Task.FromResult<IEnumerable<SupportTicket>>(_tickets);
+            return System.Threading.Tasks.Task.FromResult<IEnumerable<SupportTicket>>(_tickets);
         }
 
-        public Task<SupportTicket> GetTicketByIdAsync(int id)
+        public System.Threading.Tasks.Task<SupportTicket?> GetTicketByIdAsync(int id)
         {
             var ticket = _tickets.FirstOrDefault(t => t.Id == id);
-            return Task.FromResult(ticket);
+            return System.Threading.Tasks.Task.FromResult(ticket);
         }
 
-        public Task<IEnumerable<SupportTicket>> GetLiveInteractionsAsync()
+        public System.Threading.Tasks.Task<IEnumerable<SupportTicket>> GetLiveInteractionsAsync()
         {
-            return Task.FromResult<IEnumerable<SupportTicket>>(_tickets.Where(t => t.Status == TicketStatus.InProgress || t.Status == TicketStatus.Open));
+            return System.Threading.Tasks.Task.FromResult<IEnumerable<SupportTicket>>(_tickets.Where(t => t.Status == TicketStatus.InProgress || t.Status == TicketStatus.Open));
         }
 
-        public Task CreateTicketAsync(SupportTicket ticket)
+        public System.Threading.Tasks.Task CreateTicketAsync(SupportTicket ticket)
         {
             ticket.Id = _tickets.Max(t => t.Id) + 1;
             _tickets.Add(ticket);
-            return Task.CompletedTask;
+            return System.Threading.Tasks.Task.CompletedTask;
         }
 
-        public Task UpdateTicketAsync(SupportTicket ticket)
+        public System.Threading.Tasks.Task UpdateTicketAsync(SupportTicket ticket)
         {
             var existingTicket = _tickets.FirstOrDefault(t => t.Id == ticket.Id);
             if (existingTicket != null)
@@ -60,17 +59,17 @@ namespace NexaCRM.WebClient.Services.Mock
                 existingTicket.AgentName = ticket.AgentName;
                 existingTicket.Category = ticket.Category;
             }
-            return Task.CompletedTask;
+            return System.Threading.Tasks.Task.CompletedTask;
         }
 
-        public Task DeleteTicketAsync(int id)
+        public System.Threading.Tasks.Task DeleteTicketAsync(int id)
         {
             var ticket = _tickets.FirstOrDefault(t => t.Id == id);
             if (ticket != null)
             {
                 _tickets.Remove(ticket);
             }
-            return Task.CompletedTask;
+            return System.Threading.Tasks.Task.CompletedTask;
         }
     }
 }

--- a/src/Web/NexaCRM.WebClient/Services/Mock/MockTaskService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Mock/MockTaskService.cs
@@ -4,7 +4,6 @@ using NexaCRM.WebClient.Services.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace NexaCRM.WebClient.Services.Mock
 {
@@ -22,25 +21,25 @@ namespace NexaCRM.WebClient.Services.Mock
             };
         }
 
-        public Task<IEnumerable<Models.Task>> GetTasksAsync()
+        public System.Threading.Tasks.Task<IEnumerable<Models.Task>> GetTasksAsync()
         {
-            return Task.FromResult<IEnumerable<Models.Task>>(_tasks);
+            return System.Threading.Tasks.Task.FromResult<IEnumerable<Models.Task>>(_tasks);
         }
 
-        public Task<Models.Task> GetTaskByIdAsync(int id)
+        public System.Threading.Tasks.Task<Models.Task?> GetTaskByIdAsync(int id)
         {
             var task = _tasks.FirstOrDefault(t => t.Id == id);
-            return Task.FromResult(task);
+            return System.Threading.Tasks.Task.FromResult(task);
         }
 
-        public Task CreateTaskAsync(Models.Task task)
+        public System.Threading.Tasks.Task CreateTaskAsync(Models.Task task)
         {
             task.Id = _tasks.Max(t => t.Id) + 1;
             _tasks.Add(task);
-            return Task.CompletedTask;
+            return System.Threading.Tasks.Task.CompletedTask;
         }
 
-        public Task UpdateTaskAsync(Models.Task task)
+        public System.Threading.Tasks.Task UpdateTaskAsync(Models.Task task)
         {
             var existingTask = _tasks.FirstOrDefault(t => t.Id == task.Id);
             if (existingTask != null)
@@ -52,17 +51,17 @@ namespace NexaCRM.WebClient.Services.Mock
                 existingTask.Priority = task.Priority;
                 existingTask.AssignedTo = task.AssignedTo;
             }
-            return Task.CompletedTask;
+            return System.Threading.Tasks.Task.CompletedTask;
         }
 
-        public Task DeleteTaskAsync(int id)
+        public System.Threading.Tasks.Task DeleteTaskAsync(int id)
         {
             var task = _tasks.FirstOrDefault(t => t.Id == id);
             if (task != null)
             {
                 _tasks.Remove(task);
             }
-            return Task.CompletedTask;
+            return System.Threading.Tasks.Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
This commit resolves a number of build errors and warnings that were present in the project.

The main issues addressed are:
- Ambiguous reference to 'Task' due to a conflict between the `NexaCRM.WebClient.Models.Task` model and the `System.Threading.Tasks.Task` class. This was fixed by using the fully qualified name for `System.Threading.Tasks.Task`.
- A duplicate 'RedirectToLogin.razor' component was found and the redundant one was removed.
- An error in 'SalesPipelinePage.razor' where `stage.Value` was used on an `IGrouping` object, which was corrected to use `stage` directly.
- Several nullability warnings (CS8619, CS8618, CS8602, CS8604) were fixed by updating interfaces and implementations to correctly handle nullable types.