### PR TITLE
feat(web): add sms provider settings

### DIFF
--- a/src/Web/NexaCRM.WebClient/Models/SettingsModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/SettingsModels.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace NexaCRM.WebClient.Models.Settings;
 
@@ -13,11 +14,27 @@ public record SecuritySettings(
     bool LoginBlockEnabled = false
 );
 
-public record SmsSettings(
-    IList<string> SenderNumbers,
-    IList<string> Templates
-)
+public class SmsSettings
 {
-    public SmsSettings() : this(new List<string>(), new List<string>()) { }
+    public IList<string> SenderNumbers { get; set; }
+    public IList<string> Templates { get; set; }
+
+    [Required]
+    public string ProviderApiKey { get; set; } = string.Empty;
+
+    [Required]
+    public string ProviderApiSecret { get; set; } = string.Empty;
+
+    public string DefaultTemplate { get; set; } = string.Empty;
+
+    [Required]
+    [RegularExpression("^[a-zA-Z0-9]{3,11}$", ErrorMessage = "Sender ID must be alphanumeric and 3-11 characters.")]
+    public string SenderId { get; set; } = string.Empty;
+
+    public SmsSettings()
+    {
+        SenderNumbers = new List<string>();
+        Templates = new List<string>();
+    }
 }
 

--- a/src/Web/NexaCRM.WebClient/Pages/SmsSettingsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SmsSettingsPage.razor
@@ -1,6 +1,54 @@
 @page "/settings/sms"
+@using NexaCRM.WebClient.Models.Settings
+@using NexaCRM.WebClient.Services.Interfaces
+@inject ISmsService SmsService
 
 <ResponsivePage>
     <h3>SMS Settings</h3>
-    <p>Manage sender numbers and message templates.</p>
+    <p>Manage provider credentials, sender IDs and default templates.</p>
+    <EditForm Model="_settings" OnValidSubmit="SaveAsync" class="sms-settings-form">
+        <DataAnnotationsValidator />
+        <ValidationSummary />
+        <div class="form-field">
+            <label for="providerKey">Provider API Key</label>
+            <InputText id="providerKey" @bind-Value="_settings.ProviderApiKey" class="input" />
+            <ValidationMessage For="@(() => _settings.ProviderApiKey)" />
+        </div>
+        <div class="form-field">
+            <label for="providerSecret">Provider API Secret</label>
+            <InputText id="providerSecret" @bind-Value="_settings.ProviderApiSecret" type="password" class="input" />
+            <ValidationMessage For="@(() => _settings.ProviderApiSecret)" />
+        </div>
+        <div class="form-field">
+            <label for="senderId">Sender ID</label>
+            <InputText id="senderId" @bind-Value="_settings.SenderId" class="input" maxlength="11" />
+            <ValidationMessage For="@(() => _settings.SenderId)" />
+        </div>
+        <div class="form-field">
+            <label for="defaultTemplate">Default Template</label>
+            <InputSelect id="defaultTemplate" @bind-Value="_settings.DefaultTemplate" class="input">
+                <option value="">Select template</option>
+                @foreach (var template in _settings.Templates)
+                {
+                    <option value="@template">@template</option>
+                }
+            </InputSelect>
+            <ValidationMessage For="@(() => _settings.DefaultTemplate)" />
+        </div>
+        <button type="submit" class="save-button">Save</button>
+    </EditForm>
 </ResponsivePage>
+
+@code {
+    private SmsSettings _settings = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        _settings = await SmsService.GetSettingsAsync() ?? new SmsSettings();
+    }
+
+    private async Task SaveAsync()
+    {
+        await SmsService.SaveSettingsAsync(_settings);
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/SmsSettingsPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/SmsSettingsPage.razor.css
@@ -1,0 +1,45 @@
+/* SmsSettingsPage responsive styles */
+
+.sms-settings-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-width: 28rem;
+}
+
+.form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.input {
+    padding: 0.5rem;
+    border: 1px solid #cbd5e1;
+    border-radius: 4px;
+}
+
+.save-button {
+    align-self: flex-start;
+    padding: 0.5rem 1rem;
+    background-color: #2a74ea;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.save-button:hover {
+    background-color: #1e5bb8;
+}
+
+@media (max-width: 640px) {
+    .sms-settings-form {
+        padding: 0 1rem;
+        width: 100%;
+    }
+
+    .save-button {
+        width: 100%;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/ISmsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/ISmsService.cs
@@ -1,4 +1,5 @@
 using NexaCRM.WebClient.Models.Sms;
+using NexaCRM.WebClient.Models.Settings;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -11,5 +12,7 @@ public interface ISmsService
     Task SaveSenderNumberAsync(string number);
     Task<IEnumerable<SmsHistoryItem>> GetHistoryAsync();
     Task ScheduleSmsAsync(SmsScheduleItem schedule);
+    Task<SmsSettings> GetSettingsAsync();
+    Task SaveSettingsAsync(SmsSettings settings);
 }
 

--- a/src/Web/NexaCRM.WebClient/Services/SmsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SmsService.cs
@@ -1,4 +1,5 @@
 using NexaCRM.WebClient.Models.Sms;
+using NexaCRM.WebClient.Models.Settings;
 using NexaCRM.WebClient.Services.Interfaces;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -20,6 +21,12 @@ public class SmsService : ISmsService
         Task.FromResult<IEnumerable<SmsHistoryItem>>(new List<SmsHistoryItem>());
 
     public Task ScheduleSmsAsync(SmsScheduleItem schedule) =>
+        Task.CompletedTask;
+
+    public Task<SmsSettings> GetSettingsAsync() =>
+        Task.FromResult(new SmsSettings());
+
+    public Task SaveSettingsAsync(SmsSettings settings) =>
         Task.CompletedTask;
 }
 


### PR DESCRIPTION
## Summary
- extend SMS settings model with provider credentials, default template, and sender ID validation
- expose settings load/save methods via `ISmsService`
- build SMS settings page to edit provider credentials, sender ID, and default template
- refine SMS settings form with validation messages and mobile responsive styling

## Testing
- `dotnet build --configuration Release`
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release`


------
https://chatgpt.com/codex/tasks/task_b_68c81badeed8832cb4160d975599bedf