### PR TITLE
feat: implement statistics dashboard with date range and trend charts

### DIFF
--- a/src/Web/NexaCRM.WebClient/Models/StatisticsModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/StatisticsModels.cs
@@ -1,4 +1,14 @@
+using System;
+using System.Collections.Generic;
+
 namespace NexaCRM.WebClient.Models.Statistics;
 
 public record StatisticsSummary(int TotalMembers, int TotalLogins, int TotalDownloads);
+
+public record TrendPoint(DateTime Date, int Value);
+
+public record StatisticsResult(
+    StatisticsSummary Summary,
+    List<TrendPoint> LoginTrend,
+    List<TrendPoint> DownloadTrend);
 

--- a/src/Web/NexaCRM.WebClient/Pages/StatisticsDashboardPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/StatisticsDashboardPage.razor
@@ -1,6 +1,103 @@
 @page "/statistics/dashboard"
+@using System.Collections.Generic
+@using System.Linq
+@using NexaCRM.WebClient.Components.UI
+@using NexaCRM.WebClient.Models.Statistics
+@using NexaCRM.WebClient.Services.Interfaces
+@inject IStatisticsService StatisticsService
 
 <ResponsivePage>
     <h3>Statistics Dashboard</h3>
-    <p>View system usage statistics and reports.</p>
+
+    <div class="date-range">
+        <input type="date" @bind="startDate" @bind:format="yyyy-MM-dd" />
+        <input type="date" @bind="endDate" @bind:format="yyyy-MM-dd" />
+        <button @onclick="LoadStatistics">Update</button>
+    </div>
+
+    @if (isLoading)
+    {
+        <LoadingSpinner LoadingText="Loading statistics..." />
+    }
+    else if (stats is null ||
+            (stats.Summary.TotalMembers == 0 && stats.Summary.TotalLogins == 0 && stats.Summary.TotalDownloads == 0))
+    {
+        <p>No statistics available for the selected date range.</p>
+    }
+    else
+    {
+        <div class="summary-tiles">
+            <div class="tile">Total Members: @stats.Summary.TotalMembers</div>
+            <div class="tile">Total Logins: @stats.Summary.TotalLogins</div>
+            <div class="tile">Total Downloads: @stats.Summary.TotalDownloads</div>
+        </div>
+
+        <div class="trend-charts">
+            <div class="chart">
+                <h4>Logins Trend</h4>
+                @if (stats.LoginTrend.Any())
+                {
+                    <svg width="100%" height="100" viewBox="0 0 100 100">
+                        <polyline fill="none" stroke="blue" stroke-width="2" points="@GetTrendPoints(stats.LoginTrend)" />
+                    </svg>
+                }
+                else
+                {
+                    <p>No data.</p>
+                }
+            </div>
+
+            <div class="chart">
+                <h4>Downloads Trend</h4>
+                @if (stats.DownloadTrend.Any())
+                {
+                    <svg width="100%" height="100" viewBox="0 0 100 100">
+                        <polyline fill="none" stroke="green" stroke-width="2" points="@GetTrendPoints(stats.DownloadTrend)" />
+                    </svg>
+                }
+                else
+                {
+                    <p>No data.</p>
+                }
+            </div>
+        </div>
+    }
 </ResponsivePage>
+
+@code {
+    private DateTime startDate = DateTime.Today.AddDays(-7);
+    private DateTime endDate = DateTime.Today;
+    private StatisticsResult? stats;
+    private bool isLoading = true;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadStatistics();
+    }
+
+    private async Task LoadStatistics()
+    {
+        isLoading = true;
+        stats = await StatisticsService.GetStatisticsAsync(startDate, endDate);
+        isLoading = false;
+    }
+
+    private static string GetTrendPoints(List<TrendPoint> trend)
+    {
+        if (trend.Count == 0) return string.Empty;
+        var max = trend.Max(p => p.Value);
+        var min = trend.Min(p => p.Value);
+        var range = max - min;
+        if (range == 0) range = 1;
+
+        var points = new System.Text.StringBuilder();
+        for (int i = 0; i < trend.Count; i++)
+        {
+            var x = (double)i / (trend.Count - 1) * 100;
+            var y = 100 - ((double)(trend[i].Value - min) / range * 100);
+            points.AppendFormat(System.Globalization.CultureInfo.InvariantCulture, "{0:F2},{1:F2} ", x, y);
+        }
+        return points.ToString();
+    }
+}
+

--- a/src/Web/NexaCRM.WebClient/Pages/StatisticsDashboardPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/StatisticsDashboardPage.razor.css
@@ -1,0 +1,54 @@
+/* StatisticsDashboardPage styles */
+
+.summary-tiles {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-md, 1rem);
+    margin: var(--spacing-md, 1rem) 0;
+}
+
+.summary-tiles .tile {
+    flex: 1;
+    padding: var(--spacing-md, 1rem);
+    border: 1px solid var(--border-color, #d0d9e7);
+    border-radius: 0.5rem;
+    text-align: center;
+}
+
+.trend-charts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-md, 1rem);
+}
+
+.trend-charts .chart {
+    flex: 1;
+    min-width: 250px;
+}
+
+.date-range {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--spacing-sm, 0.5rem);
+    margin-bottom: var(--spacing-md, 1rem);
+}
+
+@media (max-width: 600px) {
+    .summary-tiles {
+        flex-direction: column;
+    }
+
+    .trend-charts {
+        flex-direction: column;
+    }
+
+    .trend-charts .chart {
+        min-width: 100%;
+    }
+
+    .date-range {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IStatisticsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IStatisticsService.cs
@@ -1,10 +1,11 @@
-using NexaCRM.WebClient.Models.Statistics;
+using System;
 using System.Threading.Tasks;
+using NexaCRM.WebClient.Models.Statistics;
 
 namespace NexaCRM.WebClient.Services.Interfaces;
 
 public interface IStatisticsService
 {
-    Task<StatisticsSummary> GetStatisticsAsync(string? companyId = null, string? teamId = null, string? memberId = null);
+    Task<StatisticsResult> GetStatisticsAsync(DateTime startDate, DateTime endDate);
 }
 

--- a/src/Web/NexaCRM.WebClient/Services/StatisticsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/StatisticsService.cs
@@ -1,22 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using NexaCRM.WebClient.Models.Statistics;
 using NexaCRM.WebClient.Services.Interfaces;
-using System.Threading.Tasks;
 
 namespace NexaCRM.WebClient.Services;
 
 public class StatisticsService : IStatisticsService
 {
-    public Task<StatisticsSummary> GetStatisticsAsync(string? companyId = null, string? teamId = null, string? memberId = null)
+    public Task<StatisticsResult> GetStatisticsAsync(DateTime startDate, DateTime endDate)
     {
-        var members = 100;
-        var logins = 200;
-        var downloads = 50;
+        var rand = new Random();
+        var dates = Enumerable.Range(0, (endDate - startDate).Days + 1)
+            .Select(offset => startDate.AddDays(offset))
+            .ToList();
 
-        if (!string.IsNullOrEmpty(companyId)) members += 10;
-        if (!string.IsNullOrEmpty(teamId)) logins += 20;
-        if (!string.IsNullOrEmpty(memberId)) downloads += 5;
+        var loginTrend = dates
+            .Select(d => new TrendPoint(d, rand.Next(0, 100)))
+            .ToList();
 
-        return Task.FromResult(new StatisticsSummary(members, logins, downloads));
+        var downloadTrend = dates
+            .Select(d => new TrendPoint(d, rand.Next(0, 50)))
+            .ToList();
+
+        var summary = new StatisticsSummary(
+            TotalMembers: rand.Next(1000, 10000),
+            TotalLogins: loginTrend.Sum(p => p.Value),
+            TotalDownloads: downloadTrend.Sum(p => p.Value)
+        );
+
+        return Task.FromResult(new StatisticsResult(summary, loginTrend, downloadTrend));
     }
 }
 


### PR DESCRIPTION
## Summary
- extend statistics models and service to deliver summary and trend data
- add date-range selectors, loading and empty states to statistics dashboard
- style dashboard with summary tiles, SVG trend charts, and mobile-responsive layout

## Testing
- `dotnet build --configuration Release`
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release`


------
https://chatgpt.com/codex/tasks/task_b_68c81d7fe6cc832ca7a3538bfb5af2b1