### PR TITLE
feat: display system info with config and pdf links

### DIFF
--- a/src/Web/NexaCRM.WebClient/Models/SystemInfoModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/SystemInfoModels.cs
@@ -2,7 +2,7 @@ namespace NexaCRM.WebClient.Models.SystemInfo;
 
 public record SystemInfo(
     string Terms = "",
-    string CompanyContact = "",
-    string BusinessAddress = ""
+    string CompanyAddress = "",
+    string[] SupportContacts = null!
 );
 

--- a/src/Web/NexaCRM.WebClient/NexaCRM.WebClient.csproj
+++ b/src/Web/NexaCRM.WebClient/NexaCRM.WebClient.csproj
@@ -10,12 +10,13 @@
 	<!-- net8.0 타겟에만 Blazor WebAssembly 8.0 패키지 참조 -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<!-- Blazor WebAssembly 핵심 런타임 참조 -->
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
-		<!-- 개발 서버 도구 (PrivateAssets로 빌드 출력 미포함) -->
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0" PrivateAssets="all" />
-		<!-- Microsoft.AspNetCore.* 네임스페이스 정의 어셈블리 -->
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.0" />
-	</ItemGroup>
+                <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
+                <!-- 개발 서버 도구 (PrivateAssets로 빌드 출력 미포함) -->
+                <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0" PrivateAssets="all" />
+                <!-- Microsoft.AspNetCore.* 네임스페이스 정의 어셈블리 -->
+                <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
+                <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.0" />
+                <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.0" />
+                <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+        </ItemGroup>
 </Project>

--- a/src/Web/NexaCRM.WebClient/Pages/SystemInfoPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SystemInfoPage.razor
@@ -1,6 +1,48 @@
 @page "/system/info"
+@using NexaCRM.WebClient.Services.Interfaces
+@using NexaCRM.WebClient.Models.SystemInfo
+@inject ISystemInfoService SystemInfoService
 
 <ResponsivePage>
-    <h3>System Information</h3>
-    <p>View terms of service, company contact and address.</p>
+    <div class="container mx-auto p-4 space-y-6">
+        <h3 class="mb-4 text-center sm:text-left">System Information</h3>
+        @if (_info is null)
+        {
+            <p>Loading...</p>
+        }
+        else
+        {
+            <section class="system-info-section">
+                <h4 class="section-title">Terms of Service</h4>
+                <p class="section-content">@_info.Terms</p>
+                <a href="docs/terms.pdf" class="btn btn-primary download-link" download>Download Terms (PDF)</a>
+            </section>
+            <section class="system-info-section">
+                <h4 class="section-title">Company Address</h4>
+                <address class="section-content">@_info.CompanyAddress</address>
+            </section>
+            <section class="system-info-section">
+                <h4 class="section-title">Support Contacts</h4>
+                <ul class="section-list">
+                    @if (_info.SupportContacts is not null)
+                    {
+                        @foreach (var contact in _info.SupportContacts)
+                        {
+                            <li>@contact</li>
+                        }
+                    }
+                </ul>
+                <a href="docs/privacy.pdf" class="btn btn-secondary download-link" download>Download Privacy Policy (PDF)</a>
+            </section>
+        }
+    </div>
 </ResponsivePage>
+
+@code {
+    private SystemInfo? _info;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _info = await SystemInfoService.GetSystemInfoAsync();
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/SystemInfoPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/SystemInfoPage.razor.css
@@ -1,0 +1,41 @@
+/* SystemInfoPage responsive styles */
+
+.system-info-section {
+    background-color: var(--surface-color);
+    border-radius: 0.5rem;
+    padding: 1rem;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.section-title {
+    font-size: 1.125rem;
+    margin-bottom: 0.5rem;
+}
+
+.section-content {
+    margin-bottom: 0.5rem;
+}
+
+.section-list {
+    margin-left: 1.25rem;
+    margin-bottom: 0.5rem;
+}
+
+.download-link {
+    display: block;
+    width: 100%;
+    text-align: center;
+    margin-top: 0.75rem;
+}
+
+@media (min-width: 640px) {
+    .system-info-section {
+        padding: 1.5rem;
+    }
+
+    .download-link {
+        width: auto;
+        display: inline-block;
+    }
+}
+

--- a/src/Web/NexaCRM.WebClient/Services/SystemInfoService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SystemInfoService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using NexaCRM.WebClient.Models.SystemInfo;
 using NexaCRM.WebClient.Services.Interfaces;
 using System.Threading.Tasks;
@@ -6,7 +7,17 @@ namespace NexaCRM.WebClient.Services;
 
 public class SystemInfoService : ISystemInfoService
 {
-    public Task<SystemInfo> GetSystemInfoAsync() =>
-        Task.FromResult(new SystemInfo());
+    private readonly IConfiguration _configuration;
+
+    public SystemInfoService(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public Task<SystemInfo> GetSystemInfoAsync()
+    {
+        var info = _configuration.GetSection("SystemInfo").Get<SystemInfo>() ?? new SystemInfo();
+        return Task.FromResult(info);
+    }
 }
 

--- a/src/Web/NexaCRM.WebClient/wwwroot/appsettings.json
+++ b/src/Web/NexaCRM.WebClient/wwwroot/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "SystemInfo": {
+    "Terms": "All services are provided as-is.",
+    "CompanyAddress": "123 Nexa Street, Seoul",
+    "SupportContacts": [
+      "support@nexa.example",
+      "+82-2-1234-5678"
+    ]
+  }
+}

--- a/src/Web/NexaCRM.WebClient/wwwroot/docs/privacy.pdf
+++ b/src/Web/NexaCRM.WebClient/wwwroot/docs/privacy.pdf
@@ -1,0 +1,36 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 52 >>
+stream
+BT /F1 18 Tf 10 100 Td (Privacy Policy) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+6 0 obj
+<< /Font << /F1 5 0 R >> >>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000111 00000 n 
+0000000212 00000 n 
+0000000321 00000 n 
+0000000383 00000 n 
+trailer
+<< /Root 1 0 R /Size 7 >>
+startxref
+438
+%%EOF

--- a/src/Web/NexaCRM.WebClient/wwwroot/docs/terms.pdf
+++ b/src/Web/NexaCRM.WebClient/wwwroot/docs/terms.pdf
@@ -1,0 +1,36 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT /F1 24 Tf 10 100 Td (Terms) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+6 0 obj
+<< /Font << /F1 5 0 R >> >>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000111 00000 n 
+0000000212 00000 n 
+0000000311 00000 n 
+0000000373 00000 n 
+trailer
+<< /Root 1 0 R /Size 7 >>
+startxref
+428
+%%EOF


### PR DESCRIPTION
## Summary
- load terms, address, and support contacts from `appsettings.json` via `ISystemInfoService`
- render responsive sections on `SystemInfoPage` with download links for terms and privacy PDFs
- improve mobile layout of system info sections with dedicated responsive CSS

## Testing
- `dotnet restore`
- `dotnet build --configuration Release`
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release`


------
https://chatgpt.com/codex/tasks/task_b_68c81d8a96dc832c856d89c162aa6829