### PR TITLE
feat: add db distribution assignment and white theme default

### DIFF
--- a/src/Web/NexaCRM.WebClient/Models/Agent.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Agent.cs
@@ -5,5 +5,6 @@ namespace NexaCRM.WebClient.Models
         public int Id { get; set; }
         public string? Name { get; set; }
         public string? Email { get; set; }
+        public string? Role { get; set; }
     }
 }

--- a/src/Web/NexaCRM.WebClient/Models/Db/DbCustomer.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Db/DbCustomer.cs
@@ -11,29 +11,29 @@ namespace NexaCRM.WebClient.Models.Db
         // This is the foreign key to the Contact model
         public int ContactId { get; set; }
 
-        [Required(ErrorMessage = "고객명은 필수입니다.")]
-        [Display(Name = "고객명")]
+        [Required(ErrorMessage = "Customer name is required.")]
+        [Display(Name = "Customer Name")]
         public string CustomerName { get; set; }
 
-        [Display(Name = "연락처")]
+        [Display(Name = "Contact")]
         public string ContactNumber { get; set; }
 
-        [Display(Name = "담당자")]
+        [Display(Name = "Assigned To")]
         public string AssignedTo { get; set; }
 
-        [Display(Name = "분배일")]
+        [Display(Name = "Assigned Date")]
         public DateTime AssignedDate { get; set; }
 
-        [Display(Name = "DB 상태")]
+        [Display(Name = "Status")]
         public DbStatus Status { get; set; }
 
-        [Display(Name = "최종 컨택일")]
+        [Display(Name = "Last Contact Date")]
         public DateTime LastContactDate { get; set; }
 
-        [Display(Name = "관심(중요) 표시")]
+        [Display(Name = "Starred")]
         public bool IsStarred { get; set; }
 
-        [Display(Name = "전달자")]
+        [Display(Name = "Assigned By")]
         public string Assigner { get; set; }
     }
 }

--- a/src/Web/NexaCRM.WebClient/Models/Db/DbStatus.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Db/DbStatus.cs
@@ -1,22 +1,15 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace NexaCRM.WebClient.Models.Db
 {
     public enum DbStatus
     {
-        [Display(Name = "신규")]
         New,
 
-        [Display(Name = "상담중")]
         InProgress,
 
-        [Display(Name = "부재중")]
         NoAnswer,
 
-        [Display(Name = "계약완료")]
         Completed,
 
-        [Display(Name = "보류")]
         OnHold
     }
 }

--- a/src/Web/NexaCRM.WebClient/Pages/AllDbListPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/AllDbListPage.razor
@@ -7,9 +7,10 @@
 @inject IDbDataService DbDataService
 @inject IStringLocalizer<AllDbListPage> Localizer
 @inject NavigationManager NavigationManager
-@inject AuthenticationStateProvider AuthenticationStateProvider 
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject IStringLocalizer<DbStatus> StatusLocalizer
 <div class="container-fluid mt-4">
-    <h1 class="mb-4">전체 DB 목록</h1>
+    <h1 class="mb-4">@Localizer["Title"]</h1>
 
     @if (customers == null)
     {
@@ -26,14 +27,14 @@
             <table class="table table-striped table-hover">
                 <thead class="table-light">
                     <tr>
-                        <th>고객명</th>
-                        <th>연락처</th>
-                        <th>담당자</th>
-                        <th>분배일</th>
-                        <th>DB 상태</th>
-                        <th>최종 컨택일</th>
-                        <th>관심</th>
-                        <th>전달자</th>
+                        <th>@Localizer["CustomerName"]</th>
+                        <th>@Localizer["Contact"]</th>
+                        <th>@Localizer["AssignedTo"]</th>
+                        <th>@Localizer["AssignedDate"]</th>
+                        <th>@Localizer["Status"]</th>
+                        <th>@Localizer["LastContact"]</th>
+                        <th>@Localizer["Starred"]</th>
+                        <th>@Localizer["Assigner"]</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -44,7 +45,7 @@
                             <td>@customer.ContactNumber</td>
                             <td>@customer.AssignedTo</td>
                             <td>@customer.AssignedDate.ToShortDateString()</td>
-                            <td>@customer.Status</td>
+                            <td>@StatusLocalizer[customer.Status.ToString()]</td>
                             <td>@customer.LastContactDate.ToShortDateString()</td>
                             <td>@(customer.IsStarred ? "★" : "")</td>
                             <td>@customer.Assigner</td>
@@ -67,19 +68,19 @@
                         }
                     </h5>
                     <div class="card-info-row">
-                        <span class="card-info-label">연락처</span>
+                        <span class="card-info-label">@Localizer["Contact"]</span>
                         <span class="card-info-value">@customer.ContactNumber</span>
                     </div>
                      <div class="card-info-row">
-                        <span class="card-info-label">담당자</span>
+                        <span class="card-info-label">@Localizer["AssignedTo"]</span>
                         <span class="card-info-value">@customer.AssignedTo</span>
                     </div>
                     <div class="card-info-row">
-                        <span class="card-info-label">DB 상태</span>
-                        <span class="card-info-value">@customer.Status</span>
+                        <span class="card-info-label">@Localizer["Status"]</span>
+                        <span class="card-info-value">@StatusLocalizer[customer.Status.ToString()]</span>
                     </div>
                     <div class="card-info-row">
-                        <span class="card-info-label">최종 컨택일</span>
+                        <span class="card-info-label">@Localizer["LastContact"]</span>
                         <span class="card-info-value">@customer.LastContactDate.ToShortDateString()</span>
                     </div>
                 </div>

--- a/src/Web/NexaCRM.WebClient/Pages/AllDbListPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/AllDbListPage.razor.css
@@ -2,6 +2,14 @@
         cursor: pointer;
     }
 
+    .desktop-table-view {
+        overflow-x: auto;
+    }
+
+    .desktop-table-view table {
+        min-width: 800px;
+    }
+
     .mobile-card-view {
         display: none;
     }

--- a/src/Web/NexaCRM.WebClient/Pages/AllDbListPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/AllDbListPage.razor.css
@@ -1,5 +1,10 @@
+ .table-hover tbody tr {
+     transition: background-color 0.3s ease;
+ }
+
  .table-hover tbody tr:hover {
      cursor: pointer;
+     background-color: #f8f9fa;
  }
 
  .desktop-table-view {
@@ -22,6 +27,13 @@
      margin-bottom: 16px;
      box-shadow: 0 2px 4px rgba(0,0,0,0.05);
      cursor: pointer;
+     transition: transform 0.3s ease, box-shadow 0.3s ease;
+     animation: fadeIn 0.4s ease-in;
+ }
+
+ .customer-card:hover {
+     transform: translateY(-2px);
+     box-shadow: 0 4px 8px rgba(0,0,0,0.1);
  }
 
  .customer-card h5 {
@@ -46,6 +58,17 @@
  .card-info-value {
      font-weight: 500;
  }
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
 
  /* Show card view on mobile, hide table */
  @media (max-width: 767.98px) {

--- a/src/Web/NexaCRM.WebClient/Pages/AllDbListPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/AllDbListPage.razor.css
@@ -1,60 +1,59 @@
-    .table-hover tbody tr:hover {
-        cursor: pointer;
-    }
+ .table-hover tbody tr:hover {
+     cursor: pointer;
+ }
 
-    .desktop-table-view {
-        overflow-x: auto;
-    }
+ .desktop-table-view {
+     overflow-x: auto;
+ }
 
-    .desktop-table-view table {
-        min-width: 800px;
-    }
+ .desktop-table-view table {
+     min-width: 800px;
+ }
 
-    .mobile-card-view {
-        display: none;
-    }
+ .mobile-card-view {
+     display: none;
+ }
 
-    .customer-card {
-        background-color: #fff;
-        border: 1px solid #e7ecf3;
-        border-radius: 8px;
-        padding: 16px;
-        margin-bottom: 16px;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-        cursor: pointer;
-    }
+ .customer-card {
+     background-color: #fff;
+     border: 1px solid #e7ecf3;
+     border-radius: 8px;
+     padding: 16px;
+     margin-bottom: 16px;
+     box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+     cursor: pointer;
+ }
 
-    .customer-card h5 {
-        margin-bottom: 12px;
-        font-weight: 600;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-    }
+ .customer-card h5 {
+     margin-bottom: 12px;
+     font-weight: 600;
+     display: flex;
+     justify-content: space-between;
+     align-items: center;
+ }
 
-    .card-info-row {
-        display: flex;
-        justify-content: space-between;
-        font-size: 0.9rem;
-        margin-bottom: 8px;
-    }
+ .card-info-row {
+     display: flex;
+     justify-content: space-between;
+     font-size: 0.9rem;
+     margin-bottom: 8px;
+ }
 
-    .card-info-label {
-        color: #6c757d;
-    }
+ .card-info-label {
+     color: #6c757d;
+ }
 
-    .card-info-value {
-        font-weight: 500;
-    }
+ .card-info-value {
+     font-weight: 500;
+ }
 
+ /* Show card view on mobile, hide table */
+ @media (max-width: 767.98px) {
+     .desktop-table-view {
+         display: none;
+     }
 
-    /* Show card view on mobile, hide table */
-    @media (max-width: 767.98px) {
-        .desktop-table-view {
-            display: none;
-        }
-
-        .mobile-card-view {
-            display: block;
-        }
-    }
+     .mobile-card-view {
+         display: block;
+     }
+ }

--- a/src/Web/NexaCRM.WebClient/Pages/AssignDbPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/AssignDbPage.razor
@@ -8,9 +8,10 @@
 @inject IDbDataService DbDataService
 @inject IAgentService AgentService
 @inject NavigationManager NavigationManager
+@inject IStringLocalizer<AssignDbPage> Localizer
 
 <div class="page-container">
-    <h1 class="mb-4">DB 분배</h1>
+    <h1 class="mb-4">@Localizer["Title"]</h1>
 
     @if (agents == null)
     {
@@ -23,16 +24,16 @@
     else
     {
         <div class="mb-3">
-            <label class="form-label">담당자 선택</label>
+            <label class="form-label">@Localizer["SelectAgentLabel"]</label>
             <select class="form-select" @bind="selectedAgentName">
-                <option value="">담당자를 선택하세요</option>
+                <option value="">@Localizer["SelectAgentPlaceholder"]</option>
                 @foreach (var agent in agents)
                 {
                     <option value="@agent.Name">@agent.Name</option>
                 }
             </select>
         </div>
-        <button class="btn btn-primary btn-assign" @onclick="AssignAsync">분배</button>
+        <button class="btn btn-primary btn-assign" @onclick="AssignAsync">@Localizer["AssignButton"]</button>
     }
 </div>
 

--- a/src/Web/NexaCRM.WebClient/Pages/AssignDbPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/AssignDbPage.razor
@@ -1,0 +1,54 @@
+@page "/db/distribution/assign/{contactId:int}"
+@attribute [Authorize(Roles = "Manager")]
+
+@using NexaCRM.WebClient.Models
+@using NexaCRM.WebClient.Services.Interfaces
+
+@inject IDbDataService DbDataService
+@inject IAgentService AgentService
+@inject NavigationManager NavigationManager
+
+<h1 class="mb-4">DB 분배</h1>
+
+@if (agents == null)
+{
+    <div class="d-flex justify-content-center">
+        <div class="spinner-border" role="status">
+            <span class="visually-hidden">Loading...</span>
+        </div>
+    </div>
+}
+else
+{
+    <div class="mb-3">
+        <label class="form-label">담당자 선택</label>
+        <select class="form-select" @bind="selectedAgentName">
+            <option value="">담당자를 선택하세요</option>
+            @foreach (var agent in agents)
+            {
+                <option value="@agent.Name">@agent.Name</option>
+            }
+        </select>
+    </div>
+    <button class="btn btn-primary" @onclick="Assign">분배</button>
+}
+
+@code {
+    [Parameter] public int contactId { get; set; }
+    private IEnumerable<Agent> agents;
+    private string selectedAgentName;
+
+    protected override async System.Threading.Tasks.Task OnInitializedAsync()
+    {
+        agents = await AgentService.GetAgentsAsync();
+    }
+
+    private async System.Threading.Tasks.Task Assign()
+    {
+        if (!string.IsNullOrEmpty(selectedAgentName))
+        {
+            await DbDataService.AssignDbToAgentAsync(contactId, selectedAgentName);
+            NavigationManager.NavigateTo("/db/distribution/status");
+        }
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/AssignDbPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/AssignDbPage.razor
@@ -1,8 +1,9 @@
-@page "/db/distribution/assign/{contactId:int}"
+@page "/db/distribution/assign/{ContactId:int}"
 @attribute [Authorize(Roles = "Manager")]
 
 @using NexaCRM.WebClient.Models
 @using NexaCRM.WebClient.Services.Interfaces
+@using System.Linq
 
 @inject IDbDataService DbDataService
 @inject IAgentService AgentService
@@ -30,24 +31,25 @@ else
             }
         </select>
     </div>
-    <button class="btn btn-primary" @onclick="Assign">분배</button>
+    <button class="btn btn-primary" @onclick="AssignAsync">분배</button>
 }
 
 @code {
-    [Parameter] public int contactId { get; set; }
+    [Parameter] public int ContactId { get; set; }
     private IEnumerable<Agent> agents;
     private string selectedAgentName;
 
     protected override async System.Threading.Tasks.Task OnInitializedAsync()
     {
-        agents = await AgentService.GetAgentsAsync();
+        var allAgents = await AgentService.GetAgentsAsync();
+        agents = allAgents.Where(a => a.Role == "Sales");
     }
 
-    private async System.Threading.Tasks.Task Assign()
+    private async System.Threading.Tasks.Task AssignAsync()
     {
         if (!string.IsNullOrEmpty(selectedAgentName))
         {
-            await DbDataService.AssignDbToAgentAsync(contactId, selectedAgentName);
+            await DbDataService.AssignDbToAgentAsync(ContactId, selectedAgentName);
             NavigationManager.NavigateTo("/db/distribution/status");
         }
     }

--- a/src/Web/NexaCRM.WebClient/Pages/AssignDbPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/AssignDbPage.razor
@@ -9,30 +9,32 @@
 @inject IAgentService AgentService
 @inject NavigationManager NavigationManager
 
-<h1 class="mb-4">DB 분배</h1>
+<div class="page-container">
+    <h1 class="mb-4">DB 분배</h1>
 
-@if (agents == null)
-{
-    <div class="d-flex justify-content-center">
-        <div class="spinner-border" role="status">
-            <span class="visually-hidden">Loading...</span>
+    @if (agents == null)
+    {
+        <div class="d-flex justify-content-center">
+            <div class="spinner-border" role="status">
+                <span class="visually-hidden">Loading...</span>
+            </div>
         </div>
-    </div>
-}
-else
-{
-    <div class="mb-3">
-        <label class="form-label">담당자 선택</label>
-        <select class="form-select" @bind="selectedAgentName">
-            <option value="">담당자를 선택하세요</option>
-            @foreach (var agent in agents)
-            {
-                <option value="@agent.Name">@agent.Name</option>
-            }
-        </select>
-    </div>
-    <button class="btn btn-primary" @onclick="AssignAsync">분배</button>
-}
+    }
+    else
+    {
+        <div class="mb-3">
+            <label class="form-label">담당자 선택</label>
+            <select class="form-select" @bind="selectedAgentName">
+                <option value="">담당자를 선택하세요</option>
+                @foreach (var agent in agents)
+                {
+                    <option value="@agent.Name">@agent.Name</option>
+                }
+            </select>
+        </div>
+        <button class="btn btn-primary btn-assign" @onclick="AssignAsync">분배</button>
+    }
+</div>
 
 @code {
     [Parameter] public int ContactId { get; set; }

--- a/src/Web/NexaCRM.WebClient/Pages/AssignDbPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/AssignDbPage.razor.css
@@ -1,0 +1,17 @@
+.page-container {
+    animation: fadeIn 0.3s ease-in;
+}
+
+.btn-assign {
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-assign:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/DbDistributionStatusPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/DbDistributionStatusPage.razor
@@ -62,8 +62,8 @@
                             <td>@customer.Status</td>
                             <td>@customer.LastContactDate.ToShortDateString()</td>
                             <td>
-                                <button class="btn btn-secondary btn-sm me-1" @onclick="() => Redistribute(customer.ContactId)">재분배</button>
-                                <button class="btn btn-danger btn-sm" @onclick="() => Recall(customer.ContactId)">회수</button>
+                                <button class="btn btn-secondary btn-sm me-1 action-btn" @onclick="() => Redistribute(customer.ContactId)">재분배</button>
+                                <button class="btn btn-danger btn-sm action-btn" @onclick="() => Recall(customer.ContactId)">회수</button>
                             </td>
                         </tr>
                     }

--- a/src/Web/NexaCRM.WebClient/Pages/DbDistributionStatusPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/DbDistributionStatusPage.razor
@@ -5,6 +5,7 @@
 @using NexaCRM.WebClient.Services.Interfaces
 
 @inject IDbDataService DbDataService
+@inject NavigationManager NavigationManager
 
 <div class="container-fluid mt-4">
     <h1 class="mb-4">DB 분배 현황</h1>
@@ -61,8 +62,8 @@
                             <td>@customer.Status</td>
                             <td>@customer.LastContactDate.ToShortDateString()</td>
                             <td>
-                                <button class="btn btn-secondary btn-sm me-1">재분배</button>
-                                <button class="btn btn-danger btn-sm">회수</button>
+                                <button class="btn btn-secondary btn-sm me-1" @onclick="() => Redistribute(customer.ContactId)">재분배</button>
+                                <button class="btn btn-danger btn-sm" @onclick="() => Recall(customer.ContactId)">회수</button>
                             </td>
                         </tr>
                     }
@@ -90,5 +91,17 @@
         statusCounts = customers
             .GroupBy(c => c.Status)
             .ToDictionary(g => g.Key, g => g.Count());
+    }
+
+    private void Redistribute(int contactId)
+    {
+        NavigationManager.NavigateTo($"/db/distribution/assign/{contactId}");
+    }
+
+    private async Task Recall(int contactId)
+    {
+        await DbDataService.RecallDbAsync(contactId);
+        customers = await DbDataService.GetDbDistributionStatusAsync();
+        ProcessDataForChart();
     }
 }

--- a/src/Web/NexaCRM.WebClient/Pages/DbDistributionStatusPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/DbDistributionStatusPage.razor
@@ -6,10 +6,12 @@
 
 @inject IDbDataService DbDataService
 @inject NavigationManager NavigationManager
+@inject IStringLocalizer<DbDistributionStatusPage> Localizer
+@inject IStringLocalizer<DbStatus> StatusLocalizer
 
 <div class="container-fluid mt-4">
-    <h1 class="mb-4">DB 분배 현황</h1>
-    <p class="text-muted mb-4">팀 전체의 DB 분배 이력 및 현황을 조회합니다.</p>
+    <h1 class="mb-4">@Localizer["Title"]</h1>
+    <p class="text-muted mb-4">@Localizer["Subtitle"]</p>
 
     @if (customers == null)
     {
@@ -24,12 +26,12 @@
         <!-- Chart Section -->
         <div class="card mb-4">
             <div class="card-body">
-                <h5 class="card-title">DB 상태별 현황</h5>
+                <h5 class="card-title">@Localizer["StatusSummaryTitle"]</h5>
                 <div class="d-flex justify-content-around p-3">
                     @foreach (var status in statusCounts)
                     {
                         <div class="text-center">
-                            <h6 class="mb-0">@status.Key</h6>
+                            <h6 class="mb-0">@StatusLocalizer[status.Key.ToString()]</h6>
                             <div class="fs-2 fw-bold">@status.Value</div>
                         </div>
                     }
@@ -37,18 +39,18 @@
             </div>
         </div>
 
-        <h3 class="h5 mb-3">전체 목록</h3>
+        <h3 class="h5 mb-3">@Localizer["AllListTitle"]</h3>
         <div class="table-responsive">
             <table class="table table-striped table-hover">
                 <thead class="table-light">
                     <tr>
-                        <th>고객명</th>
-                        <th>연락처</th>
-                        <th>담당자</th>
-                        <th>분배일</th>
-                        <th>DB 상태</th>
-                        <th>최종 컨택일</th>
-                        <th>액션</th>
+                        <th>@Localizer["CustomerName"]</th>
+                        <th>@Localizer["Contact"]</th>
+                        <th>@Localizer["AssignedTo"]</th>
+                        <th>@Localizer["AssignedDate"]</th>
+                        <th>@Localizer["Status"]</th>
+                        <th>@Localizer["LastContact"]</th>
+                        <th>@Localizer["Actions"]</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -59,11 +61,11 @@
                             <td>@customer.ContactNumber</td>
                             <td>@customer.AssignedTo</td>
                             <td>@customer.AssignedDate.ToShortDateString()</td>
-                            <td>@customer.Status</td>
+                            <td>@StatusLocalizer[customer.Status.ToString()]</td>
                             <td>@customer.LastContactDate.ToShortDateString()</td>
                             <td>
-                                <button class="btn btn-secondary btn-sm me-1 action-btn" @onclick="() => Redistribute(customer.ContactId)">재분배</button>
-                                <button class="btn btn-danger btn-sm action-btn" @onclick="() => Recall(customer.ContactId)">회수</button>
+                                <button class="btn btn-secondary btn-sm me-1 action-btn" @onclick="() => Redistribute(customer.ContactId)">@Localizer["Redistribute"]</button>
+                                <button class="btn btn-danger btn-sm action-btn" @onclick="() => Recall(customer.ContactId)">@Localizer["Recall"]</button>
                             </td>
                         </tr>
                     }

--- a/src/Web/NexaCRM.WebClient/Pages/DbDistributionStatusPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/DbDistributionStatusPage.razor.css
@@ -1,0 +1,26 @@
+.table-responsive {
+    animation: fadeIn 0.3s ease-in;
+}
+
+.table-hover tbody tr {
+    transition: background-color 0.2s ease;
+}
+
+.table-hover tbody tr:hover {
+    background-color: #f8f9fa;
+    cursor: pointer;
+}
+
+.action-btn {
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.action-btn:hover {
+    transform: scale(1.05);
+    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/Index.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/Index.razor
@@ -5,15 +5,16 @@
 @inject NavigationManager NavigationManager
 @inject IJSRuntime JSRuntime
 @inject AuthenticationStateProvider AuthStateProvider
+@inject IStringLocalizer<Index> Localizer
 
 @if (!_hasNavigated)
 {
     <div class="d-flex justify-content-center align-items-center" style="height: 100vh;">
         <div class="text-center">
             <div class="spinner-border text-primary" role="status">
-                <span class="sr-only">로딩 중...</span>
+                <span class="sr-only">@Localizer["Loading"]</span>
             </div>
-            <p class="mt-3">애플리케이션을 로딩하고 있습니다...</p>
+            <p class="mt-3">@Localizer["LoadingApp"]</p>
         </div>
     </div>
 }

--- a/src/Web/NexaCRM.WebClient/Pages/UnassignedDbListPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/UnassignedDbListPage.razor
@@ -39,7 +39,7 @@
                             <td>@customer.ContactNumber</td>
                             <td>@customer.Status</td>
                             <td>
-                                <button class="btn btn-primary btn-sm" @onclick="() => NavigateToAssign(customer.ContactId)">분배하기</button>
+                                <button class="btn btn-primary btn-sm btn-assign" @onclick="() => NavigateToAssign(customer.ContactId)">분배하기</button>
                             </td>
                         </tr>
                     }

--- a/src/Web/NexaCRM.WebClient/Pages/UnassignedDbListPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/UnassignedDbListPage.razor
@@ -6,10 +6,12 @@
 
 @inject IDbDataService DbDataService
 @inject NavigationManager NavigationManager
+@inject IStringLocalizer<UnassignedDbListPage> Localizer
+@inject IStringLocalizer<DbStatus> StatusLocalizer
 
 <div class="container-fluid mt-4">
-    <h1 class="mb-4">미분배 DB 목록</h1>
-    <p class="text-muted mb-4">아직 담당자에게 할당되지 않은 DB 목록입니다. 여기서 DB를 분배할 수 있습니다.</p>
+    <h1 class="mb-4">@Localizer["Title"]</h1>
+    <p class="text-muted mb-4">@Localizer["Subtitle"]</p>
 
     @if (customers == null)
     {
@@ -25,10 +27,10 @@
             <table class="table table-striped table-hover">
                 <thead class="table-light">
                     <tr>
-                        <th>고객명</th>
-                        <th>연락처</th>
-                        <th>DB 상태</th>
-                        <th>액션</th>
+                        <th>@Localizer["CustomerName"]</th>
+                        <th>@Localizer["Contact"]</th>
+                        <th>@Localizer["Status"]</th>
+                        <th>@Localizer["Actions"]</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -37,9 +39,9 @@
                         <tr>
                             <td>@customer.CustomerName</td>
                             <td>@customer.ContactNumber</td>
-                            <td>@customer.Status</td>
+                            <td>@StatusLocalizer[customer.Status.ToString()]</td>
                             <td>
-                                <button class="btn btn-primary btn-sm btn-assign" @onclick="() => NavigateToAssign(customer.ContactId)">분배하기</button>
+                                <button class="btn btn-primary btn-sm btn-assign" @onclick="() => NavigateToAssign(customer.ContactId)">@Localizer["AssignAction"]</button>
                             </td>
                         </tr>
                     }

--- a/src/Web/NexaCRM.WebClient/Pages/UnassignedDbListPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/UnassignedDbListPage.razor
@@ -5,6 +5,7 @@
 @using NexaCRM.WebClient.Services.Interfaces
 
 @inject IDbDataService DbDataService
+@inject NavigationManager NavigationManager
 
 <div class="container-fluid mt-4">
     <h1 class="mb-4">미분배 DB 목록</h1>
@@ -38,7 +39,7 @@
                             <td>@customer.ContactNumber</td>
                             <td>@customer.Status</td>
                             <td>
-                                <button class="btn btn-primary btn-sm">분배하기</button>
+                                <button class="btn btn-primary btn-sm" @onclick="() => NavigateToAssign(customer.ContactId)">분배하기</button>
                             </td>
                         </tr>
                     }
@@ -54,5 +55,10 @@
     protected override async Task OnInitializedAsync()
     {
         customers = await DbDataService.GetUnassignedDbListAsync();
+    }
+
+    private void NavigateToAssign(int contactId)
+    {
+        NavigationManager.NavigateTo($"/db/distribution/assign/{contactId}");
     }
 }

--- a/src/Web/NexaCRM.WebClient/Pages/UnassignedDbListPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/UnassignedDbListPage.razor.css
@@ -1,0 +1,25 @@
+.table-responsive {
+    animation: fadeIn 0.3s ease-in;
+}
+
+.table-hover tbody tr {
+    transition: background-color 0.2s ease;
+}
+
+.table-hover tbody tr:hover {
+    background-color: #f8f9fa;
+    cursor: pointer;
+}
+
+.btn-assign {
+    transition: transform 0.2s ease;
+}
+
+.btn-assign:hover {
+    transform: scale(1.05);
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}

--- a/src/Web/NexaCRM.WebClient/Resources/Models/Db/DbStatus.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Models/Db/DbStatus.en-US.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="New" xml:space="preserve">
+    <value>New</value>
+  </data>
+  <data name="InProgress" xml:space="preserve">
+    <value>In Progress</value>
+  </data>
+  <data name="NoAnswer" xml:space="preserve">
+    <value>No Answer</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>Completed</value>
+  </data>
+  <data name="OnHold" xml:space="preserve">
+    <value>On Hold</value>
+  </data>
+</root>

--- a/src/Web/NexaCRM.WebClient/Resources/Models/Db/DbStatus.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Models/Db/DbStatus.ko-KR.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="New" xml:space="preserve">
+    <value>신규</value>
+  </data>
+  <data name="InProgress" xml:space="preserve">
+    <value>상담중</value>
+  </data>
+  <data name="NoAnswer" xml:space="preserve">
+    <value>부재중</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>계약완료</value>
+  </data>
+  <data name="OnHold" xml:space="preserve">
+    <value>보류</value>
+  </data>
+</root>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/AllDbListPage.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/AllDbListPage.en-US.resx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>All DB List</value>
+  </data>
+  <data name="CustomerName" xml:space="preserve">
+    <value>Customer</value>
+  </data>
+  <data name="Contact" xml:space="preserve">
+    <value>Contact</value>
+  </data>
+  <data name="AssignedTo" xml:space="preserve">
+    <value>Assigned To</value>
+  </data>
+  <data name="AssignedDate" xml:space="preserve">
+    <value>Assigned Date</value>
+  </data>
+  <data name="Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="LastContact" xml:space="preserve">
+    <value>Last Contact</value>
+  </data>
+  <data name="Starred" xml:space="preserve">
+    <value>Starred</value>
+  </data>
+  <data name="Assigner" xml:space="preserve">
+    <value>Assigned By</value>
+  </data>
+</root>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/AllDbListPage.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/AllDbListPage.ko-KR.resx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>전체 DB 목록</value>
+  </data>
+  <data name="CustomerName" xml:space="preserve">
+    <value>고객명</value>
+  </data>
+  <data name="Contact" xml:space="preserve">
+    <value>연락처</value>
+  </data>
+  <data name="AssignedTo" xml:space="preserve">
+    <value>담당자</value>
+  </data>
+  <data name="AssignedDate" xml:space="preserve">
+    <value>분배일</value>
+  </data>
+  <data name="Status" xml:space="preserve">
+    <value>DB 상태</value>
+  </data>
+  <data name="LastContact" xml:space="preserve">
+    <value>최종 컨택일</value>
+  </data>
+  <data name="Starred" xml:space="preserve">
+    <value>관심</value>
+  </data>
+  <data name="Assigner" xml:space="preserve">
+    <value>전달자</value>
+  </data>
+</root>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/AssignDbPage.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/AssignDbPage.en-US.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Assign DB</value>
+  </data>
+  <data name="SelectAgentLabel" xml:space="preserve">
+    <value>Select Agent</value>
+  </data>
+  <data name="SelectAgentPlaceholder" xml:space="preserve">
+    <value>Choose an agent</value>
+  </data>
+  <data name="AssignButton" xml:space="preserve">
+    <value>Assign</value>
+  </data>
+</root>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/AssignDbPage.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/AssignDbPage.ko-KR.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>DB 분배</value>
+  </data>
+  <data name="SelectAgentLabel" xml:space="preserve">
+    <value>담당자 선택</value>
+  </data>
+  <data name="SelectAgentPlaceholder" xml:space="preserve">
+    <value>담당자를 선택하세요</value>
+  </data>
+  <data name="AssignButton" xml:space="preserve">
+    <value>분배</value>
+  </data>
+</root>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/DbDistributionStatusPage.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/DbDistributionStatusPage.en-US.resx
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>DB Distribution Status</value>
+  </data>
+  <data name="Subtitle" xml:space="preserve">
+    <value>View the distribution history and status across the team.</value>
+  </data>
+  <data name="StatusSummaryTitle" xml:space="preserve">
+    <value>Status Overview</value>
+  </data>
+  <data name="AllListTitle" xml:space="preserve">
+    <value>Full List</value>
+  </data>
+  <data name="CustomerName" xml:space="preserve">
+    <value>Customer</value>
+  </data>
+  <data name="Contact" xml:space="preserve">
+    <value>Contact</value>
+  </data>
+  <data name="AssignedTo" xml:space="preserve">
+    <value>Assigned To</value>
+  </data>
+  <data name="AssignedDate" xml:space="preserve">
+    <value>Assigned Date</value>
+  </data>
+  <data name="Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="LastContact" xml:space="preserve">
+    <value>Last Contact</value>
+  </data>
+  <data name="Actions" xml:space="preserve">
+    <value>Actions</value>
+  </data>
+  <data name="Redistribute" xml:space="preserve">
+    <value>Redistribute</value>
+  </data>
+  <data name="Recall" xml:space="preserve">
+    <value>Recall</value>
+  </data>
+</root>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/DbDistributionStatusPage.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/DbDistributionStatusPage.ko-KR.resx
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>DB 분배 현황</value>
+  </data>
+  <data name="Subtitle" xml:space="preserve">
+    <value>팀 전체의 DB 분배 이력 및 현황을 조회합니다.</value>
+  </data>
+  <data name="StatusSummaryTitle" xml:space="preserve">
+    <value>DB 상태별 현황</value>
+  </data>
+  <data name="AllListTitle" xml:space="preserve">
+    <value>전체 목록</value>
+  </data>
+  <data name="CustomerName" xml:space="preserve">
+    <value>고객명</value>
+  </data>
+  <data name="Contact" xml:space="preserve">
+    <value>연락처</value>
+  </data>
+  <data name="AssignedTo" xml:space="preserve">
+    <value>담당자</value>
+  </data>
+  <data name="AssignedDate" xml:space="preserve">
+    <value>분배일</value>
+  </data>
+  <data name="Status" xml:space="preserve">
+    <value>DB 상태</value>
+  </data>
+  <data name="LastContact" xml:space="preserve">
+    <value>최종 컨택일</value>
+  </data>
+  <data name="Actions" xml:space="preserve">
+    <value>액션</value>
+  </data>
+  <data name="Redistribute" xml:space="preserve">
+    <value>재분배</value>
+  </data>
+  <data name="Recall" xml:space="preserve">
+    <value>회수</value>
+  </data>
+</root>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/Index.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/Index.en-US.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Loading" xml:space="preserve">
+    <value>Loading...</value>
+  </data>
+  <data name="LoadingApp" xml:space="preserve">
+    <value>Loading the application...</value>
+  </data>
+</root>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/Index.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/Index.ko-KR.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Loading" xml:space="preserve">
+    <value>로딩 중...</value>
+  </data>
+  <data name="LoadingApp" xml:space="preserve">
+    <value>애플리케이션을 로딩하고 있습니다...</value>
+  </data>
+</root>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/UnassignedDbListPage.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/UnassignedDbListPage.en-US.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Unassigned DB List</value>
+  </data>
+  <data name="Subtitle" xml:space="preserve">
+    <value>These DB records are not yet assigned. Assign them here.</value>
+  </data>
+  <data name="CustomerName" xml:space="preserve">
+    <value>Customer</value>
+  </data>
+  <data name="Contact" xml:space="preserve">
+    <value>Contact</value>
+  </data>
+  <data name="Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="Actions" xml:space="preserve">
+    <value>Actions</value>
+  </data>
+  <data name="AssignAction" xml:space="preserve">
+    <value>Assign</value>
+  </data>
+</root>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/UnassignedDbListPage.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/UnassignedDbListPage.ko-KR.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>미분배 DB 목록</value>
+  </data>
+  <data name="Subtitle" xml:space="preserve">
+    <value>아직 담당자에게 할당되지 않은 DB 목록입니다. 여기서 DB를 분배할 수 있습니다.</value>
+  </data>
+  <data name="CustomerName" xml:space="preserve">
+    <value>고객명</value>
+  </data>
+  <data name="Contact" xml:space="preserve">
+    <value>연락처</value>
+  </data>
+  <data name="Status" xml:space="preserve">
+    <value>DB 상태</value>
+  </data>
+  <data name="Actions" xml:space="preserve">
+    <value>액션</value>
+  </data>
+  <data name="AssignAction" xml:space="preserve">
+    <value>분배하기</value>
+  </data>
+</root>

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IDbDataService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IDbDataService.cs
@@ -13,6 +13,10 @@ namespace NexaCRM.WebClient.Services.Interfaces
         Task<IEnumerable<DbCustomer>> GetTodaysAssignedDbAsync();
         Task<IEnumerable<DbCustomer>> GetDbDistributionStatusAsync();
 
+        Task AssignDbToAgentAsync(int contactId, string agentName);
+        Task ReassignDbAsync(int contactId, string agentName);
+        Task RecallDbAsync(int contactId);
+
         // Methods for Sales
         Task<IEnumerable<DbCustomer>> GetNewDbListAsync(string salesAgentName);
         Task<IEnumerable<DbCustomer>> GetStarredDbListAsync(string salesAgentName);

--- a/src/Web/NexaCRM.WebClient/Services/Mock/MockAgentService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Mock/MockAgentService.cs
@@ -12,11 +12,12 @@ namespace NexaCRM.WebClient.Services.Mock
         {
             _agents = new List<Agent>
             {
-                new Agent { Id = 1, Name = "Ethan Harper", Email = "ethan.harper@example.com" },
-                new Agent { Id = 2, Name = "Olivia Bennett", Email = "olivia.bennett@example.com" },
-                new Agent { Id = 3, Name = "Noah Foster", Email = "noah.foster@example.com" },
-                new Agent { Id = 4, Name = "Isabella Reed", Email = "isabella.reed@example.com" },
-                new Agent { Id = 5, Name = "Lucas Coleman", Email = "lucas.coleman@example.com" }
+                new Agent { Id = 1, Name = "Ethan Harper", Email = "ethan.harper@example.com", Role = "Sales" },
+                new Agent { Id = 2, Name = "Olivia Bennett", Email = "olivia.bennett@example.com", Role = "Sales" },
+                new Agent { Id = 3, Name = "Noah Foster", Email = "noah.foster@example.com", Role = "Sales" },
+                new Agent { Id = 4, Name = "Isabella Reed", Email = "isabella.reed@example.com", Role = "Sales" },
+                new Agent { Id = 5, Name = "Lucas Coleman", Email = "lucas.coleman@example.com", Role = "Sales" },
+                new Agent { Id = 6, Name = "Mia Manager", Email = "mia.manager@example.com", Role = "Manager" }
             };
         }
 

--- a/src/Web/NexaCRM.WebClient/Services/Mock/MockDbDataService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Mock/MockDbDataService.cs
@@ -50,6 +50,31 @@ namespace NexaCRM.WebClient.Services.Mock
         public Task<IEnumerable<DbCustomer>> GetTodaysAssignedDbAsync() => FilterData(c => c.AssignedDate.Date == DateTime.Today);
         public Task<IEnumerable<DbCustomer>> GetDbDistributionStatusAsync() => FilterData(c => !string.IsNullOrEmpty(c.AssignedTo)); // Same as Team Status for this mock
 
+        public Task AssignDbToAgentAsync(int contactId, string agentName)
+        {
+            var customer = _dbCustomers.FirstOrDefault(c => c.ContactId == contactId);
+            if (customer != null)
+            {
+                customer.AssignedTo = agentName;
+                customer.AssignedDate = DateTime.Now;
+                customer.Assigner = ManagerName;
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task ReassignDbAsync(int contactId, string agentName)
+            => AssignDbToAgentAsync(contactId, agentName);
+
+        public Task RecallDbAsync(int contactId)
+        {
+            var customer = _dbCustomers.FirstOrDefault(c => c.ContactId == contactId);
+            if (customer != null)
+            {
+                customer.AssignedTo = null;
+            }
+            return Task.CompletedTask;
+        }
+
         // Sales Methods
         public Task<IEnumerable<DbCustomer>> GetNewDbListAsync(string salesAgentName) => FilterData(c => c.AssignedTo == salesAgentName && c.Status == DbStatus.New);
         public Task<IEnumerable<DbCustomer>> GetStarredDbListAsync(string salesAgentName) => FilterData(c => c.AssignedTo == salesAgentName && c.IsStarred);

--- a/src/Web/NexaCRM.WebClient/wwwroot/js/theme-manager.js
+++ b/src/Web/NexaCRM.WebClient/wwwroot/js/theme-manager.js
@@ -17,8 +17,8 @@ window.themeManager = {
     
     // Initialize theme system
     init: () => {
-        // Get saved preference or default to auto
-        const savedTheme = localStorage.getItem(window.themeManager.STORAGE_KEY) || window.themeManager.THEMES.AUTO;
+        // Get saved preference or default to light theme
+        const savedTheme = localStorage.getItem(window.themeManager.STORAGE_KEY) || window.themeManager.THEMES.LIGHT;
         
         // Set up system theme detection
         window.themeManager.setupSystemThemeDetection();

--- a/tests/BlazorWebApp.Tests/BlazorWebApp.Tests.csproj
+++ b/tests/BlazorWebApp.Tests/BlazorWebApp.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\src\\Web\\NexaCRM.WebClient\\NexaCRM.WebClient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/BlazorWebApp.Tests/MockDbDataServiceTests.cs
+++ b/tests/BlazorWebApp.Tests/MockDbDataServiceTests.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using System.Threading.Tasks;
+using NexaCRM.WebClient.Services.Mock;
+
+namespace BlazorWebApp.Tests;
+
+public class MockDbDataServiceTests
+{
+    [Fact]
+    public async Task AssignDbToAgentAsync_AssignsCustomer()
+    {
+        var service = new MockDbDataService();
+        var unassigned = await service.GetUnassignedDbListAsync();
+        var customer = unassigned.First();
+        await service.AssignDbToAgentAsync(customer.ContactId, "이영업");
+        var assigned = (await service.GetAllDbListAsync()).First(c => c.ContactId == customer.ContactId);
+        Assert.Equal("이영업", assigned.AssignedTo);
+    }
+
+    [Fact]
+    public async Task RecallDbAsync_RemovesAssignment()
+    {
+        var service = new MockDbDataService();
+        var assignedCustomer = (await service.GetAllDbListAsync()).First(c => c.AssignedTo != null);
+        await service.RecallDbAsync(assignedCustomer.ContactId);
+        var recalled = (await service.GetAllDbListAsync()).First(c => c.ContactId == assignedCustomer.ContactId);
+        Assert.Null(recalled.AssignedTo);
+    }
+}


### PR DESCRIPTION
## Summary
- enable assigning unassigned DBs to sales agents via new assign page
- add redistribution and recall actions to distribution status view
- ensure full DB list displays correctly and default to light theme

## Testing
- `dotnet build --configuration Release`
- `dotnet test --configuration Release`


------
https://chatgpt.com/codex/tasks/task_b_68c517a1cea4832c9be3e2232fd765d4