### PR TITLE
feat: display organization stats

### DIFF
--- a/src/Web/NexaCRM.WebClient/Pages/OrganizationStatsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/OrganizationStatsPage.razor
@@ -1,6 +1,74 @@
 @page "/organization/stats"
+@using Microsoft.Extensions.Localization
+@using NexaCRM.WebClient.Models.Organization
+@using NexaCRM.WebClient.Services.Interfaces
+@using System.Linq
+@inject IOrganizationService OrganizationService
+@inject IStringLocalizer<OrganizationStatsPage> Localizer
 
 <ResponsivePage>
-    <h3>Organization Statistics</h3>
-    <p>View statistics by company, team and member.</p>
+    <h3>@Localizer["OrganizationStatistics"]</h3>
+    <p>@Localizer["StatisticsDescription"]</p>
+
+    @if (stats == null)
+    {
+        <div class="d-flex justify-content-center">
+            <div class="spinner-border" role="status">
+                <span class="visually-hidden">@Localizer["Loading"]</span>
+            </div>
+        </div>
+    }
+    else if (!stats.Any())
+    {
+        <p>@Localizer["NoStatistics"]</p>
+    }
+    else
+    {
+        <div class="desktop-table-view">
+            <div class="table-responsive">
+                <table class="table table-striped">
+                    <thead>
+                        <tr>
+                            <th>@Localizer["UnitName"]</th>
+                            <th>@Localizer["MemberCount"]</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var stat in stats)
+                        {
+                            <tr>
+                                <td>@stat.UnitName</td>
+                                <td>@stat.MemberCount</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="mobile-card-view">
+            @foreach (var stat in stats)
+            {
+                <div class="stat-card">
+                    <div class="card-info-row">
+                        <span class="card-info-label">@Localizer["UnitName"]</span>
+                        <span class="card-info-value">@stat.UnitName</span>
+                    </div>
+                    <div class="card-info-row">
+                        <span class="card-info-label">@Localizer["MemberCount"]</span>
+                        <span class="card-info-value">@stat.MemberCount</span>
+                    </div>
+                </div>
+            }
+        </div>
+    }
 </ResponsivePage>
+
+@code {
+    private IEnumerable<OrganizationStats>? stats;
+
+    protected override async Task OnInitializedAsync()
+    {
+        stats = await OrganizationService.GetOrganizationStatsAsync();
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/OrganizationStatsPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/OrganizationStatsPage.razor.css
@@ -1,0 +1,40 @@
+.desktop-table-view {
+}
+
+.mobile-card-view {
+    display: none;
+}
+
+.stat-card {
+    background-color: #fff;
+    border: 1px solid #e7ecf3;
+    border-radius: 8px;
+    padding: 16px;
+    margin-bottom: 16px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.card-info-row {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.9rem;
+    margin-bottom: 8px;
+}
+
+.card-info-label {
+    color: #6c757d;
+}
+
+.card-info-value {
+    font-weight: 500;
+}
+
+@media (max-width: 767.98px) {
+    .desktop-table-view {
+        display: none;
+    }
+
+    .mobile-card-view {
+        display: block;
+    }
+}


### PR DESCRIPTION
## Summary
- fetch organization stats via `GetOrganizationStatsAsync`
- show localized table with loading and empty states
- improve mobile UX with responsive table and card layout

## Testing
- `dotnet build NexaCrmSolution.sln --configuration Release`
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release`


------
https://chatgpt.com/codex/tasks/task_b_68c821758c2c832c880114e5df2fd108