### PR TITLE
feat: enable custom report definitions with preview

### DIFF
--- a/SERVICE_INTERFACES_REFERENCE.md
+++ b/SERVICE_INTERFACES_REFERENCE.md
@@ -440,6 +440,9 @@ private async Task LaunchCampaign()
 ```csharp
 public interface IReportService
 {
+    Task SaveReportDefinitionAsync(ReportDefinition definition);
+    Task<IEnumerable<ReportDefinition>> GetReportDefinitionsAsync();
+    Task<ReportData> GenerateReportAsync(ReportDefinition definition);
     Task<ReportData> GetQuarterlyPerformanceAsync();
     Task<ReportData> GetLeadSourceAnalyticsAsync();
     Task<ReportData> GetTicketVolumeAsync();
@@ -461,6 +464,21 @@ public interface IReportService
 - **Return Type**: `Task<ReportData>`
 - **Parameters**: None
 - **Includes**: Lead sources, conversion rates, and ROI by channel
+
+**SaveReportDefinitionAsync(ReportDefinition)**
+- **Purpose**: Persists a custom report definition
+- **Return Type**: `Task`
+- **Parameters**: `ReportDefinition` definition
+
+**GetReportDefinitionsAsync()**
+- **Purpose**: Retrieves saved report definitions
+- **Return Type**: `Task<IEnumerable<ReportDefinition>>`
+- **Parameters**: None
+
+**GenerateReportAsync(ReportDefinition)**
+- **Purpose**: Generates report data based on a definition
+- **Return Type**: `Task<ReportData>`
+- **Parameters**: `ReportDefinition` definition
 
 **GetTicketVolumeAsync()**
 - **Purpose**: Reports on support ticket volume and trends

--- a/WEB_CLIENT_DOCUMENTATION.md
+++ b/WEB_CLIENT_DOCUMENTATION.md
@@ -219,7 +219,7 @@ builder.Services.AddScoped<IActivityService, MockActivityService>();
 - **ContactsPage.razor**: Contact management interface with search and filtering
 - **SalesPipelinePage.razor**: Visual deal pipeline with drag-and-drop functionality
 - **TasksPage.razor**: Task management interface with assignment and tracking
-- **ReportsPage.razor**: Comprehensive reporting dashboard with multiple report types
+- **ReportsPage.razor**: Custom report builder with field selection, filters, saved definitions, preview, and mobile-friendly layout
 
 **Support and Service Pages:**
 - **CustomerSupportDashboard.razor**: Support team dashboard with ticket overview

--- a/src/Web/NexaCRM.WebClient/Models/ReportDefinition.cs
+++ b/src/Web/NexaCRM.WebClient/Models/ReportDefinition.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace NexaCRM.WebClient.Models
+{
+    public class ReportDefinition
+    {
+        public string? Name { get; set; }
+        public List<string> SelectedFields { get; set; } = new();
+        public Dictionary<string, string> Filters { get; set; } = new();
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/ReportsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/ReportsPage.razor
@@ -1,225 +1,116 @@
 @page "/reports-page"
 @using Microsoft.Extensions.Localization
+@using NexaCRM.WebClient.Models
+@using NexaCRM.WebClient.Services.Interfaces
 @inject IStringLocalizer<ReportsPage> Localizer
+@inject IReportService ReportService
 
-<div
-    class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden"
-    style="--select-button-svg: url('data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724px%27 height=%2724px%27 fill=%27rgb(77,106,153)%27 viewBox=%270 0 256 256%27%3e%3cpath d=%27M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48A8,8,0,0,0,85.66,85.66Z%27%3e%3c/path%3e%3c/svg%3e'); font-family: Inter, &quot;Noto Sans&quot;, sans-serif;"
->
-    <div class="layout-container flex h-full grow flex-col">
-    <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-10 py-3">
-        <div class="flex items-center gap-8">
-        <div class="flex items-center gap-4 text-[#0e131b]">
-            <div class="size-4">
-            <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M24 18.4228L42 11.475V34.3663C42 34.7796 41.7457 35.1504 41.3601 35.2992L24 42V18.4228Z"
-                fill="currentColor"
-                ></path>
-                <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M24 8.18819L33.4123 11.574L24 15.2071L14.5877 11.574L24 8.18819ZM9 15.8487L21 20.4805V37.6263L9 32.9945V15.8487ZM27 37.6263V20.4805L39 15.8487V32.9945L27 37.6263ZM25.354 2.29885C24.4788 1.98402 23.5212 1.98402 22.646 2.29885L4.98454 8.65208C3.7939 9.08038 3 10.2097 3 11.475V34.3663C3 36.0196 4.01719 37.5026 5.55962 38.098L22.9197 44.7987C23.6149 45.0671 24.3851 45.0671 25.0803 44.7987L42.4404 38.098C43.9828 37.5026 45 36.0196 45 34.3663V11.475C45 10.2097 44.2061 9.08038 43.0155 8.65208L25.354 2.29885Z"
-                fill="currentColor"
-                ></path>
-            </svg>
-            </div>
-            <h2 class="text-[#0e131b] text-lg font-bold leading-tight tracking-[-0.015em]">@Localizer["SalesPro"]</h2>
-        </div>
-        <div class="flex items-center gap-9">
-            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Dashboard"]</a>
-            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Contacts"]</a>
-            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Deals"]</a>
-            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Tasks"]</a>
-            <a class="text-[#0e131b] text-sm font-medium leading-normal" href="#">@Localizer["Reports"]</a>
-        </div>
-        </div>
-        <div class="flex flex-1 justify-end gap-8">
-        <label class="flex flex-col min-w-40 !h-10 max-w-64">
-            <div class="flex w-full flex-1 items-stretch rounded-lg h-full">
-            <div
-                class="text-[#4d6a99] flex border-none bg-[#e7ecf3] items-center justify-center pl-4 rounded-l-lg border-r-0"
-                data-icon="MagnifyingGlass"
-                data-size="24px"
-                data-weight="regular"
-            >
-                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
-                <path
-                    d="M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z"
-                ></path>
-                </svg>
-            </div>
-            <input
-                placeholder='@Localizer["Search"]'
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border-none bg-[#e7ecf3] focus:border-none h-full placeholder:text-[#4d6a99] px-4 rounded-l-none border-l-0 pl-2 text-base font-normal leading-normal"
-                value=""
-            />
-            </div>
-        </label>
-        <button
-            class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 bg-[#e7ecf3] text-[#0e131b] gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
-        >
-            <div class="text-[#0e131b]" data-icon="Bell" data-size="20px" data-weight="regular">
-            <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
-                <path
-                d="M221.8,175.94C216.25,166.38,208,139.33,208,104a80,80,0,1,0-160,0c0,35.34-8.26,62.38-13.81,71.94A16,16,0,0,0,48,200H88.81a40,40,0,0,0,78.38,0H208a16,16,0,0,0,13.8-24.06ZM128,216a24,24,0,0,1-22.62-16h45.24A24,24,0,0,1,128,216ZM48,184c7.7-13.24,16-43.92,16-80a64,64,0,1,1,128,0c0,36.05,8.28,66.73,16,80Z"
-                ></path>
-            </svg>
-            </div>
-        </button>
-        <div
-            class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
-            style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuCVbBY-9ye3VEUHqTnyR4PYWraio51rDBrExbaHf3kJpN4thIHaSoMgQfsvV28mHsssFsn4Y5FX2iSomAIBaQsgvXloM_Vn8xKUiKMXOjd5dWyrfSWzrSeqhzR9FaruDo-_E0jlHVB7hguwExVfBKbVe0TzB6LrewfRar1rDFVyw6E6VKhUdh1YhBwxlqkP1V6pQoQKp7uady7ufQ9szbtBYDwrbPE2Lb8-3wKFgDx84Q_XoIN4B4zGX5lwGeBvqzXXogg-cBvbTJMJ");'
-        ></div>
-        </div>
-    </header>
-    <div class="px-40 flex flex-1 justify-center py-5">
-        <div class="layout-content-container flex flex-col max-w-[960px] flex-1">
-        <div class="flex flex-wrap justify-between gap-3 p-4">
-            <p class="text-[#0e131b] tracking-light text-[32px] font-bold leading-tight min-w-72">@Localizer["ReportsTitle"]</p>
-            <button
-            class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-8 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-medium leading-normal"
-            >
-            <span class="truncate">@Localizer["NewReport"]</span>
-            </button>
-        </div>
-        <h2 class="text-[#0e131b] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">@Localizer["ReportBuilder"]</h2>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <h2 class="text-[#0e131b] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">@Localizer["GroupingAndSorting"]</h2>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <h2 class="text-[#0e131b] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">@Localizer["Visualization"]</h2>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-            <label class="flex flex-col min-w-40 flex-1">
-            <select
-                class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border border-[#d0d9e7] bg-slate-50 focus:border-[#d0d9e7] h-14 bg-[image:--select-button-svg] placeholder:text-[#4d6a99] p-[15px] text-base font-normal leading-normal"
-            >
-                <option value="one"></option>
-                <option value="two">two</option>
-                <option value="three">three</option>
-            </select>
-            </label>
-        </div>
-        <div class="flex justify-stretch">
-            <div class="flex flex-1 gap-3 flex-wrap px-4 py-3 justify-start">
-            <button
-                class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-bold leading-normal tracking-[0.015em]"
-            >
-                <span class="truncate">@Localizer["ExportPDF"]</span>
-            </button>
-            <button
-                class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-bold leading-normal tracking-[0.015em]"
-            >
-                <span class="truncate">@Localizer["ExportCSV"]</span>
-            </button>
-            </div>
-        </div>
-        <div class="flex px-4 py-3 justify-start">
-            <button
-            class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-bold leading-normal tracking-[0.015em]"
-            >
-            <span class="truncate">@Localizer["ScheduleReport"]</span>
-            </button>
-        </div>
+<h1 class="text-2xl font-bold mb-4">@Localizer["ReportsTitle"]</h1>
+
+<EditForm Model="currentDefinition">
+    <InputText @bind-Value="currentDefinition.Name" placeholder='@Localizer["ReportName"]' class="form-input mb-2" />
+    <div class="report-form-row mb-2">
+        <InputText @bind-Value="newField" placeholder='@Localizer["Field"]' class="form-input flex-1" />
+        <button type="button" class="px-2 py-1 bg-[#e7ecf3] rounded" @onclick="AddField">@Localizer["Add"]</button>
+    </div>
+    <ul class="mb-2">
+        @foreach (var field in currentDefinition.SelectedFields)
+        {
+            <li>@field</li>
+        }
+    </ul>
+    <div class="report-form-row mb-2">
+        <InputText @bind-Value="filterKey" placeholder='@Localizer["FilterKey"]' class="form-input flex-1" />
+        <InputText @bind-Value="filterValue" placeholder='@Localizer["FilterValue"]' class="form-input flex-1" />
+        <button type="button" class="px-2 py-1 bg-[#e7ecf3] rounded" @onclick="AddFilter">@Localizer["Add"]</button>
+    </div>
+    <ul class="mb-2">
+        @foreach (var filter in currentDefinition.Filters)
+        {
+            <li>@filter.Key: @filter.Value</li>
+        }
+    </ul>
+    <div class="report-actions mb-4">
+        <button type="button" class="px-3 py-1 bg-[#e7ecf3] rounded" @onclick="SaveDefinition">@Localizer["SaveDefinition"]</button>
+        <button type="button" class="px-3 py-1 bg-[#e7ecf3] rounded" @onclick="GenerateReport">@Localizer["GenerateReport"]</button>
+    </div>
+</EditForm>
+
+<h2 class="text-xl font-bold mb-2">@Localizer["SavedReports"]</h2>
+<ul class="mb-4">
+    @foreach (var def in savedDefinitions)
+    {
+        <li><button class="underline" @onclick="() => LoadDefinition(def)">@def.Name</button></li>
+    }
+</ul>
+
+<h2 class="text-xl font-bold mb-2">@Localizer["Preview"]</h2>
+@if (preview != null)
+{
+    <div class="report-preview">
+        <h3 class="font-bold mb-2">@preview.Title</h3>
+        <div class="report-table-container">
+            <table class="table-auto border-collapse w-full">
+                <thead>
+                    <tr><th class="border px-2">Field</th><th class="border px-2">Value</th></tr>
+                </thead>
+                <tbody>
+                    @foreach (var item in preview.Data)
+                    {
+                        <tr><td class="border px-2">@item.Key</td><td class="border px-2">@item.Value</td></tr>
+                    }
+                </tbody>
+            </table>
         </div>
     </div>
-    </div>
-</div>
+}
+
+@code {
+    private ReportDefinition currentDefinition = new();
+    private List<ReportDefinition> savedDefinitions = new();
+    private ReportData? preview;
+    private string? newField;
+    private string? filterKey;
+    private string? filterValue;
+
+    protected override async System.Threading.Tasks.Task OnInitializedAsync()
+    {
+        savedDefinitions = (await ReportService.GetReportDefinitionsAsync()).ToList();
+    }
+
+    private void AddField()
+    {
+        if (!string.IsNullOrWhiteSpace(newField))
+        {
+            currentDefinition.SelectedFields.Add(newField);
+            newField = string.Empty;
+        }
+    }
+
+    private void AddFilter()
+    {
+        if (!string.IsNullOrWhiteSpace(filterKey) && filterValue is not null)
+        {
+            currentDefinition.Filters[filterKey] = filterValue;
+            filterKey = filterValue = string.Empty;
+        }
+    }
+
+    private async System.Threading.Tasks.Task SaveDefinition()
+    {
+        await ReportService.SaveReportDefinitionAsync(currentDefinition);
+        savedDefinitions = (await ReportService.GetReportDefinitionsAsync()).ToList();
+        currentDefinition = new ReportDefinition();
+    }
+
+    private async System.Threading.Tasks.Task LoadDefinition(ReportDefinition def)
+    {
+        currentDefinition = def;
+        await GenerateReport();
+    }
+
+    private async System.Threading.Tasks.Task GenerateReport()
+    {
+        preview = await ReportService.GenerateReportAsync(currentDefinition);
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/ReportsPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/ReportsPage.razor.css
@@ -1,0 +1,32 @@
+/* ReportsPage mobile responsive styles */
+
+.report-form-row {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.report-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.report-table-container {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+@media (max-width: 640px) {
+    .report-form-row,
+    .report-actions {
+        flex-direction: column;
+    }
+
+    .report-form-row > *,
+    .report-actions > * {
+        width: 100%;
+    }
+
+    .report-actions button {
+        width: 100%;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/ReportsPage.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/ReportsPage.en-US.resx
@@ -45,4 +45,31 @@
   <data name="ScheduleReport" xml:space="preserve">
     <value>Schedule Report</value>
   </data>
+  <data name="ReportName" xml:space="preserve">
+    <value>Report Name</value>
+  </data>
+  <data name="Field" xml:space="preserve">
+    <value>Field</value>
+  </data>
+  <data name="Add" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="FilterKey" xml:space="preserve">
+    <value>Filter Key</value>
+  </data>
+  <data name="FilterValue" xml:space="preserve">
+    <value>Filter Value</value>
+  </data>
+  <data name="SaveDefinition" xml:space="preserve">
+    <value>Save Definition</value>
+  </data>
+  <data name="SavedReports" xml:space="preserve">
+    <value>Saved Reports</value>
+  </data>
+  <data name="GenerateReport" xml:space="preserve">
+    <value>Generate Report</value>
+  </data>
+  <data name="Preview" xml:space="preserve">
+    <value>Preview</value>
+  </data>
 </root>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/ReportsPage.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/ReportsPage.ko-KR.resx
@@ -45,4 +45,31 @@
   <data name="ScheduleReport" xml:space="preserve">
     <value>보고서 예약</value>
   </data>
+  <data name="ReportName" xml:space="preserve">
+    <value>보고서 이름</value>
+  </data>
+  <data name="Field" xml:space="preserve">
+    <value>필드</value>
+  </data>
+  <data name="Add" xml:space="preserve">
+    <value>추가</value>
+  </data>
+  <data name="FilterKey" xml:space="preserve">
+    <value>필터 키</value>
+  </data>
+  <data name="FilterValue" xml:space="preserve">
+    <value>필터 값</value>
+  </data>
+  <data name="SaveDefinition" xml:space="preserve">
+    <value>정의 저장</value>
+  </data>
+  <data name="SavedReports" xml:space="preserve">
+    <value>저장된 보고서</value>
+  </data>
+  <data name="GenerateReport" xml:space="preserve">
+    <value>보고서 생성</value>
+  </data>
+  <data name="Preview" xml:space="preserve">
+    <value>미리보기</value>
+  </data>
 </root>

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IReportService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IReportService.cs
@@ -1,14 +1,17 @@
+using System.Collections.Generic;
 using NexaCRM.WebClient.Models;
-using System.Threading.Tasks;
 
 namespace NexaCRM.WebClient.Services.Interfaces
 {
     public interface IReportService
     {
-        Task<ReportData> GetQuarterlyPerformanceAsync();
-        Task<ReportData> GetLeadSourceAnalyticsAsync();
-        Task<ReportData> GetTicketVolumeAsync();
-        Task<ReportData> GetResolutionRateAsync();
-        Task<ReportData> GetTicketsByCategoryAsync();
+        System.Threading.Tasks.Task SaveReportDefinitionAsync(ReportDefinition definition);
+        System.Threading.Tasks.Task<IEnumerable<ReportDefinition>> GetReportDefinitionsAsync();
+        System.Threading.Tasks.Task<ReportData> GenerateReportAsync(ReportDefinition definition);
+        System.Threading.Tasks.Task<ReportData> GetQuarterlyPerformanceAsync();
+        System.Threading.Tasks.Task<ReportData> GetLeadSourceAnalyticsAsync();
+        System.Threading.Tasks.Task<ReportData> GetTicketVolumeAsync();
+        System.Threading.Tasks.Task<ReportData> GetResolutionRateAsync();
+        System.Threading.Tasks.Task<ReportData> GetTicketsByCategoryAsync();
     }
 }

--- a/src/Web/NexaCRM.WebClient/Services/Mock/MockReportService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Mock/MockReportService.cs
@@ -1,11 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using NexaCRM.WebClient.Models;
 using NexaCRM.WebClient.Services.Interfaces;
-using System.Collections.Generic;
 
 namespace NexaCRM.WebClient.Services.Mock
 {
     public class MockReportService : IReportService
     {
+        private readonly List<ReportDefinition> _definitions = new();
+
+        public System.Threading.Tasks.Task SaveReportDefinitionAsync(ReportDefinition definition)
+        {
+            _definitions.Add(definition);
+            return System.Threading.Tasks.Task.CompletedTask;
+        }
+
+        public System.Threading.Tasks.Task<IEnumerable<ReportDefinition>> GetReportDefinitionsAsync()
+        {
+            return System.Threading.Tasks.Task.FromResult<IEnumerable<ReportDefinition>>(_definitions);
+        }
+
+        public System.Threading.Tasks.Task<ReportData> GenerateReportAsync(ReportDefinition definition)
+        {
+            var data = new ReportData
+            {
+                Title = definition.Name,
+                Data = definition.SelectedFields.ToDictionary(f => f, f => (double)Random.Shared.Next(10, 100))
+            };
+
+            return System.Threading.Tasks.Task.FromResult(data);
+        }
+
         public System.Threading.Tasks.Task<ReportData> GetQuarterlyPerformanceAsync()
         {
             var data = new ReportData

--- a/tests/BlazorWebApp.Tests/MockReportServiceTests.cs
+++ b/tests/BlazorWebApp.Tests/MockReportServiceTests.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Linq;
+using NexaCRM.WebClient.Models;
+using NexaCRM.WebClient.Services.Mock;
+
+namespace BlazorWebApp.Tests;
+
+public class MockReportServiceTests
+{
+    [Fact]
+    public async System.Threading.Tasks.Task SaveReportDefinitionAsync_PersistsDefinition()
+    {
+        var service = new MockReportService();
+        var def = new ReportDefinition { Name = "Test", SelectedFields = new List<string> { "A" } };
+        await service.SaveReportDefinitionAsync(def);
+        var defs = await service.GetReportDefinitionsAsync();
+        Assert.Contains(defs, d => d.Name == "Test");
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GenerateReportAsync_ReturnsDataForFields()
+    {
+        var service = new MockReportService();
+        var def = new ReportDefinition { Name = "Test", SelectedFields = new List<string> { "Field1", "Field2" } };
+        var data = await service.GenerateReportAsync(def);
+        Assert.Equal(def.SelectedFields.Count, data.Data!.Count);
+        foreach (var field in def.SelectedFields)
+        {
+            Assert.True(data.Data.ContainsKey(field));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ReportDefinition` model to capture selected fields and filters
- extend `IReportService` and mock implementation to save and generate reports
- build reports page with form, saved report list, and preview rendering
- document and localize new reporting features
- optimize reports page for mobile with responsive layout

## Testing
- `dotnet build --configuration Release`
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release`


------
https://chatgpt.com/codex/tasks/task_b_68c81d81c624832cb864a02cb2f42963