### PR TITLE
feat: add SMS history table with filters and export

### DIFF
--- a/src/Web/NexaCRM.WebClient/Models/SmsModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/SmsModels.cs
@@ -8,7 +8,7 @@ public record BulkSmsRequest(IList<string> Recipients, string Message)
     public BulkSmsRequest() : this(new List<string>(), string.Empty) { }
 }
 
-public record SmsHistoryItem(string Recipient, string Message, DateTime SentAt);
+public record SmsHistoryItem(string Recipient, string Message, DateTime SentAt, string Status);
 
 public record SmsScheduleItem(DateTime ScheduledAt, BulkSmsRequest Request)
 {

--- a/src/Web/NexaCRM.WebClient/Pages/SmsHistoryPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SmsHistoryPage.razor
@@ -1,6 +1,83 @@
 @page "/sms/history"
+@using NexaCRM.WebClient.Models.Sms
 
 <ResponsivePage>
     <h3>SMS History</h3>
-    <p>Review SMS delivery history.</p>
+
+    <div class="mb-3">
+        <div class="row g-2 sms-filters">
+            <div class="col-12 col-md">
+                <input type="date" class="form-control" @bind="startDate" @bind:after="ResetPage" />
+            </div>
+            <div class="col-12 col-md">
+                <input type="date" class="form-control" @bind="endDate" @bind:after="ResetPage" />
+            </div>
+            <div class="col-12 col-md">
+                <input class="form-control" placeholder="Recipient" @bind="recipient" @bind:event="oninput" @bind:after="ResetPage" />
+            </div>
+            <div class="col-12 col-md">
+                <select class="form-select" @bind="status" @bind:after="ResetPage">
+                    <option value="">All</option>
+                    <option>Sent</option>
+                    <option>Failed</option>
+                </select>
+            </div>
+            <div class="col-12 col-md-auto text-md-end">
+                <button class="btn btn-secondary w-100 w-md-auto" @onclick="ExportCsv">Export CSV</button>
+            </div>
+        </div>
+    </div>
+
+    @if (history == null)
+    {
+        <p>Loading...</p>
+    }
+    else
+    {
+        <div class="d-none d-md-block">
+            <div class="table-responsive">
+                <table class="table table-striped sms-history-table">
+                    <thead>
+                        <tr>
+                            <th>Recipient</th>
+                            <th>Message</th>
+                            <th>Sent At</th>
+                            <th>Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in PagedHistory)
+                        {
+                            <tr>
+                                <td>@item.Recipient</td>
+                                <td>@item.Message</td>
+                                <td>@item.SentAt.ToLocalTime()</td>
+                                <td>@item.Status</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="sms-history-mobile d-md-none">
+            @foreach (var item in PagedHistory)
+            {
+                <div class="card sms-history-card">
+                    <div class="card-body">
+                        <div><strong>Recipient:</strong> @item.Recipient</div>
+                        <div class="sms-message"><strong>Message:</strong> @item.Message</div>
+                        <div><strong>Sent At:</strong> @item.SentAt.ToLocalTime()</div>
+                        <div><strong>Status:</strong> @item.Status</div>
+                    </div>
+                </div>
+            }
+        </div>
+
+        <div class="d-flex flex-column flex-md-row justify-content-between align-items-center gap-2 pagination-controls">
+            <button class="btn btn-outline-primary w-100 w-md-auto" @onclick="PrevPage" disabled="@(_currentPage == 1)">Previous</button>
+            <span>Page @_currentPage of @TotalPages</span>
+            <button class="btn btn-outline-primary w-100 w-md-auto" @onclick="NextPage" disabled="@(_currentPage == TotalPages)">Next</button>
+        </div>
+    }
 </ResponsivePage>

--- a/src/Web/NexaCRM.WebClient/Pages/SmsHistoryPage.razor.cs
+++ b/src/Web/NexaCRM.WebClient/Pages/SmsHistoryPage.razor.cs
@@ -1,0 +1,82 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using NexaCRM.WebClient.Models.Sms;
+using NexaCRM.WebClient.Services.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Pages;
+
+public partial class SmsHistoryPage
+{
+    [Inject] private ISmsService SmsService { get; set; } = default!;
+    [Inject] private IJSRuntime JS { get; set; } = default!;
+
+    private IEnumerable<SmsHistoryItem>? history;
+    private DateTime? startDate;
+    private DateTime? endDate;
+    private string recipient = string.Empty;
+    private string status = string.Empty;
+
+    private int _currentPage = 1;
+    private const int PageSize = 10;
+
+    protected override async Task OnInitializedAsync()
+    {
+        history = await SmsService.GetHistoryAsync();
+    }
+
+    private IEnumerable<SmsHistoryItem> FilteredHistory =>
+        history?.Where(item =>
+            (!startDate.HasValue || item.SentAt.Date >= startDate.Value.Date) &&
+            (!endDate.HasValue || item.SentAt.Date <= endDate.Value.Date) &&
+            (string.IsNullOrWhiteSpace(recipient) || item.Recipient.Contains(recipient, StringComparison.OrdinalIgnoreCase)) &&
+            (string.IsNullOrWhiteSpace(status) || string.Equals(item.Status, status, StringComparison.OrdinalIgnoreCase)))
+        ?? Enumerable.Empty<SmsHistoryItem>();
+
+    private IEnumerable<SmsHistoryItem> PagedHistory =>
+        FilteredHistory.Skip((_currentPage - 1) * PageSize).Take(PageSize);
+
+    private int TotalPages => Math.Max(1, (int)Math.Ceiling(FilteredHistory.Count() / (double)PageSize));
+
+    private void PrevPage()
+    {
+        if (_currentPage > 1)
+        {
+            _currentPage--;
+        }
+    }
+
+    private void NextPage()
+    {
+        if (_currentPage < TotalPages)
+        {
+            _currentPage++;
+        }
+    }
+
+    private void ResetPage()
+    {
+        _currentPage = 1;
+    }
+
+    private async Task ExportCsv()
+    {
+        var lines = new List<string> { "Recipient,Message,SentAt,Status" };
+        foreach (var item in FilteredHistory)
+        {
+            var line = string.Join(',', Escape(item.Recipient), Escape(item.Message), item.SentAt.ToString("u"), Escape(item.Status));
+            lines.Add(line);
+        }
+        var csv = string.Join("\n", lines);
+        await JS.InvokeVoidAsync("downloadCsv", "sms_history.csv", csv);
+    }
+
+    private static string Escape(string? input)
+    {
+        if (string.IsNullOrEmpty(input)) return "\"\"";
+        return $"\"{input.Replace("\"", "\"\"")}\"";
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/SmsHistoryPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/SmsHistoryPage.razor.css
@@ -1,0 +1,21 @@
+/* SmsHistoryPage Mobile Responsive Styles */
+
+.sms-history-table td:nth-child(2) {
+    word-break: break-word;
+}
+
+.sms-history-card {
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+@media (max-width: 576px) {
+    .sms-filters .col-12:not(:last-child) {
+        margin-bottom: 0.5rem;
+    }
+
+    .pagination-controls button {
+        min-height: 44px;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Services/SmsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SmsService.cs
@@ -1,5 +1,6 @@
 using NexaCRM.WebClient.Models.Sms;
 using NexaCRM.WebClient.Services.Interfaces;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -17,7 +18,12 @@ public class SmsService : ISmsService
         Task.CompletedTask;
 
     public Task<IEnumerable<SmsHistoryItem>> GetHistoryAsync() =>
-        Task.FromResult<IEnumerable<SmsHistoryItem>>(new List<SmsHistoryItem>());
+        Task.FromResult<IEnumerable<SmsHistoryItem>>(new List<SmsHistoryItem>
+        {
+            new("010-1234-5678", "Hello!", DateTime.UtcNow.AddDays(-1), "Sent"),
+            new("010-2345-6789", "Reminder", DateTime.UtcNow.AddDays(-2), "Failed"),
+            new("010-3456-7890", "Promotion", DateTime.UtcNow.AddDays(-3), "Sent"),
+        });
 
     public Task ScheduleSmsAsync(SmsScheduleItem schedule) =>
         Task.CompletedTask;

--- a/src/Web/NexaCRM.WebClient/wwwroot/index.html
+++ b/src/Web/NexaCRM.WebClient/wwwroot/index.html
@@ -41,6 +41,7 @@
     <script src="js/theme-manager.js"></script>
     <script src="js/device.js"></script>
     <script src="js/interactions.js"></script>
+    <script src="js/csv-export.js"></script>
 </body>
 
 </html>

--- a/src/Web/NexaCRM.WebClient/wwwroot/js/csv-export.js
+++ b/src/Web/NexaCRM.WebClient/wwwroot/js/csv-export.js
@@ -1,0 +1,10 @@
+window.downloadCsv = (filename, content) => {
+    const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(link.href);
+};


### PR DESCRIPTION
## Summary
- add Status field to SmsHistoryItem and seed sample history
- display SMS history with pagination, filtering, and CSV export
- include client-side script for CSV downloads
- enhance SMS history page with responsive filters, mobile card layout, and adaptive pagination

## Testing
- `dotnet build --configuration Release`
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release`


------
https://chatgpt.com/codex/tasks/task_b_68c81d8825b8832cb91d52115dd36306