### PR TITLE
feat: Add loading animation to the page

### DIFF
--- a/src/Web/NexaCRM.WebClient/wwwroot/css/app.css
+++ b/src/Web/NexaCRM.WebClient/wwwroot/css/app.css
@@ -529,3 +529,18 @@ input, select, textarea {
     .blazor-error-boundary::after {
         content: "An error has occurred."
     }
+
+/* Loading Spinner Animation */
+.loader {
+    border: 8px solid #f3f3f3; /* Light grey */
+    border-top: 8px solid #3498db; /* Blue */
+    border-radius: 50%;
+    width: 60px;
+    height: 60px;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}

--- a/src/Web/NexaCRM.WebClient/wwwroot/index.html
+++ b/src/Web/NexaCRM.WebClient/wwwroot/index.html
@@ -14,7 +14,9 @@
 </head>
 
 <body>
-    <div id="app">Loading...</div>
+    <div id="app" style="display: flex; justify-content: center; align-items: center; height: 100vh;">
+        <div class="loader"></div>
+    </div>
 
     <div id="blazor-error-ui">
         An unhandled error has occurred.


### PR DESCRIPTION
This commit introduces a CSS-based loading spinner to the initial page load.

- Modified `index.html` to include a `div` for the loader.
- Added keyframe animation and styling for the spinner in `app.css`
- The loader is centered on the page and will be displayed while the Blazor application is bootstrapping.