### PR TITLE
build: target .NET 8 only

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ graph TD
 
 🏁 시작하기
 ### 필수 요소
-- .NET SDK (6.0, 7.0, 8.0)
+- .NET SDK 8.0
 - Docker & Docker Compose
 
 ### 클론 및 설정

--- a/src/Web/NexaCRM.WebClient/Pages/MyAssignmentHistoryPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/MyAssignmentHistoryPage.razor
@@ -50,7 +50,7 @@
 
 
     /* Show card view on mobile, hide table */
-    @media (max-width: 767.98px) {
+    @@media (max-width: 767.98px) {
         .desktop-table-view {
             display: none;
         }

--- a/src/Web/NexaCRM.WebClient/Pages/MyDbListPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/MyDbListPage.razor
@@ -50,7 +50,7 @@
 
 
     /* Show card view on mobile, hide table */
-    @media (max-width: 767.98px) {
+    @@media (max-width: 767.98px) {
         .desktop-table-view {
             display: none;
         }

--- a/src/Web/NexaCRM.WebClient/Pages/NewlyAssignedDbPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/NewlyAssignedDbPage.razor
@@ -58,7 +58,7 @@
 
 
     /* Show card view on mobile, hide table */
-    @media (max-width: 767.98px) {
+    @@media (max-width: 767.98px) {
         .desktop-table-view {
             display: none;
         }

--- a/src/Web/NexaCRM.WebClient/Pages/StarredDbListPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/StarredDbListPage.razor
@@ -50,7 +50,7 @@
 
 
     /* Show card view on mobile, hide table */
-    @media (max-width: 767.98px) {
+    @@media (max-width: 767.98px) {
         .desktop-table-view {
             display: none;
         }

--- a/tests/NexaCRM.WebClient.UnitTests/NexaCRM.WebClient.UnitTests.csproj
+++ b/tests/NexaCRM.WebClient.UnitTests/NexaCRM.WebClient.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+               <TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>


### PR DESCRIPTION
## Summary
- state explicitly that only .NET SDK 8.0 is required
- align WebClient unit tests to single net8.0 target
- escape Razor `@media` queries causing build errors

## Testing
- `dotnet build --configuration Release` 
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release` *(fails: project file does not exist)*
- `dotnet test --configuration Release` *(fails: 10 tests in NexaCRM.WebClient.UnitTests)*

------
https://chatgpt.com/codex/tasks/task_b_68c50444673c832ca1d2c454663b0486