### PR TITLE
feat: add notice management page with CRUD support

### DIFF
--- a/src/Web/NexaCRM.WebClient/Pages/NoticeManagementPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/NoticeManagementPage.razor
@@ -1,6 +1,217 @@
 @page "/support/notices"
+@using Microsoft.AspNetCore.Components.Forms
+@using NexaCRM.WebClient.Models.CustomerCenter
+@using NexaCRM.WebClient.Services.Interfaces
+@inject INoticeService NoticeService
+@inject IJSRuntime JSRuntime
 
 <ResponsivePage>
     <h3>Notice Management</h3>
-    <p>Create and manage announcements.</p>
+
+    <div class="search-bar mb-3">
+        <input class="form-control flex-grow-1" placeholder="Search notices" value="@searchTerm" @oninput="OnSearchChanged" />
+        <button class="btn btn-success" @onclick="ShowCreateModal">
+            <span class="oi oi-plus"></span> New Notice
+        </button>
+    </div>
+
+    @if (PagedNotices.Any())
+    {
+        <div class="table-responsive d-none d-md-block">
+            <table class="table align-middle">
+                <thead>
+                    <tr>
+                        <th>Title</th>
+                        <th>Content</th>
+                        <th class="text-end"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var notice in PagedNotices)
+                    {
+                        <tr>
+                            <td>@notice.Title</td>
+                            <td>@notice.Content</td>
+                            <td class="text-end">
+                                <div class="btn-group btn-group-sm">
+                                    <button class="btn btn-primary" @onclick="() => ShowEditModal(notice)">
+                                        <span class="oi oi-pencil"></span>
+                                    </button>
+                                    <button class="btn btn-danger" @onclick="() => DeleteNotice(notice.Id)">
+                                        <span class="oi oi-trash"></span>
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+
+        <div class="d-md-none">
+            @foreach (var notice in PagedNotices)
+            {
+                <div class="card mb-2">
+                    <div class="card-body">
+                        <h5 class="card-title">@notice.Title</h5>
+                        <p class="card-text">@notice.Content</p>
+                        <div class="d-flex justify-content-end">
+                            <button class="btn btn-sm btn-primary me-1" @onclick="() => ShowEditModal(notice)">
+                                <span class="oi oi-pencil"></span>
+                            </button>
+                            <button class="btn btn-sm btn-danger" @onclick="() => DeleteNotice(notice.Id)">
+                                <span class="oi oi-trash"></span>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+
+        @if (TotalPages > 1)
+        {
+            <nav>
+                <ul class="pagination">
+                    <li class="page-item @(currentPage == 1 ? "disabled" : string.Empty)">
+                        <button class="page-link" @onclick="PreviousPage">Prev</button>
+                    </li>
+                    @for (int i = 1; i <= TotalPages; i++)
+                    {
+                        <li class="page-item @(currentPage == i ? "active" : string.Empty)">
+                            <button class="page-link" @onclick="() => GoToPage(i)">@i</button>
+                        </li>
+                    }
+                    <li class="page-item @(currentPage == TotalPages ? "disabled" : string.Empty)">
+                        <button class="page-link" @onclick="NextPage">Next</button>
+                    </li>
+                </ul>
+            </nav>
+        }
+    }
+    else
+    {
+        <p>No notices found.</p>
+    }
 </ResponsivePage>
+
+@if (showModal)
+{
+    <div class="modal-backdrop" @onclick="CloseModal">
+        <div class="modal-content" @onclick:stopPropagation="true">
+            <EditForm OnValidSubmit="SaveNotice">
+                <div class="mb-3">
+                    <label class="form-label">Title</label>
+                    <InputText class="form-control" @bind-Value="editTitle" />
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Content</label>
+                    <InputTextArea class="form-control" @bind-Value="editContent" />
+                </div>
+                <div class="text-end">
+                    <button type="submit" class="btn btn-primary me-2">Save</button>
+                    <button type="button" class="btn btn-secondary" @onclick="CloseModal">Cancel</button>
+                </div>
+            </EditForm>
+        </div>
+    </div>
+}
+
+@code {
+    private List<Notice> notices = new();
+    private string searchTerm = string.Empty;
+    private int currentPage = 1;
+    private const int PageSize = 5;
+    private bool showModal;
+    private int? editingId;
+    private string editTitle = string.Empty;
+    private string editContent = string.Empty;
+
+    private IEnumerable<Notice> FilteredNotices =>
+        string.IsNullOrWhiteSpace(searchTerm)
+            ? notices
+            : notices.Where(n => n.Title.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ||
+                                 n.Content.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
+
+    private int TotalPages => (int)Math.Ceiling(FilteredNotices.Count() / (double)PageSize);
+
+    private IEnumerable<Notice> PagedNotices =>
+        FilteredNotices.Skip((currentPage - 1) * PageSize).Take(PageSize);
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadNotices();
+    }
+
+    private async Task LoadNotices()
+    {
+        notices = (await NoticeService.GetNoticesAsync()).ToList();
+        currentPage = 1;
+    }
+
+    private void OnSearchChanged(ChangeEventArgs e)
+    {
+        searchTerm = e.Value?.ToString() ?? string.Empty;
+        currentPage = 1;
+    }
+
+    private void GoToPage(int page) => currentPage = page;
+
+    private void PreviousPage()
+    {
+        if (currentPage > 1)
+        {
+            currentPage--;
+        }
+    }
+
+    private void NextPage()
+    {
+        if (currentPage < TotalPages)
+        {
+            currentPage++;
+        }
+    }
+
+    private void ShowCreateModal()
+    {
+        editingId = null;
+        editTitle = string.Empty;
+        editContent = string.Empty;
+        showModal = true;
+    }
+
+    private void ShowEditModal(Notice notice)
+    {
+        editingId = notice.Id;
+        editTitle = notice.Title;
+        editContent = notice.Content;
+        showModal = true;
+    }
+
+    private void CloseModal() => showModal = false;
+
+    private async Task SaveNotice()
+    {
+        if (editingId.HasValue)
+        {
+            await NoticeService.UpdateNoticeAsync(new Notice(editingId.Value, editTitle, editContent));
+        }
+        else
+        {
+            await NoticeService.CreateNoticeAsync(new Notice(0, editTitle, editContent));
+        }
+
+        showModal = false;
+        await LoadNotices();
+    }
+
+    private async Task DeleteNotice(int id)
+    {
+        if (await JSRuntime.InvokeAsync<bool>("confirm", "Delete this notice?"))
+        {
+            await NoticeService.DeleteNoticeAsync(id);
+            await LoadNotices();
+        }
+    }
+}
+

--- a/src/Web/NexaCRM.WebClient/Pages/NoticeManagementPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/NoticeManagementPage.razor.css
@@ -1,0 +1,47 @@
+/* Search bar */
+.search-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+/* Modal Styles */
+.modal-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background: white;
+    border-radius: 8px;
+    padding: 20px;
+    max-width: 600px;
+    width: 90%;
+    max-height: 80vh;
+    overflow-y: auto;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+@media (max-width: 576px) {
+    .search-bar {
+        flex-direction: column;
+    }
+
+    .search-bar button {
+        width: 100%;
+    }
+
+    .modal-content {
+        width: 95%;
+        padding: 15px;
+    }
+}
+

--- a/src/Web/NexaCRM.WebClient/Program.cs
+++ b/src/Web/NexaCRM.WebClient/Program.cs
@@ -44,6 +44,7 @@ builder.Services.AddScoped<IOrganizationService, OrganizationService>();
 builder.Services.AddScoped<IDbAdminService, DbAdminService>();
 builder.Services.AddScoped<IStatisticsService, StatisticsService>();
 builder.Services.AddScoped<ICustomerCenterService, CustomerCenterService>();
+builder.Services.AddScoped<INoticeService, NoticeService>();
 builder.Services.AddScoped<ISmsService, SmsService>();
 builder.Services.AddScoped<ISystemInfoService, SystemInfoService>();
 

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/INoticeService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/INoticeService.cs
@@ -1,0 +1,15 @@
+using NexaCRM.WebClient.Models.CustomerCenter;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+public interface INoticeService
+{
+    Task<IEnumerable<Notice>> GetNoticesAsync();
+    Task<Notice?> GetNoticeAsync(int id);
+    Task CreateNoticeAsync(Notice notice);
+    Task UpdateNoticeAsync(Notice notice);
+    Task DeleteNoticeAsync(int id);
+}
+

--- a/src/Web/NexaCRM.WebClient/Services/NoticeService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/NoticeService.cs
@@ -1,0 +1,49 @@
+using NexaCRM.WebClient.Models.CustomerCenter;
+using NexaCRM.WebClient.Services.Interfaces;
+
+namespace NexaCRM.WebClient.Services;
+
+public class NoticeService : INoticeService
+{
+    private readonly List<Notice> _notices = new()
+    {
+        new Notice(1, "Welcome", "Welcome to NexaCRM!"),
+        new Notice(2, "Maintenance", "System maintenance on Friday."),
+    };
+
+    private int _nextId = 3;
+
+    public Task<IEnumerable<Notice>> GetNoticesAsync() =>
+        Task.FromResult<IEnumerable<Notice>>(_notices);
+
+    public Task<Notice?> GetNoticeAsync(int id) =>
+        Task.FromResult(_notices.FirstOrDefault(n => n.Id == id));
+
+    public Task CreateNoticeAsync(Notice notice)
+    {
+        var newNotice = notice with { Id = _nextId++ };
+        _notices.Add(newNotice);
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateNoticeAsync(Notice notice)
+    {
+        var index = _notices.FindIndex(n => n.Id == notice.Id);
+        if (index >= 0)
+        {
+            _notices[index] = notice;
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteNoticeAsync(int id)
+    {
+        var notice = _notices.FirstOrDefault(n => n.Id == id);
+        if (notice is not null)
+        {
+            _notices.Remove(notice);
+        }
+        return Task.CompletedTask;
+    }
+}
+


### PR DESCRIPTION
## Summary
- list and search notices with pagination
- add modals for creating and editing notices via notice service
- enable notice deletion with confirmation prompts
- enhance mobile UX with responsive search bar and card layout

## Testing
- `dotnet build --configuration Release`
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release`


------
https://chatgpt.com/codex/tasks/task_b_68c81d8572e4832c84d89c749a46948f