### PR TITLE
feat: scaffold module pages with mobile-first layout

### DIFF
--- a/src/Web/NexaCRM.WebClient/Models/CustomerCenterModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/CustomerCenterModels.cs
@@ -1,0 +1,6 @@
+namespace NexaCRM.WebClient.Models.CustomerCenter;
+
+public record Notice(int Id, string Title, string Content);
+
+public record FaqItem(int Id, string Question, string Answer);
+

--- a/src/Web/NexaCRM.WebClient/Models/Db/DbAdminModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Db/DbAdminModels.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+
+namespace NexaCRM.WebClient.Models.Db;
+
+public record DbSearchCriteria(
+    bool CheckDuplicates,
+    DateTime? From,
+    DateTime? To
+);
+
+public record DbExportSettings(IList<string> Fields)
+{
+    public DbExportSettings() : this(new List<string>()) { }
+}
+

--- a/src/Web/NexaCRM.WebClient/Models/OrganizationModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/OrganizationModels.cs
@@ -1,0 +1,6 @@
+namespace NexaCRM.WebClient.Models.Organization;
+
+public record OrganizationUnit(int Id, string Name, int? ParentId);
+
+public record OrganizationStats(string UnitName, int MemberCount);
+

--- a/src/Web/NexaCRM.WebClient/Models/SettingsModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/SettingsModels.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace NexaCRM.WebClient.Models.Settings;
+
+public record CompanyInfo(
+    string Name = "",
+    string Address = "",
+    string ContactNumber = ""
+);
+
+public record SecuritySettings(
+    bool IpRestrictionEnabled = false,
+    bool LoginBlockEnabled = false
+);
+
+public record SmsSettings(
+    IList<string> SenderNumbers,
+    IList<string> Templates
+)
+{
+    public SmsSettings() : this(new List<string>(), new List<string>()) { }
+}
+

--- a/src/Web/NexaCRM.WebClient/Models/SmsModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/SmsModels.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+
+namespace NexaCRM.WebClient.Models.Sms;
+
+public record BulkSmsRequest(IList<string> Recipients, string Message)
+{
+    public BulkSmsRequest() : this(new List<string>(), string.Empty) { }
+}
+
+public record SmsHistoryItem(string Recipient, string Message, DateTime SentAt);
+
+public record SmsScheduleItem(DateTime ScheduledAt, BulkSmsRequest Request)
+{
+    public SmsScheduleItem() : this(DateTime.UtcNow, new BulkSmsRequest()) { }
+}
+

--- a/src/Web/NexaCRM.WebClient/Models/StatisticsModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/StatisticsModels.cs
@@ -1,0 +1,4 @@
+namespace NexaCRM.WebClient.Models.Statistics;
+
+public record StatisticsSummary(int TotalMembers, int TotalLogins, int TotalDownloads);
+

--- a/src/Web/NexaCRM.WebClient/Models/SystemInfoModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/SystemInfoModels.cs
@@ -1,0 +1,8 @@
+namespace NexaCRM.WebClient.Models.SystemInfo;
+
+public record SystemInfo(
+    string Terms = "",
+    string CompanyContact = "",
+    string BusinessAddress = ""
+);
+

--- a/src/Web/NexaCRM.WebClient/Pages/BulkSmsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/BulkSmsPage.razor
@@ -1,0 +1,6 @@
+@page "/sms/bulk"
+
+<ResponsivePage>
+    <h3>Bulk SMS Sending</h3>
+    <p>Send SMS messages to multiple recipients.</p>
+</ResponsivePage>

--- a/src/Web/NexaCRM.WebClient/Pages/CompanyInfoPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/CompanyInfoPage.razor
@@ -1,0 +1,6 @@
+@page "/settings/company-info"
+
+<ResponsivePage>
+    <h3>Company Information Management</h3>
+    <p>Manage company profile and business details.</p>
+</ResponsivePage>

--- a/src/Web/NexaCRM.WebClient/Pages/DbAdvancedManagementPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/DbAdvancedManagementPage.razor
@@ -1,0 +1,6 @@
+@page "/db/advanced"
+
+<ResponsivePage>
+    <h3>Database Advanced Management</h3>
+    <p>Delete records, configure Excel exports and run advanced searches.</p>
+</ResponsivePage>

--- a/src/Web/NexaCRM.WebClient/Pages/FaqManagementPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/FaqManagementPage.razor
@@ -1,0 +1,6 @@
+@page "/support/faq"
+
+<ResponsivePage>
+    <h3>FAQ Management</h3>
+    <p>Manage frequently asked questions.</p>
+</ResponsivePage>

--- a/src/Web/NexaCRM.WebClient/Pages/NoticeManagementPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/NoticeManagementPage.razor
@@ -1,0 +1,6 @@
+@page "/support/notices"
+
+<ResponsivePage>
+    <h3>Notice Management</h3>
+    <p>Create and manage announcements.</p>
+</ResponsivePage>

--- a/src/Web/NexaCRM.WebClient/Pages/OrganizationStatsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/OrganizationStatsPage.razor
@@ -1,0 +1,6 @@
+@page "/organization/stats"
+
+<ResponsivePage>
+    <h3>Organization Statistics</h3>
+    <p>View statistics by company, team and member.</p>
+</ResponsivePage>

--- a/src/Web/NexaCRM.WebClient/Pages/OrganizationStructurePage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/OrganizationStructurePage.razor
@@ -1,0 +1,6 @@
+@page "/organization/structure"
+
+<ResponsivePage>
+    <h3>Organization Structure</h3>
+    <p>Manage production companies, teams and members.</p>
+</ResponsivePage>

--- a/src/Web/NexaCRM.WebClient/Pages/SecuritySettingsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SecuritySettingsPage.razor
@@ -1,0 +1,6 @@
+@page "/settings/security"
+
+<ResponsivePage>
+    <h3>Security Settings</h3>
+    <p>Configure IP restrictions, login blocking and other security options.</p>
+</ResponsivePage>

--- a/src/Web/NexaCRM.WebClient/Pages/SenderNumberManagementPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SenderNumberManagementPage.razor
@@ -1,0 +1,6 @@
+@page "/sms/senders"
+
+<ResponsivePage>
+    <h3>Sender Number Management</h3>
+    <p>Register and manage sender phone numbers.</p>
+</ResponsivePage>

--- a/src/Web/NexaCRM.WebClient/Pages/SmsHistoryPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SmsHistoryPage.razor
@@ -1,0 +1,6 @@
+@page "/sms/history"
+
+<ResponsivePage>
+    <h3>SMS History</h3>
+    <p>Review SMS delivery history.</p>
+</ResponsivePage>

--- a/src/Web/NexaCRM.WebClient/Pages/SmsSchedulePage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SmsSchedulePage.razor
@@ -1,0 +1,6 @@
+@page "/schedule/sms"
+
+<ResponsivePage>
+    <h3>SMS Schedule</h3>
+    <p>Register and view scheduled SMS messages.</p>
+</ResponsivePage>

--- a/src/Web/NexaCRM.WebClient/Pages/SmsSettingsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SmsSettingsPage.razor
@@ -1,0 +1,6 @@
+@page "/settings/sms"
+
+<ResponsivePage>
+    <h3>SMS Settings</h3>
+    <p>Manage sender numbers and message templates.</p>
+</ResponsivePage>

--- a/src/Web/NexaCRM.WebClient/Pages/StatisticsDashboardPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/StatisticsDashboardPage.razor
@@ -1,0 +1,6 @@
+@page "/statistics/dashboard"
+
+<ResponsivePage>
+    <h3>Statistics Dashboard</h3>
+    <p>View system usage statistics and reports.</p>
+</ResponsivePage>

--- a/src/Web/NexaCRM.WebClient/Pages/SystemAdminSettingsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SystemAdminSettingsPage.razor
@@ -1,0 +1,6 @@
+@page "/organization/system-admin"
+
+<ResponsivePage>
+    <h3>System Administration</h3>
+    <p>Configure global system administrators.</p>
+</ResponsivePage>

--- a/src/Web/NexaCRM.WebClient/Pages/SystemInfoPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SystemInfoPage.razor
@@ -1,0 +1,6 @@
+@page "/system/info"
+
+<ResponsivePage>
+    <h3>System Information</h3>
+    <p>View terms of service, company contact and address.</p>
+</ResponsivePage>

--- a/src/Web/NexaCRM.WebClient/Program.cs
+++ b/src/Web/NexaCRM.WebClient/Program.cs
@@ -38,6 +38,14 @@ builder.Services.AddScoped<IActivityService, MockActivityService>();
 builder.Services.AddScoped<ISalesManagementService, MockSalesManagementService>();
 builder.Services.AddScoped<IRolePermissionService, RolePermissionService>();
 builder.Services.AddScoped<IDbDataService, MockDbDataService>();
+builder.Services.AddScoped<IDeviceService, DeviceService>();
+builder.Services.AddScoped<ISettingsService, SettingsService>();
+builder.Services.AddScoped<IOrganizationService, OrganizationService>();
+builder.Services.AddScoped<IDbAdminService, DbAdminService>();
+builder.Services.AddScoped<IStatisticsService, StatisticsService>();
+builder.Services.AddScoped<ICustomerCenterService, CustomerCenterService>();
+builder.Services.AddScoped<ISmsService, SmsService>();
+builder.Services.AddScoped<ISystemInfoService, SystemInfoService>();
 
 var culture = new CultureInfo("ko-KR");
 CultureInfo.DefaultThreadCurrentCulture = culture;

--- a/src/Web/NexaCRM.WebClient/Services/CustomerCenterService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/CustomerCenterService.cs
@@ -1,0 +1,22 @@
+using NexaCRM.WebClient.Models.CustomerCenter;
+using NexaCRM.WebClient.Services.Interfaces;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services;
+
+public class CustomerCenterService : ICustomerCenterService
+{
+    public Task<IEnumerable<Notice>> GetNoticesAsync() =>
+        Task.FromResult<IEnumerable<Notice>>(new List<Notice>());
+
+    public Task SaveNoticeAsync(Notice notice) =>
+        Task.CompletedTask;
+
+    public Task<IEnumerable<FaqItem>> GetFaqItemsAsync() =>
+        Task.FromResult<IEnumerable<FaqItem>>(new List<FaqItem>());
+
+    public Task SaveFaqItemAsync(FaqItem item) =>
+        Task.CompletedTask;
+}
+

--- a/src/Web/NexaCRM.WebClient/Services/DbAdminService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/DbAdminService.cs
@@ -1,0 +1,20 @@
+using NexaCRM.WebClient.Models.Db;
+using NexaCRM.WebClient.Services.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services;
+
+public class DbAdminService : IDbAdminService
+{
+    public Task DeleteEntryAsync(int id) =>
+        Task.CompletedTask;
+
+    public Task<byte[]> ExportToExcelAsync(DbExportSettings settings) =>
+        Task.FromResult(Array.Empty<byte>());
+
+    public Task<IEnumerable<DbCustomer>> SearchAsync(DbSearchCriteria criteria) =>
+        Task.FromResult<IEnumerable<DbCustomer>>(new List<DbCustomer>());
+}
+

--- a/src/Web/NexaCRM.WebClient/Services/DeviceService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/DeviceService.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using Microsoft.JSInterop;
+using NexaCRM.WebClient.Services.Interfaces;
+
+namespace NexaCRM.WebClient.Services
+{
+    public class DeviceService : IDeviceService
+    {
+        private readonly IJSRuntime _jsRuntime;
+
+        public DeviceService(IJSRuntime jsRuntime)
+        {
+            _jsRuntime = jsRuntime;
+        }
+
+        public async Task<bool> IsMobileAsync()
+        {
+            return await _jsRuntime.InvokeAsync<bool>("deviceInfo.isMobile");
+        }
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/ICustomerCenterService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/ICustomerCenterService.cs
@@ -1,0 +1,14 @@
+using NexaCRM.WebClient.Models.CustomerCenter;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+public interface ICustomerCenterService
+{
+    Task<IEnumerable<Notice>> GetNoticesAsync();
+    Task SaveNoticeAsync(Notice notice);
+    Task<IEnumerable<FaqItem>> GetFaqItemsAsync();
+    Task SaveFaqItemAsync(FaqItem item);
+}
+

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IDbAdminService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IDbAdminService.cs
@@ -1,0 +1,13 @@
+using NexaCRM.WebClient.Models.Db;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+public interface IDbAdminService
+{
+    Task DeleteEntryAsync(int id);
+    Task<byte[]> ExportToExcelAsync(DbExportSettings settings);
+    Task<IEnumerable<DbCustomer>> SearchAsync(DbSearchCriteria criteria);
+}
+

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IDeviceService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IDeviceService.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+namespace NexaCRM.WebClient.Services.Interfaces
+{
+    public interface IDeviceService
+    {
+        Task<bool> IsMobileAsync();
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IOrganizationService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IOrganizationService.cs
@@ -1,0 +1,14 @@
+using NexaCRM.WebClient.Models.Organization;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+public interface IOrganizationService
+{
+    Task<IEnumerable<OrganizationUnit>> GetOrganizationStructureAsync();
+    Task SaveOrganizationUnitAsync(OrganizationUnit unit);
+    Task<IEnumerable<OrganizationStats>> GetOrganizationStatsAsync();
+    Task SetSystemAdministratorAsync(string userId);
+}
+

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/ISettingsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/ISettingsService.cs
@@ -1,0 +1,15 @@
+using NexaCRM.WebClient.Models.Settings;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+public interface ISettingsService
+{
+    Task<CompanyInfo> GetCompanyInfoAsync();
+    Task SaveCompanyInfoAsync(CompanyInfo info);
+    Task<SecuritySettings> GetSecuritySettingsAsync();
+    Task SaveSecuritySettingsAsync(SecuritySettings settings);
+    Task<SmsSettings> GetSmsSettingsAsync();
+    Task SaveSmsSettingsAsync(SmsSettings settings);
+}
+

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/ISmsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/ISmsService.cs
@@ -1,0 +1,15 @@
+using NexaCRM.WebClient.Models.Sms;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+public interface ISmsService
+{
+    Task SendBulkSmsAsync(BulkSmsRequest request);
+    Task<IEnumerable<string>> GetSenderNumbersAsync();
+    Task SaveSenderNumberAsync(string number);
+    Task<IEnumerable<SmsHistoryItem>> GetHistoryAsync();
+    Task ScheduleSmsAsync(SmsScheduleItem schedule);
+}
+

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IStatisticsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IStatisticsService.cs
@@ -1,0 +1,10 @@
+using NexaCRM.WebClient.Models.Statistics;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+public interface IStatisticsService
+{
+    Task<StatisticsSummary> GetStatisticsAsync();
+}
+

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/ISystemInfoService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/ISystemInfoService.cs
@@ -1,0 +1,10 @@
+using NexaCRM.WebClient.Models.SystemInfo;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+public interface ISystemInfoService
+{
+    Task<SystemInfo> GetSystemInfoAsync();
+}
+

--- a/src/Web/NexaCRM.WebClient/Services/OrganizationService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/OrganizationService.cs
@@ -1,0 +1,22 @@
+using NexaCRM.WebClient.Models.Organization;
+using NexaCRM.WebClient.Services.Interfaces;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services;
+
+public class OrganizationService : IOrganizationService
+{
+    public Task<IEnumerable<OrganizationUnit>> GetOrganizationStructureAsync() =>
+        Task.FromResult<IEnumerable<OrganizationUnit>>(new List<OrganizationUnit>());
+
+    public Task SaveOrganizationUnitAsync(OrganizationUnit unit) =>
+        Task.CompletedTask;
+
+    public Task<IEnumerable<OrganizationStats>> GetOrganizationStatsAsync() =>
+        Task.FromResult<IEnumerable<OrganizationStats>>(new List<OrganizationStats>());
+
+    public Task SetSystemAdministratorAsync(string userId) =>
+        Task.CompletedTask;
+}
+

--- a/src/Web/NexaCRM.WebClient/Services/SettingsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SettingsService.cs
@@ -1,0 +1,27 @@
+using NexaCRM.WebClient.Models.Settings;
+using NexaCRM.WebClient.Services.Interfaces;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services;
+
+public class SettingsService : ISettingsService
+{
+    public Task<CompanyInfo> GetCompanyInfoAsync() =>
+        Task.FromResult(new CompanyInfo());
+
+    public Task SaveCompanyInfoAsync(CompanyInfo info) =>
+        Task.CompletedTask;
+
+    public Task<SecuritySettings> GetSecuritySettingsAsync() =>
+        Task.FromResult(new SecuritySettings());
+
+    public Task SaveSecuritySettingsAsync(SecuritySettings settings) =>
+        Task.CompletedTask;
+
+    public Task<SmsSettings> GetSmsSettingsAsync() =>
+        Task.FromResult(new SmsSettings());
+
+    public Task SaveSmsSettingsAsync(SmsSettings settings) =>
+        Task.CompletedTask;
+}
+

--- a/src/Web/NexaCRM.WebClient/Services/SmsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SmsService.cs
@@ -1,0 +1,25 @@
+using NexaCRM.WebClient.Models.Sms;
+using NexaCRM.WebClient.Services.Interfaces;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services;
+
+public class SmsService : ISmsService
+{
+    public Task SendBulkSmsAsync(BulkSmsRequest request) =>
+        Task.CompletedTask;
+
+    public Task<IEnumerable<string>> GetSenderNumbersAsync() =>
+        Task.FromResult<IEnumerable<string>>(new List<string>());
+
+    public Task SaveSenderNumberAsync(string number) =>
+        Task.CompletedTask;
+
+    public Task<IEnumerable<SmsHistoryItem>> GetHistoryAsync() =>
+        Task.FromResult<IEnumerable<SmsHistoryItem>>(new List<SmsHistoryItem>());
+
+    public Task ScheduleSmsAsync(SmsScheduleItem schedule) =>
+        Task.CompletedTask;
+}
+

--- a/src/Web/NexaCRM.WebClient/Services/StatisticsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/StatisticsService.cs
@@ -1,0 +1,12 @@
+using NexaCRM.WebClient.Models.Statistics;
+using NexaCRM.WebClient.Services.Interfaces;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services;
+
+public class StatisticsService : IStatisticsService
+{
+    public Task<StatisticsSummary> GetStatisticsAsync() =>
+        Task.FromResult(new StatisticsSummary(0, 0, 0));
+}
+

--- a/src/Web/NexaCRM.WebClient/Services/SystemInfoService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SystemInfoService.cs
@@ -1,0 +1,12 @@
+using NexaCRM.WebClient.Models.SystemInfo;
+using NexaCRM.WebClient.Services.Interfaces;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services;
+
+public class SystemInfoService : ISystemInfoService
+{
+    public Task<SystemInfo> GetSystemInfoAsync() =>
+        Task.FromResult(new SystemInfo());
+}
+

--- a/src/Web/NexaCRM.WebClient/Shared/MainLayout.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/MainLayout.razor
@@ -1,9 +1,11 @@
 @inherits LayoutComponentBase
 @using NexaCRM.WebClient.Shared
+@using NexaCRM.WebClient.Services.Interfaces
 @using Microsoft.JSInterop
+@inject IDeviceService DeviceService
 @inject IJSRuntime JSRuntime
 
-<div class="page">
+<div class="page @(isMobile ? "mobile-layout" : "desktop-layout")">
     <!-- 고정된 햄버거 버튼 - sidebar 밖에 배치 -->
     <button title="Navigation menu" class="floating-menu-toggle" @onclick="ToggleNavMenu">
         <span class="navbar-toggler-icon"></span>
@@ -23,6 +25,7 @@
 </div>
 
 @code {
+    private bool isMobile;
     private async Task ToggleNavMenu()
     {
         // JavaScript 함수 호출하여 메뉴 상태 토글
@@ -40,6 +43,8 @@
             
             // 테마 토글 아이콘 초기화
             await JSRuntime.InvokeVoidAsync("updateMainThemeToggleIcon");
+            isMobile = await DeviceService.IsMobileAsync();
+            StateHasChanged();
         }
     }
 }

--- a/src/Web/NexaCRM.WebClient/Shared/ResponsivePage.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/ResponsivePage.razor
@@ -1,0 +1,13 @@
+@using Microsoft.AspNetCore.Components
+<div class="responsive-page">
+    <div class="row">
+        <div class="col-12">
+            @ChildContent
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css
+++ b/src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css
@@ -1,0 +1,27 @@
+/* Basic responsive tweaks for mobile layout */
+@media (max-width: 768px) {
+    .mobile-layout .sidebar {
+        width: 100%;
+        position: fixed;
+        height: 100%;
+        z-index: 1000;
+    }
+    .mobile-layout main {
+        padding: 0.5rem;
+    }
+    .mobile-layout .floating-menu-toggle {
+        top: 0.5rem;
+        left: 0.5rem;
+    }
+}
+/* Responsive page container */
+.responsive-page {
+    padding: 1rem;
+}
+@media (min-width: 768px) {
+    .responsive-page {
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 2rem;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/wwwroot/index.html
+++ b/src/Web/NexaCRM.WebClient/wwwroot/index.html
@@ -10,6 +10,7 @@
     <link href="https://cdn.jsdelivr.net/npm/open-iconic@1.1.1/font/css/open-iconic-bootstrap.css" rel="stylesheet" />
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="css/app.css" rel="stylesheet" />
+    <link href="css/mobile.css" rel="stylesheet" />
     <link href="NexaCRM.WebClient.styles.css" rel="stylesheet" />
 </head>
 
@@ -38,6 +39,7 @@
     <script src="js/navigation.js"></script>
     <script src="js/culture.js"></script>
     <script src="js/theme-manager.js"></script>
+    <script src="js/device.js"></script>
     <script src="js/interactions.js"></script>
 </body>
 

--- a/src/Web/NexaCRM.WebClient/wwwroot/js/device.js
+++ b/src/Web/NexaCRM.WebClient/wwwroot/js/device.js
@@ -1,0 +1,11 @@
+window.deviceInfo = {
+    isMobile: function () {
+        if (window.matchMedia) {
+            if (window.matchMedia('(max-width: 768px)').matches) {
+                return true;
+            }
+        }
+        const ua = navigator.userAgent || navigator.vendor || window.opera;
+        return /android|iPad|iPhone|iPod/i.test(ua);
+    }
+};


### PR DESCRIPTION
## Summary
- add placeholder pages covering settings, organization, database admin, statistics, customer center, sms, and system info modules
- introduce corresponding service interfaces and stub implementations
- register new services in the Blazor Web Client for future expansion
- apply mobile-first responsive layout to new placeholder pages with a shared component

## Testing
- `dotnet build --configuration Release`
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release`


------
https://chatgpt.com/codex/tasks/task_b_68c58661ebe0832c82d084ae3db9f9e4