### PR TITLE
feat: add notification settings service and bindings

### DIFF
--- a/SERVICE_INTERFACES_REFERENCE.md
+++ b/SERVICE_INTERFACES_REFERENCE.md
@@ -440,6 +440,9 @@ private async Task LaunchCampaign()
 ```csharp
 public interface IReportService
 {
+    Task SaveReportDefinitionAsync(ReportDefinition definition);
+    Task<IEnumerable<ReportDefinition>> GetReportDefinitionsAsync();
+    Task<ReportData> GenerateReportAsync(ReportDefinition definition);
     Task<ReportData> GetQuarterlyPerformanceAsync();
     Task<ReportData> GetLeadSourceAnalyticsAsync();
     Task<ReportData> GetTicketVolumeAsync();
@@ -461,6 +464,21 @@ public interface IReportService
 - **Return Type**: `Task<ReportData>`
 - **Parameters**: None
 - **Includes**: Lead sources, conversion rates, and ROI by channel
+
+**SaveReportDefinitionAsync(ReportDefinition)**
+- **Purpose**: Persists a custom report definition
+- **Return Type**: `Task`
+- **Parameters**: `ReportDefinition` definition
+
+**GetReportDefinitionsAsync()**
+- **Purpose**: Retrieves saved report definitions
+- **Return Type**: `Task<IEnumerable<ReportDefinition>>`
+- **Parameters**: None
+
+**GenerateReportAsync(ReportDefinition)**
+- **Purpose**: Generates report data based on a definition
+- **Return Type**: `Task<ReportData>`
+- **Parameters**: `ReportDefinition` definition
 
 **GetTicketVolumeAsync()**
 - **Purpose**: Reports on support ticket volume and trends

--- a/WEB_CLIENT_DOCUMENTATION.md
+++ b/WEB_CLIENT_DOCUMENTATION.md
@@ -219,7 +219,7 @@ builder.Services.AddScoped<IActivityService, MockActivityService>();
 - **ContactsPage.razor**: Contact management interface with search and filtering
 - **SalesPipelinePage.razor**: Visual deal pipeline with drag-and-drop functionality
 - **TasksPage.razor**: Task management interface with assignment and tracking
-- **ReportsPage.razor**: Comprehensive reporting dashboard with multiple report types
+- **ReportsPage.razor**: Custom report builder with field selection, filters, saved definitions, preview, and mobile-friendly layout
 
 **Support and Service Pages:**
 - **CustomerSupportDashboard.razor**: Support team dashboard with ticket overview

--- a/src/Web/NexaCRM.WebClient/Models/NotificationSettings.cs
+++ b/src/Web/NexaCRM.WebClient/Models/NotificationSettings.cs
@@ -1,0 +1,14 @@
+namespace NexaCRM.WebClient.Models.Settings;
+
+public class NotificationSettings
+{
+    public bool NewLeadCreated { get; set; }
+    public bool LeadStatusUpdated { get; set; }
+    public bool DealStageChanged { get; set; }
+    public bool DealValueUpdated { get; set; }
+    public bool NewTaskAssigned { get; set; }
+    public bool TaskDueDateReminder { get; set; }
+    public bool EmailNotifications { get; set; }
+    public bool InAppNotifications { get; set; }
+    public bool PushNotifications { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/OrganizationModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/OrganizationModels.cs
@@ -1,6 +1,16 @@
 namespace NexaCRM.WebClient.Models.Organization;
 
-public record OrganizationUnit(int Id, string Name, int? ParentId);
+using System.ComponentModel.DataAnnotations;
+
+public class OrganizationUnit
+{
+    public int Id { get; set; }
+
+    [Required]
+    public string Name { get; set; } = string.Empty;
+
+    public int? ParentId { get; set; }
+}
 
 public record OrganizationStats(string UnitName, int MemberCount);
 

--- a/src/Web/NexaCRM.WebClient/Models/ReportDefinition.cs
+++ b/src/Web/NexaCRM.WebClient/Models/ReportDefinition.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace NexaCRM.WebClient.Models
+{
+    public class ReportDefinition
+    {
+        public string? Name { get; set; }
+        public List<string> SelectedFields { get; set; } = new();
+        public Dictionary<string, string> Filters { get; set; } = new();
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Models/SmsModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/SmsModels.cs
@@ -8,7 +8,7 @@ public record BulkSmsRequest(IList<string> Recipients, string Message)
     public BulkSmsRequest() : this(new List<string>(), string.Empty) { }
 }
 
-public record SmsHistoryItem(string Recipient, string Message, DateTime SentAt);
+public record SmsHistoryItem(string Recipient, string Message, DateTime SentAt, string Status);
 
 public record SmsScheduleItem(DateTime ScheduledAt, BulkSmsRequest Request)
 {

--- a/src/Web/NexaCRM.WebClient/Models/SystemInfoModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/SystemInfoModels.cs
@@ -2,7 +2,7 @@ namespace NexaCRM.WebClient.Models.SystemInfo;
 
 public record SystemInfo(
     string Terms = "",
-    string CompanyContact = "",
-    string BusinessAddress = ""
+    string CompanyAddress = "",
+    string[] SupportContacts = null!
 );
 

--- a/src/Web/NexaCRM.WebClient/NexaCRM.WebClient.csproj
+++ b/src/Web/NexaCRM.WebClient/NexaCRM.WebClient.csproj
@@ -10,12 +10,13 @@
 	<!-- net8.0 타겟에만 Blazor WebAssembly 8.0 패키지 참조 -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<!-- Blazor WebAssembly 핵심 런타임 참조 -->
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
-		<!-- 개발 서버 도구 (PrivateAssets로 빌드 출력 미포함) -->
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0" PrivateAssets="all" />
-		<!-- Microsoft.AspNetCore.* 네임스페이스 정의 어셈블리 -->
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.0" />
-	</ItemGroup>
+                <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
+                <!-- 개발 서버 도구 (PrivateAssets로 빌드 출력 미포함) -->
+                <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0" PrivateAssets="all" />
+                <!-- Microsoft.AspNetCore.* 네임스페이스 정의 어셈블리 -->
+                <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
+                <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.0" />
+                <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.0" />
+                <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+        </ItemGroup>
 </Project>

--- a/src/Web/NexaCRM.WebClient/Pages/NoticeManagementPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/NoticeManagementPage.razor
@@ -1,6 +1,217 @@
 @page "/support/notices"
+@using Microsoft.AspNetCore.Components.Forms
+@using NexaCRM.WebClient.Models.CustomerCenter
+@using NexaCRM.WebClient.Services.Interfaces
+@inject INoticeService NoticeService
+@inject IJSRuntime JSRuntime
 
 <ResponsivePage>
     <h3>Notice Management</h3>
-    <p>Create and manage announcements.</p>
+
+    <div class="search-bar mb-3">
+        <input class="form-control flex-grow-1" placeholder="Search notices" value="@searchTerm" @oninput="OnSearchChanged" />
+        <button class="btn btn-success" @onclick="ShowCreateModal">
+            <span class="oi oi-plus"></span> New Notice
+        </button>
+    </div>
+
+    @if (PagedNotices.Any())
+    {
+        <div class="table-responsive d-none d-md-block">
+            <table class="table align-middle">
+                <thead>
+                    <tr>
+                        <th>Title</th>
+                        <th>Content</th>
+                        <th class="text-end"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var notice in PagedNotices)
+                    {
+                        <tr>
+                            <td>@notice.Title</td>
+                            <td>@notice.Content</td>
+                            <td class="text-end">
+                                <div class="btn-group btn-group-sm">
+                                    <button class="btn btn-primary" @onclick="() => ShowEditModal(notice)">
+                                        <span class="oi oi-pencil"></span>
+                                    </button>
+                                    <button class="btn btn-danger" @onclick="() => DeleteNotice(notice.Id)">
+                                        <span class="oi oi-trash"></span>
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+
+        <div class="d-md-none">
+            @foreach (var notice in PagedNotices)
+            {
+                <div class="card mb-2">
+                    <div class="card-body">
+                        <h5 class="card-title">@notice.Title</h5>
+                        <p class="card-text">@notice.Content</p>
+                        <div class="d-flex justify-content-end">
+                            <button class="btn btn-sm btn-primary me-1" @onclick="() => ShowEditModal(notice)">
+                                <span class="oi oi-pencil"></span>
+                            </button>
+                            <button class="btn btn-sm btn-danger" @onclick="() => DeleteNotice(notice.Id)">
+                                <span class="oi oi-trash"></span>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+
+        @if (TotalPages > 1)
+        {
+            <nav>
+                <ul class="pagination">
+                    <li class="page-item @(currentPage == 1 ? "disabled" : string.Empty)">
+                        <button class="page-link" @onclick="PreviousPage">Prev</button>
+                    </li>
+                    @for (int i = 1; i <= TotalPages; i++)
+                    {
+                        <li class="page-item @(currentPage == i ? "active" : string.Empty)">
+                            <button class="page-link" @onclick="() => GoToPage(i)">@i</button>
+                        </li>
+                    }
+                    <li class="page-item @(currentPage == TotalPages ? "disabled" : string.Empty)">
+                        <button class="page-link" @onclick="NextPage">Next</button>
+                    </li>
+                </ul>
+            </nav>
+        }
+    }
+    else
+    {
+        <p>No notices found.</p>
+    }
 </ResponsivePage>
+
+@if (showModal)
+{
+    <div class="modal-backdrop" @onclick="CloseModal">
+        <div class="modal-content" @onclick:stopPropagation="true">
+            <EditForm OnValidSubmit="SaveNotice">
+                <div class="mb-3">
+                    <label class="form-label">Title</label>
+                    <InputText class="form-control" @bind-Value="editTitle" />
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Content</label>
+                    <InputTextArea class="form-control" @bind-Value="editContent" />
+                </div>
+                <div class="text-end">
+                    <button type="submit" class="btn btn-primary me-2">Save</button>
+                    <button type="button" class="btn btn-secondary" @onclick="CloseModal">Cancel</button>
+                </div>
+            </EditForm>
+        </div>
+    </div>
+}
+
+@code {
+    private List<Notice> notices = new();
+    private string searchTerm = string.Empty;
+    private int currentPage = 1;
+    private const int PageSize = 5;
+    private bool showModal;
+    private int? editingId;
+    private string editTitle = string.Empty;
+    private string editContent = string.Empty;
+
+    private IEnumerable<Notice> FilteredNotices =>
+        string.IsNullOrWhiteSpace(searchTerm)
+            ? notices
+            : notices.Where(n => n.Title.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ||
+                                 n.Content.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
+
+    private int TotalPages => (int)Math.Ceiling(FilteredNotices.Count() / (double)PageSize);
+
+    private IEnumerable<Notice> PagedNotices =>
+        FilteredNotices.Skip((currentPage - 1) * PageSize).Take(PageSize);
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadNotices();
+    }
+
+    private async Task LoadNotices()
+    {
+        notices = (await NoticeService.GetNoticesAsync()).ToList();
+        currentPage = 1;
+    }
+
+    private void OnSearchChanged(ChangeEventArgs e)
+    {
+        searchTerm = e.Value?.ToString() ?? string.Empty;
+        currentPage = 1;
+    }
+
+    private void GoToPage(int page) => currentPage = page;
+
+    private void PreviousPage()
+    {
+        if (currentPage > 1)
+        {
+            currentPage--;
+        }
+    }
+
+    private void NextPage()
+    {
+        if (currentPage < TotalPages)
+        {
+            currentPage++;
+        }
+    }
+
+    private void ShowCreateModal()
+    {
+        editingId = null;
+        editTitle = string.Empty;
+        editContent = string.Empty;
+        showModal = true;
+    }
+
+    private void ShowEditModal(Notice notice)
+    {
+        editingId = notice.Id;
+        editTitle = notice.Title;
+        editContent = notice.Content;
+        showModal = true;
+    }
+
+    private void CloseModal() => showModal = false;
+
+    private async Task SaveNotice()
+    {
+        if (editingId.HasValue)
+        {
+            await NoticeService.UpdateNoticeAsync(new Notice(editingId.Value, editTitle, editContent));
+        }
+        else
+        {
+            await NoticeService.CreateNoticeAsync(new Notice(0, editTitle, editContent));
+        }
+
+        showModal = false;
+        await LoadNotices();
+    }
+
+    private async Task DeleteNotice(int id)
+    {
+        if (await JSRuntime.InvokeAsync<bool>("confirm", "Delete this notice?"))
+        {
+            await NoticeService.DeleteNoticeAsync(id);
+            await LoadNotices();
+        }
+    }
+}
+

--- a/src/Web/NexaCRM.WebClient/Pages/NoticeManagementPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/NoticeManagementPage.razor.css
@@ -1,0 +1,47 @@
+/* Search bar */
+.search-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+/* Modal Styles */
+.modal-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background: white;
+    border-radius: 8px;
+    padding: 20px;
+    max-width: 600px;
+    width: 90%;
+    max-height: 80vh;
+    overflow-y: auto;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+@media (max-width: 576px) {
+    .search-bar {
+        flex-direction: column;
+    }
+
+    .search-bar button {
+        width: 100%;
+    }
+
+    .modal-content {
+        width: 95%;
+        padding: 15px;
+    }
+}
+

--- a/src/Web/NexaCRM.WebClient/Pages/NotificationSettingsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/NotificationSettingsPage.razor
@@ -1,13 +1,16 @@
 @page "/notification-settings-page"
 @using Microsoft.Extensions.Localization
+@using NexaCRM.WebClient.Services.Interfaces
+@using NexaCRM.WebClient.Models.Settings
 @inject IStringLocalizer<NotificationSettingsPage> Localizer
+@inject INotificationService NotificationService
 
 <div
       class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden"
       style="--select-button-svg: url('data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724px%27 height=%2724px%27 fill=%27rgb(77,106,153)%27 viewBox=%270 0 256 256%27%3e%3cpath d=%27M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48A8,8,0,0,0,85.66,85.66Z%27%3e%3c/path%3e%3c/svg%3e'); font-family: Inter, &quot;Noto Sans&quot;, sans-serif;"
     >
       <div class="layout-container flex h-full grow flex-col">
-        <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-10 py-3">
+        <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-4 md:px-10 py-3">
           <div class="flex items-center gap-4 text-[#0e131b]">
             <div class="size-4">
               <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -27,8 +30,13 @@
             </div>
             <h2 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em]">@Localizer["SalesPro"]</h2>
           </div>
-          <div class="flex flex-1 justify-end gap-8">
-            <div class="flex items-center gap-9">
+          <div class="flex flex-1 items-center justify-end gap-4 md:gap-8">
+            <button class="md:hidden p-2" @onclick="ToggleMobileMenu" aria-label="Toggle navigation">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 256 256">
+                <path d="M40 60h176a8 8 0 0 1 0 16H40a8 8 0 0 1 0-16Zm0 60h176a8 8 0 0 1 0 16H40a8 8 0 0 1 0-16Zm176 76H40a8 8 0 0 1 0-16h176a8 8 0 0 1 0 16Z"></path>
+              </svg>
+            </button>
+            <div class="hidden md:flex items-center gap-9">
               <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Dashboard"]</a>
               <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Sales"]</a>
               <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Marketing"]</a>
@@ -66,16 +74,27 @@
             ></div>
           </div>
         </header>
-        <div class="px-40 flex flex-1 justify-center py-5">
-          <div class="layout-content-container flex flex-col max-w-[960px] flex-1">
-            <div class="flex flex-wrap justify-between gap-3 p-4">
+        @if (mobileMenuOpen)
+        {
+          <nav class="md:hidden flex flex-col gap-2 border-b border-solid border-b-[#e7ecf3] px-4 py-3">
+            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Dashboard"]</a>
+            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Sales"]</a>
+            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Marketing"]</a>
+            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Service"]</a>
+            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Reports"]</a>
+            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Analytics"]</a>
+          </nav>
+        }
+        <div class="px-4 md:px-40 flex flex-1 justify-center py-5">
+          <div class="layout-content-container flex flex-col max-w-[960px] w-full flex-1">
+            <div class="flex flex-wrap justify-between gap-3 p-2 sm:p-4">
               <div class="flex min-w-72 flex-col gap-3">
-                <p class="text-[#0e131b] tracking-light text-[32px] font-bold leading-tight">@Localizer["NotificationSettings"]</p>
+                <p class="text-[#0e131b] tracking-light text-2xl md:text-[32px] font-bold leading-tight">@Localizer["NotificationSettings"]</p>
                 <p class="text-[#4d6a99] text-sm font-normal leading-normal">@Localizer["NotificationSettingsDescription"]</p>
               </div>
             </div>
-            <h3 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2 pt-4">@Localizer["NewLeads"]</h3>
-            <div class="flex items-center gap-4 bg-slate-50 px-4 min-h-[72px] py-2 justify-between">
+            <h3 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em] px-2 sm:px-4 pb-2 pt-4">@Localizer["NewLeads"]</h3>
+            <div class="flex items-center gap-4 bg-slate-50 px-2 sm:px-4 min-h-[72px] py-2 justify-between">
               <div class="flex flex-col justify-center">
                 <p class="text-[#0e131b] text-base font-medium leading-normal line-clamp-1">@Localizer["NewLeadCreated"]</p>
                 <p class="text-[#4d6a99] text-sm font-normal leading-normal line-clamp-2">@Localizer["NewLeadCreatedDescription"]</p>
@@ -85,11 +104,11 @@
                   class="relative flex h-[31px] w-[51px] cursor-pointer items-center rounded-full border-none bg-[#e7ecf3] p-0.5 has-[:checked]:justify-end has-[:checked]:bg-[#2a74ea]"
                 >
                   <div class="h-full w-[27px] rounded-full bg-white" style="box-shadow: rgba(0, 0, 0, 0.15) 0px 3px 8px, rgba(0, 0, 0, 0.06) 0px 3px 1px;"></div>
-                  <input type="checkbox" class="invisible absolute" />
+                  <input type="checkbox" class="invisible absolute" @bind="settings.NewLeadCreated" />
                 </label>
               </div>
             </div>
-            <div class="flex items-center gap-4 bg-slate-50 px-4 min-h-[72px] py-2 justify-between">
+            <div class="flex items-center gap-4 bg-slate-50 px-2 sm:px-4 min-h-[72px] py-2 justify-between">
               <div class="flex flex-col justify-center">
                 <p class="text-[#0e131b] text-base font-medium leading-normal line-clamp-1">@Localizer["LeadStatusUpdated"]</p>
                 <p class="text-[#4d6a99] text-sm font-normal leading-normal line-clamp-2">@Localizer["LeadStatusUpdatedDescription"]</p>
@@ -99,12 +118,12 @@
                   class="relative flex h-[31px] w-[51px] cursor-pointer items-center rounded-full border-none bg-[#e7ecf3] p-0.5 has-[:checked]:justify-end has-[:checked]:bg-[#2a74ea]"
                 >
                   <div class="h-full w-[27px] rounded-full bg-white" style="box-shadow: rgba(0, 0, 0, 0.15) 0px 3px 8px, rgba(0, 0, 0, 0.06) 0px 3px 1px;"></div>
-                  <input type="checkbox" class="invisible absolute" />
+                  <input type="checkbox" class="invisible absolute" @bind="settings.LeadStatusUpdated" />
                 </label>
               </div>
             </div>
-            <h3 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2 pt-4">@Localizer["DealUpdates"]</h3>
-            <div class="flex items-center gap-4 bg-slate-50 px-4 min-h-[72px] py-2 justify-between">
+            <h3 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em] px-2 sm:px-4 pb-2 pt-4">@Localizer["DealUpdates"]</h3>
+            <div class="flex items-center gap-4 bg-slate-50 px-2 sm:px-4 min-h-[72px] py-2 justify-between">
               <div class="flex flex-col justify-center">
                 <p class="text-[#0e131b] text-base font-medium leading-normal line-clamp-1">@Localizer["DealStageChanged"]</p>
                 <p class="text-[#4d6a99] text-sm font-normal leading-normal line-clamp-2">@Localizer["DealStageChangedDescription"]</p>
@@ -114,11 +133,11 @@
                   class="relative flex h-[31px] w-[51px] cursor-pointer items-center rounded-full border-none bg-[#e7ecf3] p-0.5 has-[:checked]:justify-end has-[:checked]:bg-[#2a74ea]"
                 >
                   <div class="h-full w-[27px] rounded-full bg-white" style="box-shadow: rgba(0, 0, 0, 0.15) 0px 3px 8px, rgba(0, 0, 0, 0.06) 0px 3px 1px;"></div>
-                  <input type="checkbox" class="invisible absolute" />
+                  <input type="checkbox" class="invisible absolute" @bind="settings.DealStageChanged" />
                 </label>
               </div>
             </div>
-            <div class="flex items-center gap-4 bg-slate-50 px-4 min-h-[72px] py-2 justify-between">
+            <div class="flex items-center gap-4 bg-slate-50 px-2 sm:px-4 min-h-[72px] py-2 justify-between">
               <div class="flex flex-col justify-center">
                 <p class="text-[#0e131b] text-base font-medium leading-normal line-clamp-1">@Localizer["DealValueUpdated"]</p>
                 <p class="text-[#4d6a99] text-sm font-normal leading-normal line-clamp-2">@Localizer["DealValueUpdatedDescription"]</p>
@@ -128,12 +147,12 @@
                   class="relative flex h-[31px] w-[51px] cursor-pointer items-center rounded-full border-none bg-[#e7ecf3] p-0.5 has-[:checked]:justify-end has-[:checked]:bg-[#2a74ea]"
                 >
                   <div class="h-full w-[27px] rounded-full bg-white" style="box-shadow: rgba(0, 0, 0, 0.15) 0px 3px 8px, rgba(0, 0, 0, 0.06) 0px 3px 1px;"></div>
-                  <input type="checkbox" class="invisible absolute" />
+                  <input type="checkbox" class="invisible absolute" @bind="settings.DealValueUpdated" />
                 </label>
               </div>
             </div>
-            <h3 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2 pt-4">@Localizer["TaskAssignments"]</h3>
-            <div class="flex items-center gap-4 bg-slate-50 px-4 min-h-[72px] py-2 justify-between">
+            <h3 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em] px-2 sm:px-4 pb-2 pt-4">@Localizer["TaskAssignments"]</h3>
+            <div class="flex items-center gap-4 bg-slate-50 px-2 sm:px-4 min-h-[72px] py-2 justify-between">
               <div class="flex flex-col justify-center">
                 <p class="text-[#0e131b] text-base font-medium leading-normal line-clamp-1">@Localizer["NewTaskAssigned"]</p>
                 <p class="text-[#4d6a99] text-sm font-normal leading-normal line-clamp-2">@Localizer["NewTaskAssignedDescription"]</p>
@@ -143,11 +162,11 @@
                   class="relative flex h-[31px] w-[51px] cursor-pointer items-center rounded-full border-none bg-[#e7ecf3] p-0.5 has-[:checked]:justify-end has-[:checked]:bg-[#2a74ea]"
                 >
                   <div class="h-full w-[27px] rounded-full bg-white" style="box-shadow: rgba(0, 0, 0, 0.15) 0px 3px 8px, rgba(0, 0, 0, 0.06) 0px 3px 1px;"></div>
-                  <input type="checkbox" class="invisible absolute" />
+                  <input type="checkbox" class="invisible absolute" @bind="settings.NewTaskAssigned" />
                 </label>
               </div>
             </div>
-            <div class="flex items-center gap-4 bg-slate-50 px-4 min-h-[72px] py-2 justify-between">
+            <div class="flex items-center gap-4 bg-slate-50 px-2 sm:px-4 min-h-[72px] py-2 justify-between">
               <div class="flex flex-col justify-center">
                 <p class="text-[#0e131b] text-base font-medium leading-normal line-clamp-1">@Localizer["TaskDueDateReminder"]</p>
                 <p class="text-[#4d6a99] text-sm font-normal leading-normal line-clamp-2">@Localizer["TaskDueDateReminderDescription"]</p>
@@ -157,12 +176,12 @@
                   class="relative flex h-[31px] w-[51px] cursor-pointer items-center rounded-full border-none bg-[#e7ecf3] p-0.5 has-[:checked]:justify-end has-[:checked]:bg-[#2a74ea]"
                 >
                   <div class="h-full w-[27px] rounded-full bg-white" style="box-shadow: rgba(0, 0, 0, 0.15) 0px 3px 8px, rgba(0, 0, 0, 0.06) 0px 3px 1px;"></div>
-                  <input type="checkbox" class="invisible absolute" />
+                  <input type="checkbox" class="invisible absolute" @bind="settings.TaskDueDateReminder" />
                 </label>
               </div>
             </div>
-            <h3 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2 pt-4">@Localizer["NotificationChannels"]</h3>
-            <div class="flex items-center gap-4 bg-slate-50 px-4 min-h-[72px] py-2 justify-between">
+            <h3 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em] px-2 sm:px-4 pb-2 pt-4">@Localizer["NotificationChannels"]</h3>
+            <div class="flex items-center gap-4 bg-slate-50 px-2 sm:px-4 min-h-[72px] py-2 justify-between">
               <div class="flex flex-col justify-center">
                 <p class="text-[#0e131b] text-base font-medium leading-normal line-clamp-1">@Localizer["EmailNotifications"]</p>
                 <p class="text-[#4d6a99] text-sm font-normal leading-normal line-clamp-2">@Localizer["EmailNotificationsDescription"]</p>
@@ -172,11 +191,11 @@
                   class="relative flex h-[31px] w-[51px] cursor-pointer items-center rounded-full border-none bg-[#e7ecf3] p-0.5 has-[:checked]:justify-end has-[:checked]:bg-[#2a74ea]"
                 >
                   <div class="h-full w-[27px] rounded-full bg-white" style="box-shadow: rgba(0, 0, 0, 0.15) 0px 3px 8px, rgba(0, 0, 0, 0.06) 0px 3px 1px;"></div>
-                  <input type="checkbox" class="invisible absolute" />
+                  <input type="checkbox" class="invisible absolute" @bind="settings.EmailNotifications" />
                 </label>
               </div>
             </div>
-            <div class="flex items-center gap-4 bg-slate-50 px-4 min-h-[72px] py-2 justify-between">
+            <div class="flex items-center gap-4 bg-slate-50 px-2 sm:px-4 min-h-[72px] py-2 justify-between">
               <div class="flex flex-col justify-center">
                 <p class="text-[#0e131b] text-base font-medium leading-normal line-clamp-1">@Localizer["InAppNotifications"]</p>
                 <p class="text-[#4d6a99] text-sm font-normal leading-normal line-clamp-2">@Localizer["InAppNotificationsDescription"]</p>
@@ -186,11 +205,11 @@
                   class="relative flex h-[31px] w-[51px] cursor-pointer items-center rounded-full border-none bg-[#e7ecf3] p-0.5 has-[:checked]:justify-end has-[:checked]:bg-[#2a74ea]"
                 >
                   <div class="h-full w-[27px] rounded-full bg-white" style="box-shadow: rgba(0, 0, 0, 0.15) 0px 3px 8px, rgba(0, 0, 0, 0.06) 0px 3px 1px;"></div>
-                  <input type="checkbox" class="invisible absolute" />
+                  <input type="checkbox" class="invisible absolute" @bind="settings.InAppNotifications" />
                 </label>
               </div>
             </div>
-            <div class="flex items-center gap-4 bg-slate-50 px-4 min-h-[72px] py-2 justify-between">
+            <div class="flex items-center gap-4 bg-slate-50 px-2 sm:px-4 min-h-[72px] py-2 justify-between">
               <div class="flex flex-col justify-center">
                 <p class="text-[#0e131b] text-base font-medium leading-normal line-clamp-1">@Localizer["PushNotifications"]</p>
                 <p class="text-[#4d6a99] text-sm font-normal leading-normal line-clamp-2">@Localizer["PushNotificationsDescription"]</p>
@@ -200,13 +219,13 @@
                   class="relative flex h-[31px] w-[51px] cursor-pointer items-center rounded-full border-none bg-[#e7ecf3] p-0.5 has-[:checked]:justify-end has-[:checked]:bg-[#2a74ea]"
                 >
                   <div class="h-full w-[27px] rounded-full bg-white" style="box-shadow: rgba(0, 0, 0, 0.15) 0px 3px 8px, rgba(0, 0, 0, 0.06) 0px 3px 1px;"></div>
-                  <input type="checkbox" class="invisible absolute" />
+                  <input type="checkbox" class="invisible absolute" @bind="settings.PushNotifications" />
                 </label>
               </div>
             </div>
-            <h3 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2 pt-4">@Localizer["NotificationFrequency"]</h3>
-            <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-              <label class="flex flex-col min-w-40 flex-1">
+            <h3 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em] px-2 sm:px-4 pb-2 pt-4">@Localizer["NotificationFrequency"]</h3>
+            <div class="flex max-w-full md:max-w-[480px] flex-wrap items-end gap-4 px-2 sm:px-4 py-3">
+              <label class="flex flex-col min-w-0 flex-1">
                 <p class="text-[#0e131b] text-base font-medium leading-normal pb-2">@Localizer["Frequency"]</p>
                 <select
                   class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
@@ -217,9 +236,9 @@
                 </select>
               </label>
             </div>
-            <h3 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2 pt-4">@Localizer["SnoozeOptions"]</h3>
-            <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-              <label class="flex flex-col min-w-40 flex-1">
+            <h3 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em] px-2 sm:px-4 pb-2 pt-4">@Localizer["SnoozeOptions"]</h3>
+            <div class="flex max-w-full md:max-w-[480px] flex-wrap items-end gap-4 px-2 sm:px-4 py-3">
+              <label class="flex flex-col min-w-0 flex-1">
                 <p class="text-[#0e131b] text-base font-medium leading-normal pb-2">@Localizer["SnoozeDuration"]</p>
                 <select
                   class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
@@ -230,14 +249,41 @@
                 </select>
               </label>
             </div>
-            <div class="flex px-4 py-3 justify-end">
+            <div class="flex px-2 sm:px-4 py-3 justify-end">
               <button
                 class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#2a74ea] text-slate-50 text-sm font-bold leading-normal tracking-[0.015em]"
+                @onclick="SaveSettings"
               >
                 <span class="truncate">@Localizer["SaveSettings"]</span>
               </button>
             </div>
-          </div>
-        </div>
+            @if (!string.IsNullOrEmpty(statusMessage))
+            {
+              <div class="px-2 sm:px-4 py-2 text-green-600 text-sm">@statusMessage</div>
+            }
       </div>
     </div>
+  </div>
+</div>
+
+@code {
+    private NotificationSettings settings = new();
+    private string? statusMessage;
+    private bool mobileMenuOpen;
+
+    protected override async Task OnInitializedAsync()
+    {
+        settings = await NotificationService.GetSettingsAsync();
+    }
+
+    private async Task SaveSettings()
+    {
+        await NotificationService.SaveSettingsAsync(settings);
+        statusMessage = Localizer["SettingsSaved"];
+    }
+
+    private void ToggleMobileMenu()
+    {
+        mobileMenuOpen = !mobileMenuOpen;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/OrganizationStatsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/OrganizationStatsPage.razor
@@ -1,6 +1,104 @@
 @page "/organization/stats"
+@using System.Linq
+@using System.Collections.Generic
+@using NexaCRM.WebClient.Models.Statistics
+@using NexaCRM.WebClient.Services.Interfaces
+@inject IStatisticsService StatisticsService
+@inject IJSRuntime JSRuntime
 
 <ResponsivePage>
     <h3>Organization Statistics</h3>
-    <p>View statistics by company, team and member.</p>
+
+    <div class="flex flex-col sm:flex-row sm:flex-wrap gap-2 mb-4">
+        <select class="form-input w-full sm:min-w-40" @bind="selectedCompany" @bind:after="OnFilterChanged">
+            <option value="">All Companies</option>
+            @foreach (var c in companies)
+            {
+                <option value="@c">@c</option>
+            }
+        </select>
+        <select class="form-input w-full sm:min-w-40" @bind="selectedTeam" @bind:after="OnFilterChanged">
+            <option value="">All Teams</option>
+            @foreach (var t in teams)
+            {
+                <option value="@t">@t</option>
+            }
+        </select>
+        <select class="form-input w-full sm:min-w-40" @bind="selectedMember" @bind:after="OnFilterChanged">
+            <option value="">All Members</option>
+            @foreach (var m in members)
+            {
+                <option value="@m">@m</option>
+            }
+        </select>
+        <button class="flex items-center justify-center w-full sm:w-auto rounded-lg bg-[#2a74ea] text-slate-50 px-4" @onclick="Export">Export</button>
+        <button class="flex items-center justify-center w-full sm:w-auto rounded-lg bg-[#e7ecf3] px-4" @onclick="Print">Print</button>
+    </div>
+
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        <div class="stat-card flex flex-col gap-2 rounded-lg p-4 bg-[#e7ecf3] text-center">
+            <p>Total Members</p>
+            <p class="text-xl font-bold">@summary.TotalMembers</p>
+        </div>
+        <div class="stat-card flex flex-col gap-2 rounded-lg p-4 bg-[#e7ecf3] text-center">
+            <p>Total Logins</p>
+            <p class="text-xl font-bold">@summary.TotalLogins</p>
+        </div>
+        <div class="stat-card flex flex-col gap-2 rounded-lg p-4 bg-[#e7ecf3] text-center">
+            <p>Total Downloads</p>
+            <p class="text-xl font-bold">@summary.TotalDownloads</p>
+        </div>
+    </div>
+
+    <div class="chart-container w-full flex flex-col gap-2 rounded-lg border border-[#d0d9e7] p-4 overflow-x-auto">
+        <p>Summary Chart</p>
+        <div class="grid min-w-[240px] min-h-[150px] grid-flow-col gap-3 grid-rows-[1fr_auto] items-end justify-items-center px-1">
+            <div class="border-[#4d6a99] bg-[#e7ecf3] border-t-2 w-full" style="height:@BarHeight(summary.TotalMembers)"></div>
+            <p class="text-xs font-bold text-[#4d6a99]">Members</p>
+            <div class="border-[#4d6a99] bg-[#e7ecf3] border-t-2 w-full" style="height:@BarHeight(summary.TotalLogins)"></div>
+            <p class="text-xs font-bold text-[#4d6a99]">Logins</p>
+            <div class="border-[#4d6a99] bg-[#e7ecf3] border-t-2 w-full" style="height:@BarHeight(summary.TotalDownloads)"></div>
+            <p class="text-xs font-bold text-[#4d6a99]">Downloads</p>
+        </div>
+    </div>
 </ResponsivePage>
+
+@code {
+    private StatisticsSummary summary = new(0, 0, 0);
+    private string? selectedCompany;
+    private string? selectedTeam;
+    private string? selectedMember;
+
+    private readonly List<string> companies = new() { "Alpha", "Beta" };
+    private readonly List<string> teams = new() { "Team 1", "Team 2" };
+    private readonly List<string> members = new() { "Alice", "Bob" };
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadData();
+    }
+
+    private async Task OnFilterChanged() => await LoadData();
+
+    private async Task LoadData()
+    {
+        summary = await StatisticsService.GetStatisticsAsync(selectedCompany, selectedTeam, selectedMember);
+    }
+
+    private string BarHeight(int value)
+    {
+        var max = new[] { summary.TotalMembers, summary.TotalLogins, summary.TotalDownloads }.Max();
+        if (max == 0) return "0%";
+        var pct = (int)((double)value / max * 100);
+        return pct + "%";
+    }
+
+    private async Task Export()
+    {
+        var csv = $"Metric,Value\nTotal Members,{summary.TotalMembers}\nTotal Logins,{summary.TotalLogins}\nTotal Downloads,{summary.TotalDownloads}";
+        await JSRuntime.InvokeVoidAsync("downloadFile", "organization-stats.csv", csv);
+    }
+
+    private async Task Print() => await JSRuntime.InvokeVoidAsync("print");
+}
+

--- a/src/Web/NexaCRM.WebClient/Pages/OrganizationStructurePage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/OrganizationStructurePage.razor
@@ -1,6 +1,62 @@
 @page "/organization/structure"
+@using NexaCRM.WebClient.Models.Organization
+@using NexaCRM.WebClient.Services.Interfaces
+@using Microsoft.AspNetCore.Components.Forms
+@using System.Linq
+@inject IOrganizationService OrganizationService
 
 <ResponsivePage>
     <h3>Organization Structure</h3>
     <p>Manage production companies, teams and members.</p>
+
+    <EditForm Model="unit" OnValidSubmit="SaveUnit" class="row g-3">
+        <DataAnnotationsValidator />
+        <div class="col-12 col-md-6">
+            <label for="name" class="form-label">Name</label>
+            <InputText id="name" class="form-control" @bind-Value="unit.Name" />
+            <ValidationMessage For="@(() => unit.Name)" />
+        </div>
+        <div class="col-12 col-md-6">
+            <label for="parent" class="form-label">Parent Unit</label>
+            <InputSelect id="parent" class="form-select" @bind-Value="unit.ParentId">
+                <option value="">(None)</option>
+                @foreach (var existing in units)
+                {
+                    <option value="@existing.Id">@existing.Name</option>
+                }
+            </InputSelect>
+        </div>
+        <div class="col-12 text-md-end">
+            <button type="submit" class="btn btn-primary w-100 w-md-auto">Save</button>
+        </div>
+    </EditForm>
+
+    @if (units.Any())
+    {
+        <div class="list-group unit-list mt-4">
+            @foreach (var existing in units)
+            {
+                <div class="list-group-item unit-list-item">@existing.Name</div>
+            }
+        </div>
+    }
 </ResponsivePage>
+
+@code {
+    private List<OrganizationUnit> units = new();
+    private OrganizationUnit unit = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        var existing = await OrganizationService.GetOrganizationStructureAsync();
+        units = existing.ToList();
+    }
+
+    private async Task SaveUnit()
+    {
+        await OrganizationService.SaveOrganizationUnitAsync(unit);
+        unit = new OrganizationUnit();
+        var existing = await OrganizationService.GetOrganizationStructureAsync();
+        units = existing.ToList();
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/OrganizationStructurePage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/OrganizationStructurePage.razor.css
@@ -1,0 +1,16 @@
+/* OrganizationStructurePage Mobile Responsive Styles */
+
+.unit-list {
+    max-width: 600px;
+}
+
+@media (max-width: 576px) {
+    .unit-list-item {
+        padding: 0.75rem 1rem;
+        font-size: 1rem;
+    }
+
+    .unit-list {
+        max-width: 100%;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/ReportsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/ReportsPage.razor
@@ -1,225 +1,116 @@
 @page "/reports-page"
 @using Microsoft.Extensions.Localization
+@using NexaCRM.WebClient.Models
+@using NexaCRM.WebClient.Services.Interfaces
 @inject IStringLocalizer<ReportsPage> Localizer
+@inject IReportService ReportService
 
-<div
-    class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden"
-    style="--select-button-svg: url('data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724px%27 height=%2724px%27 fill=%27rgb(77,106,153)%27 viewBox=%270 0 256 256%27%3e%3cpath d=%27M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48A8,8,0,0,0,85.66,85.66Z%27%3e%3c/path%3e%3c/svg%3e'); font-family: Inter, &quot;Noto Sans&quot;, sans-serif;"
->
-    <div class="layout-container flex h-full grow flex-col">
-    <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-10 py-3">
-        <div class="flex items-center gap-8">
-        <div class="flex items-center gap-4 text-[#0e131b]">
-            <div class="size-4">
-            <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M24 18.4228L42 11.475V34.3663C42 34.7796 41.7457 35.1504 41.3601 35.2992L24 42V18.4228Z"
-                fill="currentColor"
-                ></path>
-                <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M24 8.18819L33.4123 11.574L24 15.2071L14.5877 11.574L24 8.18819ZM9 15.8487L21 20.4805V37.6263L9 32.9945V15.8487ZM27 37.6263V20.4805L39 15.8487V32.9945L27 37.6263ZM25.354 2.29885C24.4788 1.98402 23.5212 1.98402 22.646 2.29885L4.98454 8.65208C3.7939 9.08038 3 10.2097 3 11.475V34.3663C3 36.0196 4.01719 37.5026 5.55962 38.098L22.9197 44.7987C23.6149 45.0671 24.3851 45.0671 25.0803 44.7987L42.4404 38.098C43.9828 37.5026 45 36.0196 45 34.3663V11.475C45 10.2097 44.2061 9.08038 43.0155 8.65208L25.354 2.29885Z"
-                fill="currentColor"
-                ></path>
-            </svg>
-            </div>
-            <h2 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em]">@Localizer["SalesPro"]</h2>
-        </div>
-        <div class="flex items-center gap-9">
-            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Dashboard"]</a>
-            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Contacts"]</a>
-            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Deals"]</a>
-            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Tasks"]</a>
-            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Reports"]</a>
-        </div>
-        </div>
-        <div class="flex flex-1 justify-end gap-8">
-        <label class="flex flex-col min-w-40 !h-10 max-w-64">
-            <div class="flex w-full flex-1 items-stretch rounded-lg h-full">
-            <div
-                class="text-[#4d6a99] flex border-none bg-[#e7ecf3] items-center justify-center pl-4 rounded-l-lg border-r-0"
-                data-icon="MagnifyingGlass"
-                data-size="24px"
-                data-weight="regular"
-            >
-                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
-                <path
-                    d="M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z"
-                ></path>
-                </svg>
-            </div>
-            <input
-                placeholder='@Localizer["Search"]'
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border-none bg-[#e7ecf3] focus:border-none h-full placeholder:text-[#4d6a99] px-4 rounded-l-none border-l-0 pl-2 text-base font-normal leading-normal"
-                value=""
-            />
-            </div>
-        </label>
-        <button
-            class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 bg-[#e7ecf3] text-[#0e131b] gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
-        >
-            <div class="text-[#0e131b]" data-icon="Bell" data-size="20px" data-weight="regular">
-            <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
-                <path
-                d="M221.8,175.94C216.25,166.38,208,139.33,208,104a80,80,0,1,0-160,0c0,35.34-8.26,62.38-13.81,71.94A16,16,0,0,0,48,200H88.81a40,40,0,0,0,78.38,0H208a16,16,0,0,0,13.8-24.06ZM128,216a24,24,0,0,1-22.62-16h45.24A24,24,0,0,1,128,216ZM48,184c7.7-13.24,16-43.92,16-80a64,64,0,1,1,128,0c0,36.05,8.28,66.73,16,80Z"
-                ></path>
-            </svg>
-            </div>
-        </button>
-        <div
-            class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
-            style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuCVbBY-9ye3VEUHqTnyR4PYWraio51rDBrExbaHf3kJpN4thIHaSoMgQfsvV28mHsssFsn4Y5FX2iSomAIBaQsgvXloM_Vn8xKUiKMXOjd5dWyrfSWzrSeqhzR9FaruDo-_E0jlHVB7hguwExVfBKbVe0TzB6LrewfRar1rDFVyw6E6VKhUdh1YhBwxlqkP1V6pQoQKp7uady7ufQ9szbtBYDwrbPE2Lb8-3wKFgDx84Q_XoIN4B4zGX5lwGeBvqzXXogg-cBvbTJMJ");'
-        ></div>
-        </div>
-    </header>
-    <div class="px-40 flex flex-1 justify-center py-5">
-        <div class="layout-content-container flex flex-col max-w-[960px] flex-1">
-        <div class="flex flex-wrap justify-between gap-3 p-4">
-            <p class="text-[#0e131b] tracking-light text-[32px] font-bold leading-tight min-w-72">@Localizer["ReportsTitle"]</p>
-            <button
-            class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-8 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-medium leading-normal"
-            >
-            <span class="truncate">@Localizer["NewReport"]</span>
-            </button>
-        </div>
-        <h2 class="text-[#0e131b] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">@Localizer["ReportBuilder"]</h2>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <h2 class="text-[#0e131b] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">@Localizer["GroupingAndSorting"]</h2>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <h2 class="text-[#0e131b] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">@Localizer["Visualization"]</h2>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <div class="flex justify-stretch">
-            <div class="flex flex-1 gap-3 flex-wrap px-4 py-3 justify-start">
-            <button
-                class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-bold leading-normal tracking-[0.015em]"
-            >
-                <span class="truncate">@Localizer["ExportPDF"]</span>
-            </button>
-            <button
-                class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-bold leading-normal tracking-[0.015em]"
-            >
-                <span class="truncate">@Localizer["ExportCSV"]</span>
-            </button>
-            </div>
-        </div>
-        <div class="flex px-4 py-3 justify-start">
-            <button
-            class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-bold leading-normal tracking-[0.015em]"
-            >
-            <span class="truncate">@Localizer["ScheduleReport"]</span>
-            </button>
-        </div>
+<h1 class="text-2xl font-bold mb-4">@Localizer["ReportsTitle"]</h1>
+
+<EditForm Model="currentDefinition">
+    <InputText @bind-Value="currentDefinition.Name" placeholder='@Localizer["ReportName"]' class="form-input mb-2" />
+    <div class="report-form-row mb-2">
+        <InputText @bind-Value="newField" placeholder='@Localizer["Field"]' class="form-input flex-1" />
+        <button type="button" class="px-2 py-1 bg-[#e7ecf3] rounded" @onclick="AddField">@Localizer["Add"]</button>
+    </div>
+    <ul class="mb-2">
+        @foreach (var field in currentDefinition.SelectedFields)
+        {
+            <li>@field</li>
+        }
+    </ul>
+    <div class="report-form-row mb-2">
+        <InputText @bind-Value="filterKey" placeholder='@Localizer["FilterKey"]' class="form-input flex-1" />
+        <InputText @bind-Value="filterValue" placeholder='@Localizer["FilterValue"]' class="form-input flex-1" />
+        <button type="button" class="px-2 py-1 bg-[#e7ecf3] rounded" @onclick="AddFilter">@Localizer["Add"]</button>
+    </div>
+    <ul class="mb-2">
+        @foreach (var filter in currentDefinition.Filters)
+        {
+            <li>@filter.Key: @filter.Value</li>
+        }
+    </ul>
+    <div class="report-actions mb-4">
+        <button type="button" class="px-3 py-1 bg-[#e7ecf3] rounded" @onclick="SaveDefinition">@Localizer["SaveDefinition"]</button>
+        <button type="button" class="px-3 py-1 bg-[#e7ecf3] rounded" @onclick="GenerateReport">@Localizer["GenerateReport"]</button>
+    </div>
+</EditForm>
+
+<h2 class="text-xl font-bold mb-2">@Localizer["SavedReports"]</h2>
+<ul class="mb-4">
+    @foreach (var def in savedDefinitions)
+    {
+        <li><button class="underline" @onclick="() => LoadDefinition(def)">@def.Name</button></li>
+    }
+</ul>
+
+<h2 class="text-xl font-bold mb-2">@Localizer["Preview"]</h2>
+@if (preview != null)
+{
+    <div class="report-preview">
+        <h3 class="font-bold mb-2">@preview.Title</h3>
+        <div class="report-table-container">
+            <table class="table-auto border-collapse w-full">
+                <thead>
+                    <tr><th class="border px-2">Field</th><th class="border px-2">Value</th></tr>
+                </thead>
+                <tbody>
+                    @foreach (var item in preview.Data)
+                    {
+                        <tr><td class="border px-2">@item.Key</td><td class="border px-2">@item.Value</td></tr>
+                    }
+                </tbody>
+            </table>
         </div>
     </div>
-    </div>
-</div>
+}
+
+@code {
+    private ReportDefinition currentDefinition = new();
+    private List<ReportDefinition> savedDefinitions = new();
+    private ReportData? preview;
+    private string? newField;
+    private string? filterKey;
+    private string? filterValue;
+
+    protected override async System.Threading.Tasks.Task OnInitializedAsync()
+    {
+        savedDefinitions = (await ReportService.GetReportDefinitionsAsync()).ToList();
+    }
+
+    private void AddField()
+    {
+        if (!string.IsNullOrWhiteSpace(newField))
+        {
+            currentDefinition.SelectedFields.Add(newField);
+            newField = string.Empty;
+        }
+    }
+
+    private void AddFilter()
+    {
+        if (!string.IsNullOrWhiteSpace(filterKey) && filterValue is not null)
+        {
+            currentDefinition.Filters[filterKey] = filterValue;
+            filterKey = filterValue = string.Empty;
+        }
+    }
+
+    private async System.Threading.Tasks.Task SaveDefinition()
+    {
+        await ReportService.SaveReportDefinitionAsync(currentDefinition);
+        savedDefinitions = (await ReportService.GetReportDefinitionsAsync()).ToList();
+        currentDefinition = new ReportDefinition();
+    }
+
+    private async System.Threading.Tasks.Task LoadDefinition(ReportDefinition def)
+    {
+        currentDefinition = def;
+        await GenerateReport();
+    }
+
+    private async System.Threading.Tasks.Task GenerateReport()
+    {
+        preview = await ReportService.GenerateReportAsync(currentDefinition);
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/ReportsPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/ReportsPage.razor.css
@@ -1,0 +1,32 @@
+/* ReportsPage mobile responsive styles */
+
+.report-form-row {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.report-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.report-table-container {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+@media (max-width: 640px) {
+    .report-form-row,
+    .report-actions {
+        flex-direction: column;
+    }
+
+    .report-form-row > *,
+    .report-actions > * {
+        width: 100%;
+    }
+
+    .report-actions button {
+        width: 100%;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/SenderNumberManagementPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SenderNumberManagementPage.razor
@@ -1,6 +1,155 @@
 @page "/sms/senders"
+@using Microsoft.AspNetCore.Components.Forms
+@using NexaCRM.WebClient.Services.Interfaces
+@inject ISmsService SmsService
 
 <ResponsivePage>
     <h3>Sender Number Management</h3>
     <p>Register and manage sender phone numbers.</p>
+
+    @if (!string.IsNullOrEmpty(statusMessage))
+    {
+        <div class="alert @(isError ? "alert-danger" : "alert-success")" role="alert">
+            @statusMessage
+        </div>
+    }
+
+    <button class="btn btn-primary mb-3 add-btn" @onclick="OpenDialog">Add Number</button>
+
+    <div class="d-none d-md-block">
+        <div class="table-responsive">
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Number</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @if (senderNumbers.Count == 0)
+                    {
+                        <tr>
+                            <td colspan="2">No sender numbers registered.</td>
+                        </tr>
+                    }
+                    else
+                    {
+                        @foreach (var num in senderNumbers)
+                        {
+                            <tr>
+                                <td>@num</td>
+                                <td>
+                                    <button class="btn btn-danger btn-sm" @onclick="() => RemoveNumber(num)">Remove</button>
+                                </td>
+                            </tr>
+                        }
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="d-md-none">
+        <ul class="list-group">
+            @if (senderNumbers.Count == 0)
+            {
+                <li class="list-group-item">No sender numbers registered.</li>
+            }
+            else
+            {
+                @foreach (var num in senderNumbers)
+                {
+                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                        <span>@num</span>
+                        <button class="btn btn-danger btn-sm" @onclick="() => RemoveNumber(num)">Remove</button>
+                    </li>
+                }
+            }
+        </ul>
+    </div>
+
+    @if (isDialogOpen)
+    {
+        <div class="modal show d-block" tabindex="-1" style="background-color:rgba(0,0,0,0.5);">
+            <div class="modal-dialog modal-dialog-centered modal-fullscreen-sm-down">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Add Sender Number</h5>
+                        <button type="button" class="btn-close" @onclick="CloseDialog"></button>
+                    </div>
+                    <div class="modal-body">
+                        <EditForm OnValidSubmit="SubmitNumber">
+                            <div class="mb-3">
+                                <label for="sender" class="form-label">Number</label>
+                                <InputText id="sender" class="form-control" @bind-Value="newSender" />
+                            </div>
+                            <div class="modal-footer">
+                                <button type="submit" class="btn btn-primary">Save</button>
+                                <button type="button" class="btn btn-secondary" @onclick="CloseDialog">Cancel</button>
+                            </div>
+                        </EditForm>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
 </ResponsivePage>
+
+@code {
+    private List<string> senderNumbers = new();
+    private bool isDialogOpen = false;
+    private string newSender = string.Empty;
+    private string? statusMessage;
+    private bool isError;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadNumbersAsync();
+    }
+
+    private async Task LoadNumbersAsync()
+    {
+        senderNumbers = (await SmsService.GetSenderNumbersAsync()).ToList();
+    }
+
+    private void OpenDialog() => isDialogOpen = true;
+
+    private void CloseDialog()
+    {
+        isDialogOpen = false;
+        newSender = string.Empty;
+    }
+
+    private async Task SubmitNumber()
+    {
+        try
+        {
+            await SmsService.SaveSenderNumberAsync(newSender);
+            statusMessage = "Number saved successfully.";
+            isError = false;
+            await LoadNumbersAsync();
+        }
+        catch (Exception ex)
+        {
+            statusMessage = $"Failed to save number: {ex.Message}";
+            isError = true;
+        }
+        CloseDialog();
+    }
+
+    private async Task RemoveNumber(string number)
+    {
+        try
+        {
+            await SmsService.DeleteSenderNumberAsync(number);
+            statusMessage = "Number removed successfully.";
+            isError = false;
+            await LoadNumbersAsync();
+        }
+        catch (Exception ex)
+        {
+            statusMessage = $"Failed to remove number: {ex.Message}";
+            isError = true;
+        }
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/SenderNumberManagementPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/SenderNumberManagementPage.razor.css
@@ -1,0 +1,5 @@
+@media (max-width: 576px) {
+    .add-btn {
+        width: 100%;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/SmsHistoryPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SmsHistoryPage.razor
@@ -1,6 +1,83 @@
 @page "/sms/history"
+@using NexaCRM.WebClient.Models.Sms
 
 <ResponsivePage>
     <h3>SMS History</h3>
-    <p>Review SMS delivery history.</p>
+
+    <div class="mb-3">
+        <div class="row g-2 sms-filters">
+            <div class="col-12 col-md">
+                <input type="date" class="form-control" @bind="startDate" @bind:after="ResetPage" />
+            </div>
+            <div class="col-12 col-md">
+                <input type="date" class="form-control" @bind="endDate" @bind:after="ResetPage" />
+            </div>
+            <div class="col-12 col-md">
+                <input class="form-control" placeholder="Recipient" @bind="recipient" @bind:event="oninput" @bind:after="ResetPage" />
+            </div>
+            <div class="col-12 col-md">
+                <select class="form-select" @bind="status" @bind:after="ResetPage">
+                    <option value="">All</option>
+                    <option>Sent</option>
+                    <option>Failed</option>
+                </select>
+            </div>
+            <div class="col-12 col-md-auto text-md-end">
+                <button class="btn btn-secondary w-100 w-md-auto" @onclick="ExportCsv">Export CSV</button>
+            </div>
+        </div>
+    </div>
+
+    @if (history == null)
+    {
+        <p>Loading...</p>
+    }
+    else
+    {
+        <div class="d-none d-md-block">
+            <div class="table-responsive">
+                <table class="table table-striped sms-history-table">
+                    <thead>
+                        <tr>
+                            <th>Recipient</th>
+                            <th>Message</th>
+                            <th>Sent At</th>
+                            <th>Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in PagedHistory)
+                        {
+                            <tr>
+                                <td>@item.Recipient</td>
+                                <td>@item.Message</td>
+                                <td>@item.SentAt.ToLocalTime()</td>
+                                <td>@item.Status</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="sms-history-mobile d-md-none">
+            @foreach (var item in PagedHistory)
+            {
+                <div class="card sms-history-card">
+                    <div class="card-body">
+                        <div><strong>Recipient:</strong> @item.Recipient</div>
+                        <div class="sms-message"><strong>Message:</strong> @item.Message</div>
+                        <div><strong>Sent At:</strong> @item.SentAt.ToLocalTime()</div>
+                        <div><strong>Status:</strong> @item.Status</div>
+                    </div>
+                </div>
+            }
+        </div>
+
+        <div class="d-flex flex-column flex-md-row justify-content-between align-items-center gap-2 pagination-controls">
+            <button class="btn btn-outline-primary w-100 w-md-auto" @onclick="PrevPage" disabled="@(_currentPage == 1)">Previous</button>
+            <span>Page @_currentPage of @TotalPages</span>
+            <button class="btn btn-outline-primary w-100 w-md-auto" @onclick="NextPage" disabled="@(_currentPage == TotalPages)">Next</button>
+        </div>
+    }
 </ResponsivePage>

--- a/src/Web/NexaCRM.WebClient/Pages/SmsHistoryPage.razor.cs
+++ b/src/Web/NexaCRM.WebClient/Pages/SmsHistoryPage.razor.cs
@@ -1,0 +1,82 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using NexaCRM.WebClient.Models.Sms;
+using NexaCRM.WebClient.Services.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Pages;
+
+public partial class SmsHistoryPage
+{
+    [Inject] private ISmsService SmsService { get; set; } = default!;
+    [Inject] private IJSRuntime JS { get; set; } = default!;
+
+    private IEnumerable<SmsHistoryItem>? history;
+    private DateTime? startDate;
+    private DateTime? endDate;
+    private string recipient = string.Empty;
+    private string status = string.Empty;
+
+    private int _currentPage = 1;
+    private const int PageSize = 10;
+
+    protected override async Task OnInitializedAsync()
+    {
+        history = await SmsService.GetHistoryAsync();
+    }
+
+    private IEnumerable<SmsHistoryItem> FilteredHistory =>
+        history?.Where(item =>
+            (!startDate.HasValue || item.SentAt.Date >= startDate.Value.Date) &&
+            (!endDate.HasValue || item.SentAt.Date <= endDate.Value.Date) &&
+            (string.IsNullOrWhiteSpace(recipient) || item.Recipient.Contains(recipient, StringComparison.OrdinalIgnoreCase)) &&
+            (string.IsNullOrWhiteSpace(status) || string.Equals(item.Status, status, StringComparison.OrdinalIgnoreCase)))
+        ?? Enumerable.Empty<SmsHistoryItem>();
+
+    private IEnumerable<SmsHistoryItem> PagedHistory =>
+        FilteredHistory.Skip((_currentPage - 1) * PageSize).Take(PageSize);
+
+    private int TotalPages => Math.Max(1, (int)Math.Ceiling(FilteredHistory.Count() / (double)PageSize));
+
+    private void PrevPage()
+    {
+        if (_currentPage > 1)
+        {
+            _currentPage--;
+        }
+    }
+
+    private void NextPage()
+    {
+        if (_currentPage < TotalPages)
+        {
+            _currentPage++;
+        }
+    }
+
+    private void ResetPage()
+    {
+        _currentPage = 1;
+    }
+
+    private async Task ExportCsv()
+    {
+        var lines = new List<string> { "Recipient,Message,SentAt,Status" };
+        foreach (var item in FilteredHistory)
+        {
+            var line = string.Join(',', Escape(item.Recipient), Escape(item.Message), item.SentAt.ToString("u"), Escape(item.Status));
+            lines.Add(line);
+        }
+        var csv = string.Join("\n", lines);
+        await JS.InvokeVoidAsync("downloadCsv", "sms_history.csv", csv);
+    }
+
+    private static string Escape(string? input)
+    {
+        if (string.IsNullOrEmpty(input)) return "\"\"";
+        return $"\"{input.Replace("\"", "\"\"")}\"";
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/SmsHistoryPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/SmsHistoryPage.razor.css
@@ -1,0 +1,21 @@
+/* SmsHistoryPage Mobile Responsive Styles */
+
+.sms-history-table td:nth-child(2) {
+    word-break: break-word;
+}
+
+.sms-history-card {
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+@media (max-width: 576px) {
+    .sms-filters .col-12:not(:last-child) {
+        margin-bottom: 0.5rem;
+    }
+
+    .pagination-controls button {
+        min-height: 44px;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/SystemAdminSettingsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SystemAdminSettingsPage.razor
@@ -1,6 +1,77 @@
 @page "/organization/system-admin"
+@using System.ComponentModel.DataAnnotations
+@using NexaCRM.WebClient.Services.Interfaces
+@inject IOrganizationService OrganizationService
 
 <ResponsivePage>
     <h3>System Administration</h3>
-    <p>Configure global system administrators.</p>
+
+    <div class="system-admin-form">
+        <EditForm Model="@model" OnValidSubmit="HandleValidSubmit">
+            <DataAnnotationsValidator />
+            <ValidationSummary />
+
+            <div class="form-group">
+                <label for="userId">User Identifier</label>
+                <InputText id="userId" class="form-control" @bind-Value="model.UserId" placeholder="Enter user ID" />
+                <ValidationMessage For="@(() => model.UserId)" />
+            </div>
+
+            <button type="submit" class="btn btn-primary save-btn" disabled="@isSaving">
+                @if (isSaving)
+                {
+                    <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                    <span class="visually-hidden">Saving...</span>
+                }
+                else
+                {
+                    <span>Save</span>
+                }
+            </button>
+        </EditForm>
+
+        @if (!string.IsNullOrEmpty(successMessage))
+        {
+            <div class="alert alert-success mt-3" role="alert">@successMessage</div>
+        }
+        @if (!string.IsNullOrEmpty(errorMessage))
+        {
+            <div class="alert alert-danger mt-3" role="alert">@errorMessage</div>
+        }
+    </div>
 </ResponsivePage>
+
+@code {
+    private AdminModel model = new();
+    private string? successMessage;
+    private string? errorMessage;
+
+    private bool isSaving;
+
+    private async Task HandleValidSubmit()
+    {
+        successMessage = null;
+        errorMessage = null;
+        isSaving = true;
+
+        try
+        {
+            await OrganizationService.SetSystemAdministratorAsync(model.UserId);
+            successMessage = "System administrator updated successfully.";
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Error saving: {ex.Message}";
+        }
+        finally
+        {
+            isSaving = false;
+        }
+    }
+
+    private class AdminModel
+    {
+        [Required]
+        public string UserId { get; set; } = string.Empty;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/SystemAdminSettingsPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/SystemAdminSettingsPage.razor.css
@@ -1,0 +1,16 @@
+/* SystemAdminSettingsPage Mobile Responsive Styles */
+
+.system-admin-form {
+    max-width: 400px;
+    margin-top: 1rem;
+}
+
+@media (max-width: 600px) {
+    .system-admin-form {
+        padding: 0 1rem;
+    }
+
+    .save-btn {
+        width: 100%;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/SystemInfoPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SystemInfoPage.razor
@@ -1,6 +1,48 @@
 @page "/system/info"
+@using NexaCRM.WebClient.Services.Interfaces
+@using NexaCRM.WebClient.Models.SystemInfo
+@inject ISystemInfoService SystemInfoService
 
 <ResponsivePage>
-    <h3>System Information</h3>
-    <p>View terms of service, company contact and address.</p>
+    <div class="container mx-auto p-4 space-y-6">
+        <h3 class="mb-4 text-center sm:text-left">System Information</h3>
+        @if (_info is null)
+        {
+            <p>Loading...</p>
+        }
+        else
+        {
+            <section class="system-info-section">
+                <h4 class="section-title">Terms of Service</h4>
+                <p class="section-content">@_info.Terms</p>
+                <a href="docs/terms.pdf" class="btn btn-primary download-link" download>Download Terms (PDF)</a>
+            </section>
+            <section class="system-info-section">
+                <h4 class="section-title">Company Address</h4>
+                <address class="section-content">@_info.CompanyAddress</address>
+            </section>
+            <section class="system-info-section">
+                <h4 class="section-title">Support Contacts</h4>
+                <ul class="section-list">
+                    @if (_info.SupportContacts is not null)
+                    {
+                        @foreach (var contact in _info.SupportContacts)
+                        {
+                            <li>@contact</li>
+                        }
+                    }
+                </ul>
+                <a href="docs/privacy.pdf" class="btn btn-secondary download-link" download>Download Privacy Policy (PDF)</a>
+            </section>
+        }
+    </div>
 </ResponsivePage>
+
+@code {
+    private SystemInfo? _info;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _info = await SystemInfoService.GetSystemInfoAsync();
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/SystemInfoPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/SystemInfoPage.razor.css
@@ -1,0 +1,41 @@
+/* SystemInfoPage responsive styles */
+
+.system-info-section {
+    background-color: var(--surface-color);
+    border-radius: 0.5rem;
+    padding: 1rem;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.section-title {
+    font-size: 1.125rem;
+    margin-bottom: 0.5rem;
+}
+
+.section-content {
+    margin-bottom: 0.5rem;
+}
+
+.section-list {
+    margin-left: 1.25rem;
+    margin-bottom: 0.5rem;
+}
+
+.download-link {
+    display: block;
+    width: 100%;
+    text-align: center;
+    margin-top: 0.75rem;
+}
+
+@media (min-width: 640px) {
+    .system-info-section {
+        padding: 1.5rem;
+    }
+
+    .download-link {
+        width: auto;
+        display: inline-block;
+    }
+}
+

--- a/src/Web/NexaCRM.WebClient/Program.cs
+++ b/src/Web/NexaCRM.WebClient/Program.cs
@@ -45,6 +45,7 @@ builder.Services.AddScoped<IOrganizationService, OrganizationService>();
 builder.Services.AddScoped<IDbAdminService, DbAdminService>();
 builder.Services.AddScoped<IStatisticsService, StatisticsService>();
 builder.Services.AddScoped<ICustomerCenterService, CustomerCenterService>();
+builder.Services.AddScoped<INoticeService, NoticeService>();
 builder.Services.AddScoped<ISmsService, SmsService>();
 builder.Services.AddScoped<ISystemInfoService, SystemInfoService>();
 builder.Services.AddScoped<IEmailTemplateService, MockEmailTemplateService>();

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/NotificationSettingsPage.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/NotificationSettingsPage.en-US.resx
@@ -111,4 +111,7 @@
   <data name="SaveSettings" xml:space="preserve">
     <value>Save Settings</value>
   </data>
+  <data name="SettingsSaved" xml:space="preserve">
+    <value>Settings saved successfully.</value>
+  </data>
 </root>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/NotificationSettingsPage.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/NotificationSettingsPage.ko-KR.resx
@@ -111,4 +111,7 @@
   <data name="SaveSettings" xml:space="preserve">
     <value>설정 저장</value>
   </data>
+  <data name="SettingsSaved" xml:space="preserve">
+    <value>설정이 저장되었습니다.</value>
+  </data>
 </root>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/ReportsPage.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/ReportsPage.en-US.resx
@@ -45,4 +45,31 @@
   <data name="ScheduleReport" xml:space="preserve">
     <value>Schedule Report</value>
   </data>
+  <data name="ReportName" xml:space="preserve">
+    <value>Report Name</value>
+  </data>
+  <data name="Field" xml:space="preserve">
+    <value>Field</value>
+  </data>
+  <data name="Add" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="FilterKey" xml:space="preserve">
+    <value>Filter Key</value>
+  </data>
+  <data name="FilterValue" xml:space="preserve">
+    <value>Filter Value</value>
+  </data>
+  <data name="SaveDefinition" xml:space="preserve">
+    <value>Save Definition</value>
+  </data>
+  <data name="SavedReports" xml:space="preserve">
+    <value>Saved Reports</value>
+  </data>
+  <data name="GenerateReport" xml:space="preserve">
+    <value>Generate Report</value>
+  </data>
+  <data name="Preview" xml:space="preserve">
+    <value>Preview</value>
+  </data>
 </root>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/ReportsPage.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/ReportsPage.ko-KR.resx
@@ -45,4 +45,31 @@
   <data name="ScheduleReport" xml:space="preserve">
     <value>보고서 예약</value>
   </data>
+  <data name="ReportName" xml:space="preserve">
+    <value>보고서 이름</value>
+  </data>
+  <data name="Field" xml:space="preserve">
+    <value>필드</value>
+  </data>
+  <data name="Add" xml:space="preserve">
+    <value>추가</value>
+  </data>
+  <data name="FilterKey" xml:space="preserve">
+    <value>필터 키</value>
+  </data>
+  <data name="FilterValue" xml:space="preserve">
+    <value>필터 값</value>
+  </data>
+  <data name="SaveDefinition" xml:space="preserve">
+    <value>정의 저장</value>
+  </data>
+  <data name="SavedReports" xml:space="preserve">
+    <value>저장된 보고서</value>
+  </data>
+  <data name="GenerateReport" xml:space="preserve">
+    <value>보고서 생성</value>
+  </data>
+  <data name="Preview" xml:space="preserve">
+    <value>미리보기</value>
+  </data>
 </root>

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/INoticeService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/INoticeService.cs
@@ -1,0 +1,15 @@
+using NexaCRM.WebClient.Models.CustomerCenter;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+public interface INoticeService
+{
+    Task<IEnumerable<Notice>> GetNoticesAsync();
+    Task<Notice?> GetNoticeAsync(int id);
+    Task CreateNoticeAsync(Notice notice);
+    Task UpdateNoticeAsync(Notice notice);
+    Task DeleteNoticeAsync(int id);
+}
+

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/INotificationService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/INotificationService.cs
@@ -1,0 +1,10 @@
+using NexaCRM.WebClient.Models.Settings;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+public interface INotificationService
+{
+    Task<NotificationSettings> GetSettingsAsync();
+    Task SaveSettingsAsync(NotificationSettings settings);
+}

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IReportService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IReportService.cs
@@ -1,14 +1,17 @@
+using System.Collections.Generic;
 using NexaCRM.WebClient.Models;
-using System.Threading.Tasks;
 
 namespace NexaCRM.WebClient.Services.Interfaces
 {
     public interface IReportService
     {
-        Task<ReportData> GetQuarterlyPerformanceAsync();
-        Task<ReportData> GetLeadSourceAnalyticsAsync();
-        Task<ReportData> GetTicketVolumeAsync();
-        Task<ReportData> GetResolutionRateAsync();
-        Task<ReportData> GetTicketsByCategoryAsync();
+        System.Threading.Tasks.Task SaveReportDefinitionAsync(ReportDefinition definition);
+        System.Threading.Tasks.Task<IEnumerable<ReportDefinition>> GetReportDefinitionsAsync();
+        System.Threading.Tasks.Task<ReportData> GenerateReportAsync(ReportDefinition definition);
+        System.Threading.Tasks.Task<ReportData> GetQuarterlyPerformanceAsync();
+        System.Threading.Tasks.Task<ReportData> GetLeadSourceAnalyticsAsync();
+        System.Threading.Tasks.Task<ReportData> GetTicketVolumeAsync();
+        System.Threading.Tasks.Task<ReportData> GetResolutionRateAsync();
+        System.Threading.Tasks.Task<ReportData> GetTicketsByCategoryAsync();
     }
 }

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/ISmsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/ISmsService.cs
@@ -10,6 +10,7 @@ public interface ISmsService
     Task SendBulkSmsAsync(BulkSmsRequest request);
     Task<IEnumerable<string>> GetSenderNumbersAsync();
     Task SaveSenderNumberAsync(string number);
+    Task DeleteSenderNumberAsync(string number);
     Task<IEnumerable<SmsHistoryItem>> GetHistoryAsync();
     Task ScheduleSmsAsync(SmsScheduleItem schedule);
     Task<SmsSettings> GetSettingsAsync();

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IStatisticsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IStatisticsService.cs
@@ -5,6 +5,6 @@ namespace NexaCRM.WebClient.Services.Interfaces;
 
 public interface IStatisticsService
 {
-    Task<StatisticsSummary> GetStatisticsAsync();
+    Task<StatisticsSummary> GetStatisticsAsync(string? companyId = null, string? teamId = null, string? memberId = null);
 }
 

--- a/src/Web/NexaCRM.WebClient/Services/Mock/MockReportService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Mock/MockReportService.cs
@@ -1,11 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using NexaCRM.WebClient.Models;
 using NexaCRM.WebClient.Services.Interfaces;
-using System.Collections.Generic;
 
 namespace NexaCRM.WebClient.Services.Mock
 {
     public class MockReportService : IReportService
     {
+        private readonly List<ReportDefinition> _definitions = new();
+
+        public System.Threading.Tasks.Task SaveReportDefinitionAsync(ReportDefinition definition)
+        {
+            _definitions.Add(definition);
+            return System.Threading.Tasks.Task.CompletedTask;
+        }
+
+        public System.Threading.Tasks.Task<IEnumerable<ReportDefinition>> GetReportDefinitionsAsync()
+        {
+            return System.Threading.Tasks.Task.FromResult<IEnumerable<ReportDefinition>>(_definitions);
+        }
+
+        public System.Threading.Tasks.Task<ReportData> GenerateReportAsync(ReportDefinition definition)
+        {
+            var data = new ReportData
+            {
+                Title = definition.Name,
+                Data = definition.SelectedFields.ToDictionary(f => f, f => (double)Random.Shared.Next(10, 100))
+            };
+
+            return System.Threading.Tasks.Task.FromResult(data);
+        }
+
         public System.Threading.Tasks.Task<ReportData> GetQuarterlyPerformanceAsync()
         {
             var data = new ReportData

--- a/src/Web/NexaCRM.WebClient/Services/NoticeService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/NoticeService.cs
@@ -1,0 +1,49 @@
+using NexaCRM.WebClient.Models.CustomerCenter;
+using NexaCRM.WebClient.Services.Interfaces;
+
+namespace NexaCRM.WebClient.Services;
+
+public class NoticeService : INoticeService
+{
+    private readonly List<Notice> _notices = new()
+    {
+        new Notice(1, "Welcome", "Welcome to NexaCRM!"),
+        new Notice(2, "Maintenance", "System maintenance on Friday."),
+    };
+
+    private int _nextId = 3;
+
+    public Task<IEnumerable<Notice>> GetNoticesAsync() =>
+        Task.FromResult<IEnumerable<Notice>>(_notices);
+
+    public Task<Notice?> GetNoticeAsync(int id) =>
+        Task.FromResult(_notices.FirstOrDefault(n => n.Id == id));
+
+    public Task CreateNoticeAsync(Notice notice)
+    {
+        var newNotice = notice with { Id = _nextId++ };
+        _notices.Add(newNotice);
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateNoticeAsync(Notice notice)
+    {
+        var index = _notices.FindIndex(n => n.Id == notice.Id);
+        if (index >= 0)
+        {
+            _notices[index] = notice;
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteNoticeAsync(int id)
+    {
+        var notice = _notices.FirstOrDefault(n => n.Id == id);
+        if (notice is not null)
+        {
+            _notices.Remove(notice);
+        }
+        return Task.CompletedTask;
+    }
+}
+

--- a/src/Web/NexaCRM.WebClient/Services/NotificationService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/NotificationService.cs
@@ -1,0 +1,19 @@
+using NexaCRM.WebClient.Models.Settings;
+using NexaCRM.WebClient.Services.Interfaces;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services;
+
+public class NotificationService : INotificationService
+{
+    private NotificationSettings _settings = new();
+
+    public Task<NotificationSettings> GetSettingsAsync() =>
+        Task.FromResult(_settings);
+
+    public Task SaveSettingsAsync(NotificationSettings settings)
+    {
+        _settings = settings;
+        return Task.CompletedTask;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Services/SmsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SmsService.cs
@@ -1,6 +1,7 @@
 using NexaCRM.WebClient.Models.Sms;
 using NexaCRM.WebClient.Models.Settings;
 using NexaCRM.WebClient.Services.Interfaces;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -21,7 +22,12 @@ public class SmsService : ISmsService
         Task.CompletedTask;
 
     public Task<IEnumerable<SmsHistoryItem>> GetHistoryAsync() =>
-        Task.FromResult<IEnumerable<SmsHistoryItem>>(new List<SmsHistoryItem>());
+        Task.FromResult<IEnumerable<SmsHistoryItem>>(new List<SmsHistoryItem>
+        {
+            new("010-1234-5678", "Hello!", DateTime.UtcNow.AddDays(-1), "Sent"),
+            new("010-2345-6789", "Reminder", DateTime.UtcNow.AddDays(-2), "Failed"),
+            new("010-3456-7890", "Promotion", DateTime.UtcNow.AddDays(-3), "Sent"),
+        });
 
     public Task ScheduleSmsAsync(SmsScheduleItem schedule) =>
         Task.CompletedTask;

--- a/src/Web/NexaCRM.WebClient/Services/SmsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SmsService.cs
@@ -17,6 +17,9 @@ public class SmsService : ISmsService
     public Task SaveSenderNumberAsync(string number) =>
         Task.CompletedTask;
 
+    public Task DeleteSenderNumberAsync(string number) =>
+        Task.CompletedTask;
+
     public Task<IEnumerable<SmsHistoryItem>> GetHistoryAsync() =>
         Task.FromResult<IEnumerable<SmsHistoryItem>>(new List<SmsHistoryItem>());
 

--- a/src/Web/NexaCRM.WebClient/Services/StatisticsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/StatisticsService.cs
@@ -6,7 +6,17 @@ namespace NexaCRM.WebClient.Services;
 
 public class StatisticsService : IStatisticsService
 {
-    public Task<StatisticsSummary> GetStatisticsAsync() =>
-        Task.FromResult(new StatisticsSummary(0, 0, 0));
+    public Task<StatisticsSummary> GetStatisticsAsync(string? companyId = null, string? teamId = null, string? memberId = null)
+    {
+        var members = 100;
+        var logins = 200;
+        var downloads = 50;
+
+        if (!string.IsNullOrEmpty(companyId)) members += 10;
+        if (!string.IsNullOrEmpty(teamId)) logins += 20;
+        if (!string.IsNullOrEmpty(memberId)) downloads += 5;
+
+        return Task.FromResult(new StatisticsSummary(members, logins, downloads));
+    }
 }
 

--- a/src/Web/NexaCRM.WebClient/Services/SystemInfoService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SystemInfoService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using NexaCRM.WebClient.Models.SystemInfo;
 using NexaCRM.WebClient.Services.Interfaces;
 using System.Threading.Tasks;
@@ -6,7 +7,17 @@ namespace NexaCRM.WebClient.Services;
 
 public class SystemInfoService : ISystemInfoService
 {
-    public Task<SystemInfo> GetSystemInfoAsync() =>
-        Task.FromResult(new SystemInfo());
+    private readonly IConfiguration _configuration;
+
+    public SystemInfoService(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public Task<SystemInfo> GetSystemInfoAsync()
+    {
+        var info = _configuration.GetSection("SystemInfo").Get<SystemInfo>() ?? new SystemInfo();
+        return Task.FromResult(info);
+    }
 }
 

--- a/src/Web/NexaCRM.WebClient/wwwroot/appsettings.json
+++ b/src/Web/NexaCRM.WebClient/wwwroot/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "SystemInfo": {
+    "Terms": "All services are provided as-is.",
+    "CompanyAddress": "123 Nexa Street, Seoul",
+    "SupportContacts": [
+      "support@nexa.example",
+      "+82-2-1234-5678"
+    ]
+  }
+}

--- a/src/Web/NexaCRM.WebClient/wwwroot/docs/privacy.pdf
+++ b/src/Web/NexaCRM.WebClient/wwwroot/docs/privacy.pdf
@@ -1,0 +1,36 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 52 >>
+stream
+BT /F1 18 Tf 10 100 Td (Privacy Policy) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+6 0 obj
+<< /Font << /F1 5 0 R >> >>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000111 00000 n 
+0000000212 00000 n 
+0000000321 00000 n 
+0000000383 00000 n 
+trailer
+<< /Root 1 0 R /Size 7 >>
+startxref
+438
+%%EOF

--- a/src/Web/NexaCRM.WebClient/wwwroot/docs/terms.pdf
+++ b/src/Web/NexaCRM.WebClient/wwwroot/docs/terms.pdf
@@ -1,0 +1,36 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT /F1 24 Tf 10 100 Td (Terms) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+6 0 obj
+<< /Font << /F1 5 0 R >> >>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000111 00000 n 
+0000000212 00000 n 
+0000000311 00000 n 
+0000000373 00000 n 
+trailer
+<< /Root 1 0 R /Size 7 >>
+startxref
+428
+%%EOF

--- a/src/Web/NexaCRM.WebClient/wwwroot/index.html
+++ b/src/Web/NexaCRM.WebClient/wwwroot/index.html
@@ -42,6 +42,7 @@
     <script src="js/theme-manager.js"></script>
     <script src="js/device.js"></script>
     <script src="js/interactions.js"></script>
+    <script src="js/csv-export.js"></script>
 </body>
 
 </html>

--- a/src/Web/NexaCRM.WebClient/wwwroot/js/csv-export.js
+++ b/src/Web/NexaCRM.WebClient/wwwroot/js/csv-export.js
@@ -1,0 +1,10 @@
+window.downloadCsv = (filename, content) => {
+    const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(link.href);
+};

--- a/src/Web/NexaCRM.WebClient/wwwroot/js/interactions.js
+++ b/src/Web/NexaCRM.WebClient/wwwroot/js/interactions.js
@@ -554,3 +554,26 @@ if (document.readyState === 'loading') {
 } else {
     window.interactionManager.init();
 }
+
+window.downloadFile = (fileName, content) => {
+    const blob = new Blob([content], { type: 'text/csv' });
+
+    if (navigator.share && navigator.canShare && navigator.canShare({ files: [new File([blob], fileName, { type: 'text/csv' })] })) {
+        const file = new File([blob], fileName, { type: 'text/csv' });
+        navigator.share({ files: [file] }).catch(() => fallbackDownload(blob));
+        return;
+    }
+
+    fallbackDownload(blob);
+
+    function fallbackDownload(b) {
+        const url = URL.createObjectURL(b);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = fileName;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+    }
+};

--- a/tests/BlazorWebApp.Tests/MockReportServiceTests.cs
+++ b/tests/BlazorWebApp.Tests/MockReportServiceTests.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Linq;
+using NexaCRM.WebClient.Models;
+using NexaCRM.WebClient.Services.Mock;
+
+namespace BlazorWebApp.Tests;
+
+public class MockReportServiceTests
+{
+    [Fact]
+    public async System.Threading.Tasks.Task SaveReportDefinitionAsync_PersistsDefinition()
+    {
+        var service = new MockReportService();
+        var def = new ReportDefinition { Name = "Test", SelectedFields = new List<string> { "A" } };
+        await service.SaveReportDefinitionAsync(def);
+        var defs = await service.GetReportDefinitionsAsync();
+        Assert.Contains(defs, d => d.Name == "Test");
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GenerateReportAsync_ReturnsDataForFields()
+    {
+        var service = new MockReportService();
+        var def = new ReportDefinition { Name = "Test", SelectedFields = new List<string> { "Field1", "Field2" } };
+        var data = await service.GenerateReportAsync(def);
+        Assert.Equal(def.SelectedFields.Count, data.Data!.Count);
+        foreach (var field in def.SelectedFields)
+        {
+            Assert.True(data.Data.ContainsKey(field));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- bind notification settings toggles to a shared model
- load and save settings via notification service with user confirmation
- improve mobile layout with responsive padding and collapsible navigation
- localize settings saved message

## Testing
- `dotnet build --configuration Release`
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release`


------
https://chatgpt.com/codex/tasks/task_b_68c81bb0f0d8832c80adbc3746e73570