### PR TITLE
feat: add organization structure edit form

### DIFF
--- a/src/Web/NexaCRM.WebClient/Models/OrganizationModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/OrganizationModels.cs
@@ -1,6 +1,16 @@
 namespace NexaCRM.WebClient.Models.Organization;
 
-public record OrganizationUnit(int Id, string Name, int? ParentId);
+using System.ComponentModel.DataAnnotations;
+
+public class OrganizationUnit
+{
+    public int Id { get; set; }
+
+    [Required]
+    public string Name { get; set; } = string.Empty;
+
+    public int? ParentId { get; set; }
+}
 
 public record OrganizationStats(string UnitName, int MemberCount);
 

--- a/src/Web/NexaCRM.WebClient/Pages/OrganizationStructurePage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/OrganizationStructurePage.razor
@@ -1,6 +1,62 @@
 @page "/organization/structure"
+@using NexaCRM.WebClient.Models.Organization
+@using NexaCRM.WebClient.Services.Interfaces
+@using Microsoft.AspNetCore.Components.Forms
+@using System.Linq
+@inject IOrganizationService OrganizationService
 
 <ResponsivePage>
     <h3>Organization Structure</h3>
     <p>Manage production companies, teams and members.</p>
+
+    <EditForm Model="unit" OnValidSubmit="SaveUnit" class="row g-3">
+        <DataAnnotationsValidator />
+        <div class="col-12 col-md-6">
+            <label for="name" class="form-label">Name</label>
+            <InputText id="name" class="form-control" @bind-Value="unit.Name" />
+            <ValidationMessage For="@(() => unit.Name)" />
+        </div>
+        <div class="col-12 col-md-6">
+            <label for="parent" class="form-label">Parent Unit</label>
+            <InputSelect id="parent" class="form-select" @bind-Value="unit.ParentId">
+                <option value="">(None)</option>
+                @foreach (var existing in units)
+                {
+                    <option value="@existing.Id">@existing.Name</option>
+                }
+            </InputSelect>
+        </div>
+        <div class="col-12 text-md-end">
+            <button type="submit" class="btn btn-primary w-100 w-md-auto">Save</button>
+        </div>
+    </EditForm>
+
+    @if (units.Any())
+    {
+        <div class="list-group unit-list mt-4">
+            @foreach (var existing in units)
+            {
+                <div class="list-group-item unit-list-item">@existing.Name</div>
+            }
+        </div>
+    }
 </ResponsivePage>
+
+@code {
+    private List<OrganizationUnit> units = new();
+    private OrganizationUnit unit = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        var existing = await OrganizationService.GetOrganizationStructureAsync();
+        units = existing.ToList();
+    }
+
+    private async Task SaveUnit()
+    {
+        await OrganizationService.SaveOrganizationUnitAsync(unit);
+        unit = new OrganizationUnit();
+        var existing = await OrganizationService.GetOrganizationStructureAsync();
+        units = existing.ToList();
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/OrganizationStructurePage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/OrganizationStructurePage.razor.css
@@ -1,0 +1,16 @@
+/* OrganizationStructurePage Mobile Responsive Styles */
+
+.unit-list {
+    max-width: 600px;
+}
+
+@media (max-width: 576px) {
+    .unit-list-item {
+        padding: 0.75rem 1rem;
+        font-size: 1rem;
+    }
+
+    .unit-list {
+        max-width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary
- make OrganizationUnit name required for validation
- enhance OrganizationStructurePage with responsive form and mobile list styling
- refresh units list after saving new organization unit

## Testing
- `dotnet build --configuration Release`
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release`


------
https://chatgpt.com/codex/tasks/task_b_68c82174899c832c87d2db22a59725cc