### PR TITLE
Fix compile errors in organization and SMS services

### DIFF
--- a/src/Web/NexaCRM.WebClient/Models/OrganizationModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/OrganizationModels.cs
@@ -13,3 +13,12 @@ public class OrganizationNode
     public bool IsExpanded { get; set; }
 }
 
+public class OrganizationUser
+{
+    public int Id { get; set; }
+    public string? Name { get; set; }
+    public string? Email { get; set; }
+    public string? Role { get; set; }
+    public string? Status { get; set; }
+}
+

--- a/src/Web/NexaCRM.WebClient/Pages/OrganizationStructurePage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/OrganizationStructurePage.razor
@@ -59,7 +59,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        var units = (await OrganizationService.GetStructureAsync()).ToList();
+        var units = (await OrganizationService.GetOrganizationStructureAsync()).ToList();
         var lookup = units.ToLookup(u => u.ParentId);
         _nodes = BuildTree(null);
 

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IOrganizationService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IOrganizationService.cs
@@ -1,6 +1,8 @@
-using NexaCRM.WebClient.Models.Organization;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using NexaCRM.WebClient.Models.Organization;
+using AgentModel = NexaCRM.WebClient.Models.Agent;
+using NewUserModel = NexaCRM.WebClient.Models.NewUser;
 
 namespace NexaCRM.WebClient.Services.Interfaces;
 
@@ -8,8 +10,15 @@ public interface IOrganizationService
 {
     Task<IEnumerable<OrganizationUnit>> GetOrganizationStructureAsync();
     Task SaveOrganizationUnitAsync(OrganizationUnit unit);
+    Task DeleteOrganizationUnitAsync(int id);
     Task<IEnumerable<OrganizationStats>> GetOrganizationStatsAsync();
+    Task<IEnumerable<AgentModel>> GetAdminsAsync();
+    Task AddAdminAsync(string userId);
+    Task RemoveAdminAsync(string userId);
+    Task<IEnumerable<OrganizationUser>> GetUsersAsync();
+    Task UpdateUserAsync(OrganizationUser user);
+    Task DeleteUserAsync(int userId);
     Task SetSystemAdministratorAsync(string userId);
-    Task RegisterUserAsync(NexaCRM.WebClient.Models.NewUser user);
+    Task RegisterUserAsync(NewUserModel user);
 }
 

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/ISmsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/ISmsService.cs
@@ -1,7 +1,8 @@
-using NexaCRM.WebClient.Models.Sms;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using NexaCRM.WebClient.Models.Settings;
+using NexaCRM.WebClient.Models.Sms;
 
 namespace NexaCRM.WebClient.Services.Interfaces;
 
@@ -11,6 +12,8 @@ public interface ISmsService
     Task<IEnumerable<string>> GetSenderNumbersAsync();
     Task SaveSenderNumberAsync(string number);
     Task DeleteSenderNumberAsync(string number);
+    Task<SmsSettings?> GetSettingsAsync();
+    Task SaveSettingsAsync(SmsSettings settings);
     Task<IEnumerable<SmsHistoryItem>> GetHistoryAsync();
     Task ScheduleAsync(SmsScheduleItem schedule);
     Task<IEnumerable<SmsScheduleItem>> GetUpcomingSchedulesAsync();

--- a/src/Web/NexaCRM.WebClient/Services/OrganizationService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/OrganizationService.cs
@@ -1,28 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using NexaCRM.WebClient.Models.Organization;
 using NexaCRM.WebClient.Services.Interfaces;
-using System.Collections.Generic;
-using System.Threading.Tasks;
+using AgentModel = NexaCRM.WebClient.Models.Agent;
+using NewUserModel = NexaCRM.WebClient.Models.NewUser;
 
 namespace NexaCRM.WebClient.Services;
 
 public class OrganizationService : IOrganizationService
 {
-    public Task<IEnumerable<OrganizationUnit>> GetStructureAsync() =>
-        Task.FromResult<IEnumerable<OrganizationUnit>>(new List<OrganizationUnit>());
+    private readonly List<OrganizationUnit> _organizationUnits =
+    [
+        new(1, "Head Office", null),
+        new(2, "Sales", 1),
+        new(3, "Marketing", 1),
+        new(4, "Customer Success", 2)
+    ];
 
-    public Task SaveOrganizationUnitAsync(OrganizationUnit unit) =>
-        Task.CompletedTask;
+    private readonly List<OrganizationStats> _stats =
+    [
+        new("Head Office", 12),
+        new("Sales", 8),
+        new("Marketing", 6),
+        new("Customer Success", 5)
+    ];
 
-    public Task DeleteOrganizationUnitAsync(int id) =>
-        Task.CompletedTask;
+    private readonly List<OrganizationUser> _users =
+    [
+        new() { Id = 1, Name = "Alice Kim", Email = "alice.kim@example.com", Role = "Administrator", Status = "Active" },
+        new() { Id = 2, Name = "Brian Lee", Email = "brian.lee@example.com", Role = "Manager", Status = "Active" },
+        new() { Id = 3, Name = "Chloe Park", Email = "chloe.park@example.com", Role = "Analyst", Status = "Inactive" }
+    ];
+
+    private readonly List<AgentModel> _admins =
+    [
+        new() { Id = 1, Name = "Alice Kim", Email = "alice.kim@example.com", Role = "Administrator" },
+        new() { Id = 2, Name = "Brian Lee", Email = "brian.lee@example.com", Role = "Manager" }
+    ];
+
+    public Task<IEnumerable<OrganizationUnit>> GetOrganizationStructureAsync() =>
+        Task.FromResult<IEnumerable<OrganizationUnit>>(_organizationUnits.ToList());
+
+    public Task SaveOrganizationUnitAsync(OrganizationUnit unit)
+    {
+        if (unit.Id == 0)
+        {
+            var newUnit = unit with { Id = GenerateUnitId() };
+            _organizationUnits.Add(newUnit);
+        }
+        else
+        {
+            var index = _organizationUnits.FindIndex(u => u.Id == unit.Id);
+            if (index >= 0)
+            {
+                _organizationUnits[index] = unit;
+            }
+            else
+            {
+                _organizationUnits.Add(unit);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteOrganizationUnitAsync(int id)
+    {
+        RemoveUnitRecursive(id);
+        return Task.CompletedTask;
+    }
 
     public Task<IEnumerable<OrganizationStats>> GetOrganizationStatsAsync() =>
-        Task.FromResult<IEnumerable<OrganizationStats>>(new List<OrganizationStats>());
+        Task.FromResult<IEnumerable<OrganizationStats>>(_stats.ToList());
 
-    public Task SetSystemAdministratorAsync(string userId) =>
-        Task.CompletedTask;
+    public Task<IEnumerable<AgentModel>> GetAdminsAsync() =>
+        Task.FromResult<IEnumerable<AgentModel>>(_admins.Select(CloneAdmin).ToList());
 
-    public Task RegisterUserAsync(NexaCRM.WebClient.Models.NewUser user) =>
-        Task.CompletedTask;
+    public Task AddAdminAsync(string userId)
+    {
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Task.CompletedTask;
+        }
+
+        if (_admins.Any(a => a.Id.ToString() == userId))
+        {
+            return Task.CompletedTask;
+        }
+
+        var id = int.TryParse(userId, out var parsed) ? parsed : GenerateAdminId();
+        _admins.Add(new AgentModel
+        {
+            Id = id,
+            Name = $"Admin {id}",
+            Email = $"admin{id}@example.com",
+            Role = "Administrator"
+        });
+
+        return Task.CompletedTask;
+    }
+
+    public Task RemoveAdminAsync(string userId)
+    {
+        _admins.RemoveAll(a => a.Id.ToString() == userId);
+        return Task.CompletedTask;
+    }
+
+    public Task<IEnumerable<OrganizationUser>> GetUsersAsync() =>
+        Task.FromResult<IEnumerable<OrganizationUser>>(_users.Select(CloneUser).ToList());
+
+    public Task UpdateUserAsync(OrganizationUser user)
+    {
+        var existing = _users.FirstOrDefault(u => u.Id == user.Id);
+        if (existing is not null)
+        {
+            existing.Name = user.Name;
+            existing.Email = user.Email;
+            existing.Role = user.Role;
+            existing.Status = user.Status;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteUserAsync(int userId)
+    {
+        _users.RemoveAll(u => u.Id == userId);
+        return Task.CompletedTask;
+    }
+
+    public Task SetSystemAdministratorAsync(string userId) => AddAdminAsync(userId);
+
+    public Task RegisterUserAsync(NewUserModel user)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+
+        _users.Add(new OrganizationUser
+        {
+            Id = GenerateUserId(),
+            Name = user.FullName,
+            Email = user.Email,
+            Role = "Member",
+            Status = "Pending"
+        });
+
+        return Task.CompletedTask;
+    }
+
+    private int GenerateUnitId() =>
+        _organizationUnits.Count == 0 ? 1 : _organizationUnits.Max(u => u.Id) + 1;
+
+    private int GenerateUserId() =>
+        _users.Count == 0 ? 1 : _users.Max(u => u.Id) + 1;
+
+    private int GenerateAdminId() =>
+        _admins.Count == 0 ? 1 : _admins.Max(a => a.Id) + 1;
+
+    private void RemoveUnitRecursive(int id)
+    {
+        var children = _organizationUnits.Where(u => u.ParentId == id).Select(u => u.Id).ToList();
+        _organizationUnits.RemoveAll(u => u.Id == id);
+        foreach (var child in children)
+        {
+            RemoveUnitRecursive(child);
+        }
+    }
+
+    private static OrganizationUser CloneUser(OrganizationUser source) => new()
+    {
+        Id = source.Id,
+        Name = source.Name,
+        Email = source.Email,
+        Role = source.Role,
+        Status = source.Status
+    };
+
+    private static AgentModel CloneAdmin(AgentModel source) => new()
+    {
+        Id = source.Id,
+        Name = source.Name,
+        Email = source.Email,
+        Role = source.Role
+    };
 }
-

--- a/src/Web/NexaCRM.WebClient/Services/SmsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SmsService.cs
@@ -1,34 +1,146 @@
-using NexaCRM.WebClient.Models.Sms;
-using NexaCRM.WebClient.Services.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using NexaCRM.WebClient.Models.Settings;
+using NexaCRM.WebClient.Models.Sms;
+using NexaCRM.WebClient.Services.Interfaces;
 
 namespace NexaCRM.WebClient.Services;
 
 public class SmsService : ISmsService
 {
+    private readonly List<string> _senderNumbers =
+    [
+        "+82 10-1234-5678",
+        "+82 10-9876-5432"
+    ];
+
+    private readonly List<string> _templates =
+    [
+        "Welcome to NexaCRM",
+        "Campaign follow-up",
+        "Appointment reminder"
+    ];
+
+    private readonly List<SmsHistoryItem> _history = new();
+    private readonly List<SmsScheduleItem> _schedules = new();
+    private readonly SmsSettings _settings;
+
+    public SmsService()
+    {
+        _settings = new SmsSettings
+        {
+            SenderNumbers = _senderNumbers,
+            Templates = _templates,
+            ProviderApiKey = "demo-api-key",
+            ProviderApiSecret = "demo-api-secret",
+            SenderId = "NEXACRM",
+            DefaultTemplate = _templates.First()
+        };
+    }
+
     public async Task SendBulkAsync(IEnumerable<BulkSmsRequest> batches, IProgress<int>? progress = null)
     {
         var list = batches.ToList();
+        if (list.Count == 0)
+        {
+            progress?.Report(100);
+            return;
+        }
+
         for (var i = 0; i < list.Count; i++)
         {
             await Task.Delay(10);
+            var request = list[i];
+            foreach (var recipient in request.Recipients)
+            {
+                _history.Add(new SmsHistoryItem(recipient, request.Message, DateTime.UtcNow, "Sent"));
+            }
             progress?.Report((i + 1) * 100 / list.Count);
         }
     }
 
     public Task<IEnumerable<string>> GetSenderNumbersAsync() =>
-        Task.FromResult<IEnumerable<string>>(new List<string>());
+        Task.FromResult<IEnumerable<string>>(_senderNumbers.ToList());
 
-    public Task SaveSenderNumberAsync(string number) =>
-        Task.CompletedTask;
+    public Task SaveSenderNumberAsync(string number)
+    {
+        if (!string.IsNullOrWhiteSpace(number) && !_senderNumbers.Contains(number, StringComparer.OrdinalIgnoreCase))
+        {
+            _senderNumbers.Add(number);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteSenderNumberAsync(string number)
+    {
+        _senderNumbers.RemoveAll(n => string.Equals(n, number, StringComparison.OrdinalIgnoreCase));
+        return Task.CompletedTask;
+    }
+
+    public Task<SmsSettings?> GetSettingsAsync() =>
+        Task.FromResult<SmsSettings?>(CloneSettings());
+
+    public Task SaveSettingsAsync(SmsSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        _settings.ProviderApiKey = settings.ProviderApiKey;
+        _settings.ProviderApiSecret = settings.ProviderApiSecret;
+        _settings.SenderId = settings.SenderId;
+        _settings.DefaultTemplate = settings.DefaultTemplate;
+
+        _senderNumbers.Clear();
+        foreach (var number in settings.SenderNumbers.Where(n => !string.IsNullOrWhiteSpace(n)))
+        {
+            if (!_senderNumbers.Contains(number, StringComparer.OrdinalIgnoreCase))
+            {
+                _senderNumbers.Add(number);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
 
     public Task<IEnumerable<SmsHistoryItem>> GetHistoryAsync() =>
-        Task.FromResult<IEnumerable<SmsHistoryItem>>(new List<SmsHistoryItem>());
+        Task.FromResult<IEnumerable<SmsHistoryItem>>(_history
+            .OrderByDescending(item => item.SentAt)
+            .ToList());
 
-    public Task ScheduleSmsAsync(SmsScheduleItem schedule) =>
-        Task.CompletedTask;
+    public Task ScheduleAsync(SmsScheduleItem schedule)
+    {
+        _schedules.RemoveAll(s => s.Id == schedule.Id);
+        _schedules.Add(schedule);
+        return Task.CompletedTask;
+    }
+
+    public Task<IEnumerable<SmsScheduleItem>> GetUpcomingSchedulesAsync() =>
+        Task.FromResult<IEnumerable<SmsScheduleItem>>(_schedules
+            .Where(s => !s.IsCancelled && s.ScheduledAt >= DateTime.UtcNow.AddMinutes(-1))
+            .OrderBy(s => s.ScheduledAt)
+            .ToList());
+
+    public Task CancelAsync(Guid id)
+    {
+        var index = _schedules.FindIndex(s => s.Id == id);
+        if (index >= 0)
+        {
+            _schedules[index] = _schedules[index] with { IsCancelled = true };
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private SmsSettings CloneSettings() => new()
+    {
+        ProviderApiKey = _settings.ProviderApiKey,
+        ProviderApiSecret = _settings.ProviderApiSecret,
+        SenderId = _settings.SenderId,
+        DefaultTemplate = _settings.DefaultTemplate,
+        SenderNumbers = new List<string>(_senderNumbers),
+        Templates = new List<string>(_templates)
+    };
 }
 


### PR DESCRIPTION
## Summary
- add the missing `OrganizationUser` model and align the organization structure page with the renamed API
- expand the organization service contract and implementation to supply in-memory structure, user, and admin data
- extend the SMS service interface and implementation with settings management, sender number handling, and scheduling support

## Testing
- dotnet build NexaCrmSolution.sln --configuration Release
- dotnet test ./tests/BlazorWebApp.Tests --configuration Release

------
https://chatgpt.com/codex/tasks/task_b_68c8427f5684832c88d51e3815f9c48c