### PR TITLE
fix: escape media queries in Razor pages

### DIFF
--- a/src/Web/NexaCRM.WebClient/Pages/MyAssignmentHistoryPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/MyAssignmentHistoryPage.razor
@@ -50,7 +50,7 @@
 
 
     /* Show card view on mobile, hide table */
-    @media (max-width: 767.98px) {
+    @@media (max-width: 767.98px) {
         .desktop-table-view {
             display: none;
         }

--- a/src/Web/NexaCRM.WebClient/Pages/MyDbListPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/MyDbListPage.razor
@@ -50,7 +50,7 @@
 
 
     /* Show card view on mobile, hide table */
-    @media (max-width: 767.98px) {
+    @@media (max-width: 767.98px) {
         .desktop-table-view {
             display: none;
         }

--- a/src/Web/NexaCRM.WebClient/Pages/NewlyAssignedDbPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/NewlyAssignedDbPage.razor
@@ -58,7 +58,7 @@
 
 
     /* Show card view on mobile, hide table */
-    @media (max-width: 767.98px) {
+    @@media (max-width: 767.98px) {
         .desktop-table-view {
             display: none;
         }

--- a/src/Web/NexaCRM.WebClient/Pages/StarredDbListPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/StarredDbListPage.razor
@@ -50,7 +50,7 @@
 
 
     /* Show card view on mobile, hide table */
-    @media (max-width: 767.98px) {
+    @@media (max-width: 767.98px) {
         .desktop-table-view {
             display: none;
         }


### PR DESCRIPTION
## Summary
- escape CSS media queries in Razor pages to avoid Razor parsing errors

## Testing
- `dotnet build --configuration Release`
- `dotnet test --configuration Release` *(fails: NexaCRM.WebClient.UnitTests Pages.MobileDashboardTests failures)*

------
https://chatgpt.com/codex/tasks/task_b_68c50181ce38832cb648ba51f167dfd6