### PR TITLE
fix: hide mobile overlay on navigation

### DIFF
--- a/src/Web/NexaCRM.WebClient/Shared/MainLayout.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/MainLayout.razor
@@ -80,7 +80,11 @@
 
     protected override void OnInitialized()
     {
-        NavigationManager.LocationChanged += async (_, __) => await UpdatePageTitle();
+        NavigationManager.LocationChanged += async (_, __) =>
+        {
+            await UpdatePageTitle();
+            await JSRuntime.InvokeVoidAsync("window.navigationHelper.toggleMenu", true);
+        };
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure mobile navigation overlay hides on route changes so dashboard elements are clickable on mobile

## Testing
- `dotnet build --configuration Release`
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release`


------
https://chatgpt.com/codex/tasks/task_b_68c80b1abe48832ca3f1af03def172cd