### PR TITLE
feat: Implement role-based navigation menu

### DIFF
--- a/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.en-US.resx
@@ -12,4 +12,16 @@
   <data name="Home" xml:space="preserve">
     <value>Home</value>
   </data>
+  <data name="AdminDashboard" xml:space="preserve">
+    <value>Admin Dashboard</value>
+  </data>
+  <data name="Reports" xml:space="preserve">
+    <value>Reports</value>
+  </data>
+  <data name="SalesPipeline" xml:space="preserve">
+    <value>Sales Pipeline</value>
+  </data>
+  <data name="Contacts" xml:space="preserve">
+    <value>Contacts</value>
+  </data>
 </root>

--- a/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.ko-KR.resx
@@ -12,4 +12,16 @@
   <data name="Home" xml:space="preserve">
     <value>홈</value>
   </data>
+  <data name="AdminDashboard" xml:space="preserve">
+    <value>관리자 대시보드</value>
+  </data>
+  <data name="Reports" xml:space="preserve">
+    <value>보고서</value>
+  </data>
+  <data name="SalesPipeline" xml:space="preserve">
+    <value>세일즈 파이프라인</value>
+  </data>
+  <data name="Contacts" xml:space="preserve">
+    <value>연락처</value>
+  </data>
 </root>

--- a/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor
@@ -13,22 +13,48 @@
 <div class="@NavMenuCssClass" @onclick:stopPropagation="true">
     <nav class="flex-column">
         <AuthorizeView>
-            <Authorized Context="navContext">
+            <Authorized>
                 <div class="nav-item px-3">
                     <NavLink class="nav-link" href="main-dashboard" @onclick="CloseNavMenu">
                         <span class="oi oi-dashboard" aria-hidden="true"></span> @Localizer["Dashboard"]
                     </NavLink>
                 </div>
-                <AuthorizeView Roles="Manager">
-                    <Authorized Context="innerContext">
-                        <div class="nav-item px-3">
-                            <NavLink class="nav-link" href="sales-manager-dashboard" @onclick="CloseNavMenu">
-                                <span class="oi oi-person" aria-hidden="true"></span> @Localizer["ManagerDashboard"]
-                            </NavLink>
-                        </div>
-                    </Authorized>
+
+                <AuthorizeView Roles="Admin">
+                    <div class="nav-item px-3">
+                        <NavLink class="nav-link" href="admin-dashboard" @onclick="CloseNavMenu">
+                            <span class="oi oi-cog" aria-hidden="true"></span> @Localizer["AdminDashboard"]
+                        </NavLink>
+                    </div>
                 </AuthorizeView>
-                <div class="nav-item px-3">
+
+                <AuthorizeView Roles="Manager">
+                    <div class="nav-item px-3">
+                        <NavLink class="nav-link" href="sales-manager-dashboard" @onclick="CloseNavMenu">
+                            <span class="oi oi-person" aria-hidden="true"></span> @Localizer["ManagerDashboard"]
+                        </NavLink>
+                    </div>
+                    <div class="nav-item px-3">
+                        <NavLink class="nav-link" href="reports" @onclick="CloseNavMenu">
+                            <span class="oi oi-bar-chart" aria-hidden="true"></span> @Localizer["Reports"]
+                        </NavLink>
+                    </div>
+                </AuthorizeView>
+
+                <AuthorizeView Roles="Sales">
+                    <div class="nav-item px-3">
+                        <NavLink class="nav-link" href="sales-pipeline" @onclick="CloseNavMenu">
+                            <span class="oi oi-list-rich" aria-hidden="true"></span> @Localizer["SalesPipeline"]
+                        </NavLink>
+                    </div>
+                    <div class="nav-item px-3">
+                        <NavLink class="nav-link" href="contacts" @onclick="CloseNavMenu">
+                            <span class="oi oi-people" aria-hidden="true"></span> @Localizer["Contacts"]
+                        </NavLink>
+                    </div>
+                </AuthorizeView>
+
+                <div class="nav-item px-3 mt-auto">
                     <button class="nav-link btn btn-link" @onclick="Logout">
                         <span class="oi oi-account-logout" aria-hidden="true"></span> @Localizer["Logout"]
                     </button>


### PR DESCRIPTION
This commit introduces a role-based navigation menu in the Blazor web client.

- The `NavMenu.razor` component has been updated to use `AuthorizeView` to display different navigation links based on the user's role (Admin, Manager, or Sales).
- New navigation links have been added for each role, providing access to role-specific pages.
- Localization resources for both English and Korean have been updated to include the new navigation link texts.