### PR TITLE
fix: register notice service

### DIFF
--- a/src/Web/NexaCRM.WebClient/Program.cs
+++ b/src/Web/NexaCRM.WebClient/Program.cs
@@ -44,6 +44,7 @@ builder.Services.AddScoped<IOrganizationService, OrganizationService>();
 builder.Services.AddScoped<IDbAdminService, DbAdminService>();
 builder.Services.AddScoped<IStatisticsService, StatisticsService>();
 builder.Services.AddScoped<ICustomerCenterService, CustomerCenterService>();
+builder.Services.AddScoped<INoticeService, NoticeService>();
 builder.Services.AddScoped<ISmsService, SmsService>();
 builder.Services.AddScoped<ISystemInfoService, SystemInfoService>();
 builder.Services.AddScoped<IFaqService, FaqService>();


### PR DESCRIPTION
## Summary
- register `INoticeService` with its `NoticeService` implementation in the Blazor WebAssembly DI container to resolve NoticeManagementPage injection errors

## Testing
- dotnet build --configuration Release *(fails: `dotnet` CLI not available in container)*
- dotnet test ./tests/BlazorWebApp.Tests --configuration Release *(fails: `dotnet` CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c847ff6a0c832c92c75a4b7ef35995