### PR TITLE
feat: load users from organization service

### DIFF
--- a/src/Web/NexaCRM.WebClient/Models/OrganizationModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/OrganizationModels.cs
@@ -4,3 +4,12 @@ public record OrganizationUnit(int Id, string Name, int? ParentId);
 
 public record OrganizationStats(string UnitName, int MemberCount);
 
+public class OrganizationUser
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+    public string Email { get; set; } = "";
+    public string Role { get; set; } = "";
+    public string Status { get; set; } = "";
+}
+

--- a/src/Web/NexaCRM.WebClient/Pages/SettingsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SettingsPage.razor
@@ -1,6 +1,10 @@
 @page "/settings-page"
 @using Microsoft.Extensions.Localization
+@using NexaCRM.WebClient.Models.Organization
+@using NexaCRM.WebClient.Services.Interfaces
+@using System.Linq
 @inject IStringLocalizer<SettingsPage> Localizer
+@inject IOrganizationService OrganizationService
 
 <div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
       <div class="layout-container flex h-full grow flex-col">
@@ -83,8 +87,9 @@
             </div>
             <h2 class="text-[#0e131b] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">@Localizer["UserManagement"]</h2>
             <div class="px-4 py-3 container">
-              <div class="flex overflow-hidden rounded-lg border border-[#d0d9e7] bg-slate-50">
-                <table class="flex-1">
+              <input type="text" class="mb-2 p-2 border border-[#d0d9e7] rounded w-full" placeholder='@Localizer["Search"]' @bind="searchTerm" />
+              <div class="user-table overflow-x-auto rounded-lg border border-[#d0d9e7] bg-slate-50">
+                <table class="min-w-full">
                   <thead>
                     <tr class="bg-slate-50">
                       <th class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-120 px-4 py-3 text-left text-[#0e131b] w-[400px] text-sm font-medium leading-normal">@Localizer["Name"]</th>
@@ -97,93 +102,156 @@
                     </tr>
                   </thead>
                   <tbody>
-                    <tr class="border-t border-t-[#d0d9e7]">
-                      <td class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-120 h-[72px] px-4 py-2 w-[400px] text-[#0e131b] text-sm font-normal leading-normal">
-                        @Localizer["EthanCarter"]
-                      </td>
-                      <td class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-240 h-[72px] px-4 py-2 w-[400px] text-[#4d6a99] text-sm font-normal leading-normal">
-                        @Localizer["EthanCarterEmail"]
-                      </td>
-                      <td class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-360 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
-                        <button
-                          class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-8 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-medium leading-normal w-full"
-                        >
-                          <span class="truncate">@Localizer["Admin"]</span>
-                        </button>
-                      </td>
-                      <td class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-480 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
-                        <button
-                          class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-8 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-medium leading-normal w-full"
-                        >
-                          <span class="truncate">@Localizer["Active"]</span>
-                        </button>
-                      </td>
-                      <td class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-600 h-[72px] px-4 py-2 w-60 text-[#4d6a99] text-sm font-bold leading-normal tracking-[0.015em]">
-                        @Localizer["EditDelete"]
-                      </td>
-                    </tr>
-                    <tr class="border-t border-t-[#d0d9e7]">
-                      <td class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-120 h-[72px] px-4 py-2 w-[400px] text-[#0e131b] text-sm font-normal leading-normal">
-                        @Localizer["OliviaBennett"]
-                      </td>
-                      <td class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-240 h-[72px] px-4 py-2 w-[400px] text-[#4d6a99] text-sm font-normal leading-normal">
-                        @Localizer["OliviaBennettEmail"]
-                      </td>
-                      <td class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-360 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
-                        <button
-                          class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-8 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-medium leading-normal w-full"
-                        >
-                          <span class="truncate">@Localizer["Sales"]</span>
-                        </button>
-                      </td>
-                      <td class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-480 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
-                        <button
-                          class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-8 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-medium leading-normal w-full"
-                        >
-                          <span class="truncate">@Localizer["Active"]</span>
-                        </button>
-                      </td>
-                      <td class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-600 h-[72px] px-4 py-2 w-60 text-[#4d6a99] text-sm font-bold leading-normal tracking-[0.015em]">
-                        @Localizer["EditDelete"]
-                      </td>
-                    </tr>
-                    <tr class="border-t border-t-[#d0d9e7]">
-                      <td class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-120 h-[72px] px-4 py-2 w-[400px] text-[#0e131b] text-sm font-normal leading-normal">
-                        @Localizer["NoahThompson"]
-                      </td>
-                      <td class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-240 h-[72px] px-4 py-2 w-[400px] text-[#4d6a99] text-sm font-normal leading-normal">
-                        @Localizer["NoahThompsonEmail"]
-                      </td>
-                      <td class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-360 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
-                        <button
-                          class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-8 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-medium leading-normal w-full"
-                        >
-                          <span class="truncate">@Localizer["Marketing"]</span>
-                        </button>
-                      </td>
-                      <td class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-480 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
-                        <button
-                          class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-8 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-medium leading-normal w-full"
-                        >
-                          <span class="truncate">@Localizer["Inactive"]</span>
-                        </button>
-                      </td>
-                      <td class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-600 h-[72px] px-4 py-2 w-60 text-[#4d6a99] text-sm font-bold leading-normal tracking-[0.015em]">
-                        @Localizer["EditDelete"]
-                      </td>
-                    </tr>
+                    @foreach (var user in FilteredUsers)
+                    {
+                      <tr class="border-t border-t-[#d0d9e7]">
+                        <td data-label='@Localizer["Name"]' class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-120 h-[72px] px-4 py-2 w-[400px] text-[#0e131b] text-sm font-normal leading-normal">
+                          @user.Name
+                        </td>
+                        <td data-label='@Localizer["Email"]' class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-240 h-[72px] px-4 py-2 w-[400px] text-[#4d6a99] text-sm font-normal leading-normal">
+                          @user.Email
+                        </td>
+                        <td data-label='@Localizer["Role"]' class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-360 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
+                          <button class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-8 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-medium leading-normal w-full">
+                            <span class="truncate">@user.Role</span>
+                          </button>
+                        </td>
+                        <td data-label='@Localizer["Status"]' class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-480 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
+                          <button class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-8 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-medium leading-normal w-full">
+                            <span class="truncate">@user.Status</span>
+                          </button>
+                        </td>
+                        <td data-label='@Localizer["Actions"]' class="table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-600 h-[72px] px-4 py-2 w-60 text-[#4d6a99] text-sm font-bold leading-normal tracking-[0.015em]">
+                          <div class="flex gap-2">
+                            <button class="text-blue-600" @onclick="() => OpenEdit(user)">@Localizer["Edit"]</button>
+                            <button class="text-red-600" @onclick="() => OpenDelete(user)">@Localizer["Delete"]</button>
+                          </div>
+                        </td>
+                      </tr>
+                    }
                   </tbody>
                 </table>
               </div>
             </div>
             <div class="flex px-4 py-3 justify-start">
-              <button
-                class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#2a74ea] text-slate-50 text-sm font-bold leading-normal tracking-[0.015em]"
-              >
-                <span class="truncate">@Localizer["CreateUser"]</span>
-              </button>
-            </div>
-          </div>
+      <button
+        class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#2a74ea] text-slate-50 text-sm font-bold leading-normal tracking-[0.015em]"
+      >
+        <span class="truncate">@Localizer["CreateUser"]</span>
+      </button>
+    </div>
+  </div>
+</div>
+</div>
+</div>
+
+@if (showEditDialog)
+{
+  <div class="modal-backdrop" @onclick="CloseEdit">
+    <div class="modal-content" @onclick:stopPropagation="true">
+      <h3 class="mb-4">@Localizer["EditUser"]</h3>
+      @if (selectedUser != null)
+      {
+        <div class="flex flex-col gap-2 mb-4">
+          <input class="border p-2" @bind="selectedUser.Name" />
+          <input class="border p-2" @bind="selectedUser.Email" />
+          <input class="border p-2" @bind="selectedUser.Role" />
+          <input class="border p-2" @bind="selectedUser.Status" />
         </div>
+      }
+      <div class="flex justify-end gap-2">
+        <button class="px-4 py-2 bg-blue-600 text-white rounded" @onclick="SaveEdit">@Localizer["Save"]</button>
+        <button class="px-4 py-2 border rounded" @onclick="CloseEdit">@Localizer["Cancel"]</button>
       </div>
     </div>
+  </div>
+}
+
+@if (showDeleteDialog)
+{
+  <div class="modal-backdrop" @onclick="CloseDelete">
+    <div class="modal-content" @onclick:stopPropagation="true">
+      <p>Are you sure you want to delete @selectedUser?.Name?</p>
+      <div class="flex justify-end gap-2 mt-4">
+        <button class="px-4 py-2 bg-red-600 text-white rounded" @onclick="ConfirmDelete">@Localizer["Delete"]</button>
+        <button class="px-4 py-2 border rounded" @onclick="CloseDelete">@Localizer["Cancel"]</button>
+      </div>
+    </div>
+  </div>
+}
+
+@code {
+    private List<OrganizationUser> users = new();
+    private string searchTerm = string.Empty;
+    private OrganizationUser? selectedUser;
+    private bool showEditDialog = false;
+    private bool showDeleteDialog = false;
+
+    private IEnumerable<OrganizationUser> FilteredUsers =>
+        string.IsNullOrWhiteSpace(searchTerm)
+            ? users
+            : users.Where(u =>
+                (u.Name?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (u.Email?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false));
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadUsersAsync();
+    }
+
+    private async Task LoadUsersAsync()
+    {
+        users = (await OrganizationService.GetUsersAsync()).ToList();
+    }
+
+    private void OpenEdit(OrganizationUser user)
+    {
+        selectedUser = new OrganizationUser
+        {
+            Id = user.Id,
+            Name = user.Name,
+            Email = user.Email,
+            Role = user.Role,
+            Status = user.Status
+        };
+        showEditDialog = true;
+    }
+
+    private void CloseEdit()
+    {
+        showEditDialog = false;
+        selectedUser = null;
+    }
+
+    private async Task SaveEdit()
+    {
+        if (selectedUser != null)
+        {
+            await OrganizationService.UpdateUserAsync(selectedUser);
+            await LoadUsersAsync();
+            CloseEdit();
+        }
+    }
+
+    private void OpenDelete(OrganizationUser user)
+    {
+        selectedUser = user;
+        showDeleteDialog = true;
+    }
+
+    private void CloseDelete()
+    {
+        showDeleteDialog = false;
+        selectedUser = null;
+    }
+
+    private async Task ConfirmDelete()
+    {
+        if (selectedUser != null)
+        {
+            await OrganizationService.DeleteUserAsync(selectedUser.Id);
+            await LoadUsersAsync();
+            CloseDelete();
+        }
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/SettingsPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/SettingsPage.razor.css
@@ -3,3 +3,52 @@
 @container(max-width:360px){.table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-360{display: none;}}
 @container(max-width:480px){.table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-480{display: none;}}
 @container(max-width:600px){.table-ea08c9dc-38a0-443e-b93b-5bc9be11998c-column-600{display: none;}}
+
+.user-table table {
+    width: 100%;
+}
+
+@media (max-width: 640px) {
+    .user-table thead {
+        display: none;
+    }
+
+    .user-table tr {
+        display: block;
+        border-bottom: 1px solid #d0d9e7;
+        margin-bottom: 0.75rem;
+    }
+
+    .user-table td {
+        display: flex;
+        justify-content: space-between;
+        padding: 0.5rem;
+    }
+
+    .user-table td::before {
+        content: attr(data-label);
+        font-weight: 600;
+        margin-right: 1rem;
+    }
+}
+
+.modal-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background: white;
+    border-radius: 8px;
+    padding: 20px;
+    max-width: 500px;
+    width: 90%;
+}

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IOrganizationService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IOrganizationService.cs
@@ -10,5 +10,8 @@ public interface IOrganizationService
     Task SaveOrganizationUnitAsync(OrganizationUnit unit);
     Task<IEnumerable<OrganizationStats>> GetOrganizationStatsAsync();
     Task SetSystemAdministratorAsync(string userId);
+    Task<IEnumerable<OrganizationUser>> GetUsersAsync();
+    Task UpdateUserAsync(OrganizationUser user);
+    Task DeleteUserAsync(int userId);
 }
 

--- a/src/Web/NexaCRM.WebClient/Services/OrganizationService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/OrganizationService.cs
@@ -7,6 +7,13 @@ namespace NexaCRM.WebClient.Services;
 
 public class OrganizationService : IOrganizationService
 {
+    private readonly List<OrganizationUser> _users = new()
+    {
+        new OrganizationUser { Id = 1, Name = "Ethan Carter", Email = "ethan.carter@example.com", Role = "Admin", Status = "Active" },
+        new OrganizationUser { Id = 2, Name = "Olivia Bennett", Email = "olivia.bennett@example.com", Role = "Sales", Status = "Active" },
+        new OrganizationUser { Id = 3, Name = "Noah Thompson", Email = "noah.thompson@example.com", Role = "Marketing", Status = "Inactive" }
+    };
+
     public Task<IEnumerable<OrganizationUnit>> GetOrganizationStructureAsync() =>
         Task.FromResult<IEnumerable<OrganizationUnit>>(new List<OrganizationUnit>());
 
@@ -18,5 +25,24 @@ public class OrganizationService : IOrganizationService
 
     public Task SetSystemAdministratorAsync(string userId) =>
         Task.CompletedTask;
+
+    public Task<IEnumerable<OrganizationUser>> GetUsersAsync() =>
+        Task.FromResult<IEnumerable<OrganizationUser>>(_users);
+
+    public Task UpdateUserAsync(OrganizationUser user)
+    {
+        var index = _users.FindIndex(u => u.Id == user.Id);
+        if (index >= 0)
+        {
+            _users[index] = user;
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteUserAsync(int userId)
+    {
+        _users.RemoveAll(u => u.Id == userId);
+        return Task.CompletedTask;
+    }
 }
 


### PR DESCRIPTION
## Summary
- load organization users from IOrganizationService and show them in SettingsPage
- add edit and delete dialogs with service calls
- support user search and basic modal styles
- enhance mobile layout with responsive user table

## Testing
- `dotnet build --configuration Release`
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release`


------
https://chatgpt.com/codex/tasks/task_b_68c81babc86c832c886cc45fa19e3631