### PR TITLE
feat: add fixed mobile header layout

### DIFF
--- a/src/Web/NexaCRM.WebClient/Shared/MainLayout.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/MainLayout.razor
@@ -4,12 +4,28 @@
 @using Microsoft.JSInterop
 @inject IDeviceService DeviceService
 @inject IJSRuntime JSRuntime
+@inject NavigationManager NavigationManager
 
 <div class="page @(isMobile ? "mobile-layout" : "desktop-layout")">
-    <!-- 고정된 햄버거 버튼 - sidebar 밖에 배치 -->
-    <button title="Navigation menu" class="floating-menu-toggle" @onclick="ToggleNavMenu">
-        <span class="navbar-toggler-icon"></span>
-    </button>
+    @if (isMobile)
+    {
+        <header class="mobile-fixed-header">
+            <button class="nav-menu-button" title="Navigation menu" @onclick="ToggleNavMenu">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="page-title">@currentPageTitle</div>
+            <button class="user-info-button" title="User profile" @onclick="GoToProfile">
+                <span class="oi oi-person" aria-hidden="true"></span>
+            </button>
+        </header>
+    }
+    else
+    {
+        <!-- 고정된 햄버거 버튼 - sidebar 밖에 배치 -->
+        <button title="Navigation menu" class="floating-menu-toggle" @onclick="ToggleNavMenu">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+    }
     
     <div class="sidebar">
         <NavMenu />
@@ -26,10 +42,23 @@
 
 @code {
     private bool isMobile;
+    private string currentPageTitle = string.Empty;
     private async Task ToggleNavMenu()
     {
         // JavaScript 함수 호출하여 메뉴 상태 토글
         await JSRuntime.InvokeVoidAsync("window.navigationHelper.toggleMenu");
+    }
+
+    private void GoToProfile()
+    {
+        NavigationManager.NavigateTo("profile-settings-page");
+    }
+
+    private async Task UpdatePageTitle()
+    {
+        var title = await JSRuntime.InvokeAsync<string>("eval", "document.title");
+        currentPageTitle = title.Contains('-') ? title.Split('-')[0].Trim() : title;
+        StateHasChanged();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -40,12 +69,18 @@
             await JSRuntime.InvokeVoidAsync("window.navigationHelper.setupOverlayHandler");
             // 초기 상태를 확실히 설정 (메뉴 닫힌 상태)
             await JSRuntime.InvokeVoidAsync("window.navigationHelper.toggleMenu", true);
-            
+
             // 테마 토글 아이콘 초기화
             await JSRuntime.InvokeVoidAsync("updateMainThemeToggleIcon");
             isMobile = await DeviceService.IsMobileAsync();
+            await UpdatePageTitle();
             StateHasChanged();
         }
+    }
+
+    protected override void OnInitialized()
+    {
+        NavigationManager.LocationChanged += async (_, __) => await UpdatePageTitle();
     }
 }
 

--- a/src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css
+++ b/src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css
@@ -25,3 +25,38 @@
         padding: 2rem;
     }
 }
+
+/* Fixed header for mobile */
+@media (max-width: 768px) {
+    .mobile-layout .mobile-fixed-header {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 3.5rem;
+        background-color: var(--surface-color);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 1rem;
+        z-index: 1100;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+
+    .mobile-layout .mobile-fixed-header .page-title {
+        flex: 1;
+        text-align: center;
+        font-size: 1rem;
+        font-weight: 600;
+    }
+
+    .mobile-layout .mobile-fixed-header .nav-menu-button,
+    .mobile-layout .mobile-fixed-header .user-info-button {
+        background: none;
+        border: none;
+    }
+
+    .mobile-layout main {
+        padding-top: 3.5rem;
+    }
+}


### PR DESCRIPTION
## Summary
- add mobile-only fixed header with nav toggle, page title, and profile link
- style mobile header to stay fixed at top and adjust main content spacing

## Testing
- `dotnet build --configuration Release`
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release`


------
https://chatgpt.com/codex/tasks/task_b_68c5b51f2b28832cbae011424bd9a749