### PR TITLE
fix: improve sidebar responsiveness

### DIFF
--- a/src/Web/NexaCRM.WebClient/wwwroot/css/app.css
+++ b/src/Web/NexaCRM.WebClient/wwwroot/css/app.css
@@ -147,7 +147,7 @@ a:hover, .btn-link:hover {
 .sidebar {
     background-color: var(--surface-color); /* Use theme surface color */
     border-right: 1px solid var(--border-color); /* Use theme border color */
-    width: 250px;
+    width: min(80%, 250px); /* Use fluid width on small screens */
     min-height: 100vh;
     position: fixed;
     top: 0;

--- a/tests/NexaCRM.WebClient.UnitTests/Pages/MobileDashboardTests.cs
+++ b/tests/NexaCRM.WebClient.UnitTests/Pages/MobileDashboardTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.JSInterop;
 using NexaCRM.WebClient.Pages;
+using NexaCRM.WebClient.Components.UI;
 using Xunit;
 using Microsoft.AspNetCore.Components;
 using Moq;
@@ -18,6 +19,7 @@ namespace NexaCRM.WebClient.UnitTests.Pages
             Services.AddSingleton<NavigationManager>(new MockNavigationManager());
             Services.AddSingleton(Mock.Of<IJSRuntime>());
             Services.AddSingleton<IStringLocalizer<MainDashboard>>(new MockStringLocalizer());
+            Services.AddSingleton<IStringLocalizer<FloatingActionButton>>(new MockStringLocalizer());
         }
 
         [Fact]
@@ -193,7 +195,7 @@ namespace NexaCRM.WebClient.UnitTests.Pages
             }
         }
 
-        private class MockStringLocalizer : IStringLocalizer<MainDashboard>
+        private class MockStringLocalizer : IStringLocalizer<MainDashboard>, IStringLocalizer<FloatingActionButton>
         {
             public LocalizedString this[string name] => new(name, GetMockTranslation(name));
             public LocalizedString this[string name, params object[] arguments] => new(name, string.Format(GetMockTranslation(name), arguments));


### PR DESCRIPTION
## Summary
- make global sidebar use fluid width on small screens for better mobile experience
- register floating action button localizer in mobile dashboard tests

## Testing
- `dotnet build --configuration Release`
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release` *(fails: project file does not exist)*
- `dotnet test --configuration Release`


------
https://chatgpt.com/codex/tasks/task_b_68c504030f28832cb88d30b5d535c038