### PR TITLE
fix: replace remote background assets with gradients

### DIFF
--- a/src/Web/NexaCRM.WebClient/Pages/ContactsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/ContactsPage.razor
@@ -63,7 +63,7 @@
                 </button>
                 <!-- User profile avatar -->
                 <div class="user-avatar bg-center bg-no-repeat aspect-square bg-cover rounded-full size-8 sm:size-10" 
-                     style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuB3h94o6negA_azqf1Sd6Zk10lxjjOCkpvUgo5T5ta-tQ8gO2eIu6nTXzncWb-v-kWC7qgJgPC-Ikyam8M9zSllKz9T6t-KMp8zKdL2I_zolPBQa-sQ2Q5Sc7eFuQoz82t4L4_hSgpZiJh8jgsgAgKeAHrDbn0EbpHyR5iimdJjxEWSoG5LKtzj1nEbk0rBfytEmvpu_JnAI5-I9FDSad_QJXhJedXas0YopEKXpG9_mkZ3vOm76KDjNHfWNCxmaPwr3idKeJ98jN_M");'></div>
+                     style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'></div>
             </div>
         </header>
         

--- a/src/Web/NexaCRM.WebClient/Pages/CustomerSegmentationTool.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/CustomerSegmentationTool.razor
@@ -71,7 +71,7 @@
             </button>
             <div
               class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-8 sm:size-10"
-              style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuAQ7xvyE92Onq9m4VfTpCPSJmRrGXtkYEaZinsTVy2AwzZZAK4bfy1OtUTpXp1IeiOltT0PSPJjWihKpUw1kdZuTR9kL35ypCdCb0v4uzmbx0zyc-yTyY7nbhNQI1Lql0qdKsbI8p6PyHyQTKztM8kvY5sNniItsi-ZOicrX9LO-h6t6gZ36TW6nQ05Lsb-Y1TsUef2BLKRip4bREIjQ-ldTyIPDX-3d2MqFelMEozi2d1Qgr8yjaIxH-QwymJ5yQaSO_g_QKXC38yw");'
+              style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
             ></div>
           </div>
         </header>

--- a/src/Web/NexaCRM.WebClient/Pages/CustomerSupportKnowledgeBase.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/CustomerSupportKnowledgeBase.razor
@@ -49,7 +49,7 @@
             </label>
             <div
               class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
-              style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuADLi8RW1FZJzhQA2Y7ZgCsAcEtu5W2Cv6Zi1kcXEtChVPzbv9ccNbtVgCETohc9EHQT6xgeEppMbuhJoHOS_dQYb0Vo90JCe4ZwUKdrjHMrxaUUUpPzj2z9KRVQOLugrzjfaG4m77-ymSCfk-ADH-WZf6hL47dH3ECAGVV5EKw-8bg6HDQehS-BwnV5NNxMypP19vJOGA9yVyliGmqnH6C-ItOrC58qaBc_wVpsaR-QhEZ0oGTzqysSWF4QRSZz24W4vifJ2gd040z");'
+              style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
             ></div>
           </div>
         </header>
@@ -146,7 +146,7 @@
                 </div>
                 <div
                   class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-lg flex-1"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuDrsmnOsyVt0KQ03yKeZTC9xi5jJAS9RJ4ze9DDl6BIjgRZEdwPYKho6yXvB-BteMqG2bAfVpR9t65UV2fkG1DqTOhni_N9Dwmn8DBv3MtaMRhnSARaxeIwOwEJTtE-WRBlz_7ySRdb0GZu8YhthgYK6zw1wcnKd8FZhh2HuIW-Scxk77qC3oiSpw3_TTMpNhx3NnX7d5XY_OOsppiGqW6x2sCkudfY53R2d_Z_vOMIUt28jrehQrXp4m-fSVrYE3CQKadbzexms_6g");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
               </div>
             </div>
@@ -158,7 +158,7 @@
                 </div>
                 <div
                   class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-lg flex-1"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuCJGEujK0k7d-aH490HjxJLTeKEa2EibUXLb3npIu3ETbKRtP6qvq9X64K-17PTPmT9jJQh3oHb2POejb2gipHb4x2ZiGEj1C0Xs4xtD83vj94GNwVpZRqbsh8cfSlc0ysawTnnh9cZoS9hQvGww1RegEzhYAcpvMQho78KVztDZwwrcQLnZjRZuqejtFm003wI1kEj0GI6ihUt3VSyIgXpRbZSFHhv0Yqbp-dw8l5wklHXfXlinAp0ikl3GqpYEN2f5pU2YhYtiLDn");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
               </div>
             </div>
@@ -170,7 +170,7 @@
                 </div>
                 <div
                   class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-lg flex-1"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuB0yqzBo8RmwtYTcE86H11i05-hxOTRPmNrVo9ttrqghRHCLwcRCqcKN5EK_qQ9fT5bng2A9igX9_3IqtZ3Yqx4-KSxC4XXKG6lVepGxy5x62ki_2erSkGMo9zg0Lmwr3UVB5j_xwOKLgv9Ho9XzYgC1tvm6mzsy1MUylOB6z-TtBNd6mOaPNTjEj_cGDeiTbBjfIUK27TLUPRvefVHYmFuohFqoJpdmnT8bQdj4PsMMjwzstzT2PXCFB5TLIkjS_gMNo418fNpAFPu");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
               </div>
             </div>
@@ -179,42 +179,42 @@
               <div class="flex flex-col gap-3 pb-3">
                 <div
                   class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-lg"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuCJRpqtLuAAAXcegnZv9q0Pvf2P82BsGncNTTtshtIKPaJ4DWQHZglJLJSxIztF1UyJVyS43umrWN1yUOG9BZhEw1EqbRS9P0hoyT3L5_zRDZOqHU9-PEJlJdM_mpkzL1kf3QsIpzBMjE-l8JVugZQ7s1_onhOtT3og0gOuRgud2oYLQBvCT19lIQ1QicKeQIOaEISPSvRAneHYSAiFXkRozTkIAlnJZ8_5A9S2BsCh9RQ-lb62omu6wxFqTxkIMqmfcpS44QYW1U5z");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
                 <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["TopicAccountManagement"]</p>
               </div>
               <div class="flex flex-col gap-3 pb-3">
                 <div
                   class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-lg"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuArb2a-OFBz8mdi5ISSwgFNkIW4s6fy3fPzYRXeBRwx121UZPu4hzzULieYeKJupryZtGQQINPb_BURbFw8oU5L7zul3OSOhepISsNbHgSnUPyvOklYBXm52829C6q1XspTdk3HuL56SotsmxPZ_VPEj-u4Xcrvi30zZDOl3pa0jWw1nPrUhKc2exgesB34SCqP8txO-R8V6R8egLaJVKvtN80AyWkFsWFl4zi5Aht-d9Z2wfAhoEjTKEK5THyYOe9SeR2RQ41GLW-N");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
                 <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["TopicBillingPayments"]</p>
               </div>
               <div class="flex flex-col gap-3 pb-3">
                 <div
                   class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-lg"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuC42lvr_LHvdA6HTW5a3OzQVHDII1iMA6udINTzJj9sVpZGo8QwQoS1mBxQhw66CAxkoWm-IXgVxCGMXe3k9i1mG2pLMvipBkg5RVAC-7u0kU3yF2e_DrgZ9FUfxtJ2FJWhDp2RLpRmDA1JqDLQ1HeglQPw0G23h5gl-BicQAkdBPA7KfimOLscRdbP9nlsGlTu2VNgaeZMvup5elL1spfSeShH4WvVGNBz4wUz_X-GYRfH4cj3TVtyZPxOmIw1-ZSJtF4NjsBGlu5H");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
                 <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["TopicDeviceSupport"]</p>
               </div>
               <div class="flex flex-col gap-3 pb-3">
                 <div
                   class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-lg"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuDOddk8AVEyoNmxHZHP8NrcODeZpISFTvutvpJw8ipXkomguVnh_uqbV4OaaFvj06shndNTwMaOKshNU8MtjeoNJUD0KTWsN7eYkiibONRV63SsP3W1cbIS8LMKqF6neQhXUi1q7K10FIzhYrVHUrdkLFm4JtZfbBrGyWL2d29JaAYSQtgrlGA4cv94BkPo03CfpDXC5ZW64D2OvAroQPYAD5tGS2cXL0CQ-YpQ-8T-XEaxH0rLuqUXlvh6QI2Tjy7sfzX-HYLTjc8L");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
                 <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["TopicConnectivityIssues"]</p>
               </div>
               <div class="flex flex-col gap-3 pb-3">
                 <div
                   class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-lg"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuCEQ0u9CwzBWUgpan1jhZ5zaFr7UpklStiBxzkISNAanPzJ5ocNZzXXVPeAAb9UngFXBWl7KCGZQQDp-oSYkWectCGPOMaQfpa5gOcMR3twzQ96GbEeghwflHLlLMBxsM4FxsYTaU2P_VmnhRVonNxcwarrs28tQlAjl_4Op001-1PyNUuaZSt5FriKK9vr-EP11Tcftpb4bAJOM-T7qFwNmk2AX_dA0LToTtHY39oGh1PIguOr4ikE4oRjaIxRdHAGtGKYcibRT6qA");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
                 <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["TopicSoftwareUpdates"]</p>
               </div>
               <div class="flex flex-col gap-3 pb-3">
                 <div
                   class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-lg"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuD2B6DVVcu1Qw6zPK4unAEWWVWNRHnS_EIl1uz1aMVcxOStXTd7fhIBzfGvikpFV9WQqJyLe0RwGAK1TbfCsjw4j9xPV_CduS122Tfkf3zsXvprwpAibKTcKseLBXoXkdQanHNFwjIjSiwymOlDjmrDJn2aCiS0aOgwUBY9cgyuh04bbiWfowyORte4cdh8to-_eSPsRqo2Gz0BkuyafCagn3Mh2uPp_FYE0pTF3M_oM67xEKn8wflli-IYJmZI-2NsDyb2GgvGQZRb");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
                 <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["TopicSecurityPrivacy"]</p>
               </div>

--- a/src/Web/NexaCRM.WebClient/Pages/CustomerSupportTicketManagementInterface.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/CustomerSupportTicketManagementInterface.razor
@@ -65,7 +65,7 @@
             </button>
             <div
               class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
-              style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuCx2gNdkmFw0bMXofX8y7BKqt22XdJeoNLO_SSZLCsCFFLuJhpfOZSpRTKWWQWpftko3JCtfdRWJyPrroS_LQSrzjbGUaEPszUjNPjXAw7MbT-rrBpyg9kTEZHcZjQWD_Wth0Y9ECXiX7Oy-K0T9p3qjbbhogpPL5Jo8ZOqS73bx-583FuznF_3eXcBrVsNlR6Y5DZnoBPV3bGqsJMeo9mj_G-u1SEOb4mtSsuexgFoc4kb7asIcQxAocd13E0EOwic6RMcmkH1kCW-");'
+              style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
             ></div>
           </div>
         </header>

--- a/src/Web/NexaCRM.WebClient/Pages/EmailTemplateBuilder.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/EmailTemplateBuilder.razor
@@ -76,7 +76,7 @@
             </button>
               <div
                 class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
-                style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuCL3XVsr5aS8ATjJDCWyCjG_AXHLpdfPgEtTtJ-xmWb1Gr5Rq_OZ8NULUQ08vt34JiconXrQ7NdVGUYJ96M5cXWnEmGMf1gwbDDIZniee7OhnXKK3-OW-Xt9MS1rBKcdJcrW4Z_-M9twlPTnyTad-N-O9mv3D-lhPn2sHURaWysjJuuRX4M5Bs8zUGscjfpAOJXCMVty6TVUUpgGC2-yeTInS-TlKtIaNVxl_W1lZ-Va4fOVjRHxk_Gc4OCGjIn9xN1ZRTIyfVPdE8L");'
+                style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
               ></div>
             </div>
           </header>

--- a/src/Web/NexaCRM.WebClient/Pages/LoginPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/LoginPage.razor
@@ -24,7 +24,7 @@
               <!-- 상단 이미지 섹션 -->
               <div
                 class="w-full bg-center bg-no-repeat bg-cover image-div-login-page min-h-[180px] relative"
-                style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuAfaynYSIMyWSA0KAFt_F_0xbeEywahjPH6dXL7wfRm4aWKQTJPoGB_HZxp84Z__2mS2F2ZdqQpfAcc88i6ayJKktBU574T6a8WZQAUVqfblTYgNw6sKhbnKYmqNLZbI-9w41kt0_FPlVm7B0FgCsmx4jc0i9FBdko0SFT-P4C4Q68UTWM6pAhSE7iwRPIAso3lizthXAugbRD3gqQmrottH8RGjjF_tRxV8w53STiPSwDa7xyJ6tDSIm9BIlAHNZMXZ4kmJjOjuSd7");'>
+                style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'>
                 <!-- 부드러운 그라데이션 오버레이 -->
                 <div class="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-white/10"></div>
               </div>

--- a/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor
@@ -296,7 +296,7 @@
             </div>
             <div
                 class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
-                style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuC0J2TE3H883xqYPB3xvwBY_0_cMq-Hw4RsPb09RiETGqWWmWN1yUuN7i1jEVtCD0WnkJtOIM8lMmSAMyqHgdebA0UNQXNPXNmv7ecWM3oBwxplOZ24mkxqkN8xIh6o0eHLBkAqc2bIMGNs1_qMlkzpp_NkJn-vr36fd4zvXaTb9j1itBkplTUGEjVDqW3hzRMJaeGSS91pMQHv40mOs-nUNdzb7iQmrn0Lq_EEO4N20LC7QF13d4GzJzhuvijVh-PkBNfOJvRr6NyO");'
+                style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
             ></div>
             </div>
         </header>

--- a/src/Web/NexaCRM.WebClient/Pages/MarketingInsightsReportDashboard.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/MarketingInsightsReportDashboard.razor
@@ -68,7 +68,7 @@
             </button>
             <div
               class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
-              style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuBMAVic41JW4_Z1pGP_xq6BSQFQcFJBZ12yZ1GMveTYxMqJpxTMnMVycHliTDzYdsDLM8qNNfQveE1NRSuIC_E8SX45utesHNJYMHxer_lBLmLD6q8RTFqFvvQATW3_sqfxFSV6Fh0pJP-9OXk4xB59SnUGrxChxLdwGKRXHTXOlv1PJSF75d6ujFmquV-ZbLpCkRhG1106VeWYaL81QwiKEB3BOUqCBYdzWx9qo92EJX7NYQsOPRDifCx6ARcAtlnT1EVm5cPJ6N3g");'
+              style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
             ></div>
           </div>
         </header>

--- a/src/Web/NexaCRM.WebClient/Pages/NotificationSettingsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/NotificationSettingsPage.razor
@@ -70,7 +70,7 @@
             </div>
             <div
               class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
-              style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuDDwBLzFCgipROOK51AiO0u6BgxIX5gHppl-Q-kKmhIB1tj_tWh_TLnh10tn0JZM22Dms_UUHWweNsPwt_t_H8XDhuMnDhqn4vZozzVhspqJWr5N7jvofKPzvpCoiePFyqzOSXY6wKxK6TmOyQqKHSF6sl7bMfWB5XUH93vPN62dl0KCqXT_pDyXSOgzjPjEVdEvoGcRNi8ahZVzaY5LXPJH19DqDTT8Y07Y7VFz23vcNCpEwOCamTbMZv3V3FOtv9e9BgWkl9wygUl");'
+              style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
             ></div>
           </div>
         </header>

--- a/src/Web/NexaCRM.WebClient/Pages/ProfileSettingsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/ProfileSettingsPage.razor
@@ -42,7 +42,7 @@
             </button>
             <div
               class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-8 sm:size-10"
-              style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuDg1YUgCBelo0UW6dfFN9K2ywr95p-zQPW_GtqUl-Gaejm448dkbbQbjBJYyVZUjeKq0sa38X_9XUxcDHnUM_WkmDe1KmDnX4yDMKSNgwoGthSyOLJpBd9xPu6AzBRtycDNDlBSfIh975lBre4fovkfOcpKcHVZhinbuCyOX2wpgS_t0kb05IkNQ0B1g7gpuhT3iXcvvG-6z5fhMhQ4078JZ4883SdX9fmAq1L84WWg3G2xUIlfAZ5dK7g8PP7Cs363CzURD6Vn8wp");'
+              style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
             ></div>
           </div>
         </header>

--- a/src/Web/NexaCRM.WebClient/Pages/SalesCoachingAndTrainingModule.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SalesCoachingAndTrainingModule.razor
@@ -113,7 +113,7 @@
                 <div class="flex h-full flex-1 flex-col gap-4 rounded-lg min-w-60">
                   <div
                     class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-lg flex flex-col"
-                    style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuDKolwYCU8My6-zjVPCS4QBb8PaS6D2foPR8iwWTd5MSbZ33VJiR6s-8tCwuutRxKcSvjVGOmQDrj9haK7LRDgFxTr8LCG8VFZiGdDzukVIMSf9JHsM5Wk6o9N30wc9KwCfofjECMADIgGWo6Tgd5OflQgiASdxMaLGoVNYM5J82GIJvCn3Hbf76_k2pgbRwo9tKYSvbpq1kNKKtcyw3MQiZM0f1nUpZUz4HkZyf4RVIqdwgx2SRNFrK7tDBy0vUHN3pqPFrHH3jtF8");'
+                    style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                   ></div>
                   <div>
                     <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["MasteringSalesTechniques"]</p>
@@ -123,7 +123,7 @@
                 <div class="flex h-full flex-1 flex-col gap-4 rounded-lg min-w-60">
                   <div
                     class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-lg flex flex-col"
-                    style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuCetiI8qjQ-5nVaxPn43IKFhu-xYvMpV7dPrjK6bg1VSq514EYRNdaRMltxezFPMoszzEvw5TFFShs-2sNSsBNz_gD7GTO9W7NBvKa5OeV4hXQOiS1-5kPrw4CQJSIjDRjvCQ5qjAPd27yX_monE_U0rhryAvrJzdJPhZ2L1YeYy7sJOc6CidMQboBfQtEctUDY8qpnMCQmoTu3aCgYFnA40Vfs4-iTK6JIRnVzlO0E2Qinf7I7Fq8wyx_msMXDaoEsHAkx9JY9YIJB");'
+                    style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                   ></div>
                   <div>
                     <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["ExceptionalCustomerService"]</p>
@@ -133,7 +133,7 @@
                 <div class="flex h-full flex-1 flex-col gap-4 rounded-lg min-w-60">
                   <div
                     class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-lg flex flex-col"
-                    style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuCTDP0TlzTYU5TmR0DGbiF50Q_ZWU0j1815R-148zsMpgMmdJgoS8NjRLVeSwSsnHzy45fh9_2-dtoKKlfcizyXrKY761FpDf4oqdus4SaQ8F2-DHrv5-bkY4qZ-2pPbNRz08ZH7qhcZEAQNFr1oZtdMw9dTB7cJHKYLnZ0Yloo0vWgq6xKwgHU7gkOrQCW_kQSeoLxER3c3dzis4t2ZjJMh4wPS5okOOyxkwK5nHoAks-RY40_hbN2gIsh3VMql9wxBSJHoJqFdqT6");'
+                    style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                   ></div>
                   <div>
                     <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["DeepDiveIntoProductFeatures"]</p>
@@ -147,42 +147,42 @@
               <div class="flex flex-col gap-3 pb-3">
                 <div
                   class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-lg"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuBl4tvAWkRvJVrzIXJ2tnb6xo_gymDJWOiNWavpjbbbwSNbC75l4ZlMHzaMn6uAe2p--40831kOyqVQD6W4chY7wpvU1K_tE_U7kcB053K0ViZNVd46o0FuimdHmlttmuOsQZsl4LByByHTvCI_GkrelXBMGsB-E6hfxM9wEW4kASO9t2vONHdQaf7C3QshZalo2GrEkLeqdA7jC8tGeBYPtHrHMANRH_-EMSg08aKdYkTCT-02CsxXa4-D3lCCoCH1tuk8lDPETaR-");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
                 <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["SalesSkills"]</p>
               </div>
               <div class="flex flex-col gap-3 pb-3">
                 <div
                   class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-lg"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuAArpVJ_TzOZLjNPuVAcld9ZlVLuqO4Z_CXWVchHZhBQXf3_VYmMsRJIqtWPWHW-bztxRTVwEqW39TtrOjkInXNsZKaK4hgTu-QmzHn4voA6Ra24O-MiwVP2TXVukndZc90uiuhcUNAnPSuCUJAJVRQklQJhAkV8viPIPjsoLZOCyudlvlmuUdVcnABrbrlo3-4OUJP737ZeUutOl4A-vA_2-tDOMzN7r-lrgUSjL9vfDGLnIVLDCW-gZUuyH0pdJbUaBIYjIgOH61F");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
                 <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["CustomerService"]</p>
               </div>
               <div class="flex flex-col gap-3 pb-3">
                 <div
                   class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-lg"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuBWDxegdLwV00mG8tg0jcdMJZBT_byFLU4q_PeaKbRn6RdItWlem8Igg3EybkjtiQboSYFQ11tQ0F-Bzc3kkOG7Dc_0IWUiq_0FpGvpL9R1Dp3E4N9T19gCa19fAeF4JXSho8kNGqseCsI5vU4V1ZMjhemmA9QE0LVHaXrcMONlpSjVuJPb77oRRKGYO3dtyky9MdyrYQUBEHodVgyMXXFmupMmhiZNHhuoa59TEi6Yjr3hPdLqYqKoxrlCZqWlUdj-anuVs_jz-L3b");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
                 <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["ProductKnowledge"]</p>
               </div>
               <div class="flex flex-col gap-3 pb-3">
                 <div
                   class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-lg"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuC7FbHIt9SKdheUex28Gt8TgaUmTy6IujAEUMV2xCIF_cr5mtY1qshEwNlxT3lz_bmMVdt38mQRLTdD4sxHg2G8nBgZlG_8wfKQg-GN4fzaTQvWly9rVVBY_ElFVU3U8pRA0gOB06GHAvAX-dp_cvc_T2kY-C2ycCfQeHVlvBh7bvQQlMca-NuP5OzL0lTL3orZbQSqA0sqOOQjqVF75ZJ-BtqhX3QNvA13MTS0X-53AzNMMYx1LtQlMn567ZafjBMeHE1JdrFC9Buk");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
                 <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["Communication"]</p>
               </div>
               <div class="flex flex-col gap-3 pb-3">
                 <div
                   class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-lg"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuBmz3kRg1DUTitjdImiarp9BsUsXJZQycP8O7bQ85ps3r6DQoQU68k5QT38B9rVmzbOQF22nsg0YvoAGOZmdHvVprCafFfatYVx3WBemA7C9GeRPQ0d8dPisGtWe-gxcgWqDlMZaRgxSptud18BvcSmid7YmXJf-PtqgVmhWfMHije2Rca6wd442xpQGahp2c8jFqnByY_8row-yi5YHmzRP426Xl_T93QNA8Z65MeluUP4hXX3q6AVDYU8D9WdEi3Vt7OTpGRtjdnT");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
                 <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["Negotiation"]</p>
               </div>
               <div class="flex flex-col gap-3 pb-3">
                 <div
                   class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-lg"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuCcfcs4HGPPz9KgKEZrDlazdv72T_DQcWVpO5oDJbwIuoA3SA-WvMFzFF_Zv86WLYe8aYOn53WEY7ySVKkbNRrFe5t1a369PqaOv0GYR5gy12y2dFl0BwDSVQ1JzjWF2IIzuc2h-QyALNDvykxnl2dOyDd3OAsn26RtgwsRC-uGJG4zJadrjZPGUxv2NiX0LsepEufcFQ4_6pEhTQDs59Ghe-YSeTODkyQGIWiV9AhW6megQlwowGbyIPJTXAb_gov7FtPSZTyrHXBz");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
                 <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["TimeManagement"]</p>
               </div>
@@ -203,7 +203,7 @@
                 </div>
                 <div
                   class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-lg flex-1"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuB0f-E-ScSwgNni3UKopujnpgafLxq3drMPJkBBodRiB-ypDrZQ3WYzqdjPrPIE0CzDydWkxfYqtN2mb6p3fCX-dEj6-CXlTGbV7mOkHeiNQRWC2AxuLXF9ZLcwH9M3FQRZ76z68BVq_14D44vJ3pRLgD-xhMcmCU0AVr9JEPMAS8-XPYwI-hQ4_QxiaAuhh68OpN1dq7sW37hfBxXQathgF32jUdHCRSPEKrMOe3vhh_yWEZ0c4oQ0lqIWsQOdUoWC7iLn4yKiNr1x");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
               </div>
             </div>
@@ -222,7 +222,7 @@
                 </div>
                 <div
                   class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-lg flex-1"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuD5j25Mze98ZiCvvp8kzg3GbPigT7m8MohWJHqFaS3qG2w2mJeUjQdxZPwCKm9jDRTkNYKSPkwFoDrIjgXBMr3_9Ve2hjEwdtKGYjedsqfNO1smxL8VbEcbNIsHECUyVqLSo5QmEkAQforYasYOcXKf56dZI-xKrsbrtDgKgIhztEG2JFahX6w--yBhtlfcMzK3rSrmC4t2c-RL1pykaBg58XXgUYFbjOlyu4f9k6tO7w9U_PKK4KtUf4UhGYZR3Uuni5-nTAmkAwhb");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
               </div>
             </div>
@@ -241,7 +241,7 @@
                 </div>
                 <div
                   class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-lg flex-1"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuAgoDJLyZgZjiI1xvBYxER2YdJ-7mJQXItZ_wJqu_xBHmifKR7XKBYOIr_8lUwwuTcdfiP5Kgo_xCkVUAgwP81HxnwF12xOsF04irBPemW2dyi8B84crm6XKUdk357IMUsZx77AbQ_cFkDvXq8Mn9LbVhD9HJRqLRNwkBnvp7HcbSpr1Vj49xi2X1Lx_OtcZ76vzFLaKWV3p40ZScPrKxZ1npYuJHDnx-FIZwQmeEFPJ5CerRyuW4TMTSENEWlAEfx2UVAFhXQYNO1x");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
               </div>
             </div>

--- a/src/Web/NexaCRM.WebClient/Pages/SalesManagerDashboard.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SalesManagerDashboard.razor
@@ -73,7 +73,7 @@
             </button>
             <div
               class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
-              style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuB3h94o6negA_azqf1Sd6Zk10lxjjOCkpvUgo5T5ta-tQ8gO2eIu6nTXzncWb-v-kWC7qgJgPC-Ikyam8M9zSllKz9T6t-KMp8zKdL2I_zolPBQa-sQ2Q5Sc7eFuQoz82t4L4_hSgpZiJh8jgsgAgKeAHrDbn0EbpHyR5iimdJjxEWSoG5LKtzj1nEbk0rBfytEmvpu_JnAI5-I9FDSad_QJXhJedXas0YopEKXpG9_mkZ3vOm76KDjNHfWNCxmaPwr3idKeJ98jN_M");'
+              style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
             ></div>
           </div>
         </header>

--- a/src/Web/NexaCRM.WebClient/Pages/SalesMaterialKnowledgeBase.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SalesMaterialKnowledgeBase.razor
@@ -61,7 +61,7 @@
             </button>
             <div
               class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
-              style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuBDz4qDFK6rO0j5QmxW7dnB-kWd94VcTSNR9-Ax2QPcpirUs1PzvwMxxHjENPa9PknIeixhKIFOLh9QL3-HmHsvmkgSLcvpfW1tW9FKpw2lPxW0j3KYDy8ORUCPXbV-vUKIWv8xPPW2bq5UFz0wBdFX1assJLavwFzWntZs6rKZ5LzC6CWbep49WZNK1t5jgB_bCwT4C4j_AuLgEDc5OcqNI7Hedi6aZedYxzA2apJLQmr4XCKGtEXE4mlz03asmLfkc3ZemFR7w1Nc");'
+              style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
             ></div>
           </div>
         </header>
@@ -169,7 +169,7 @@
                 </div>
                 <div
                   class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-lg flex-1"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuAnYCSO1pSPX01PmyIKb5bAoU0k_CJRFHSgLMdNV6L_J8EuR32GCiTFTFf23-UgSlztEYguQ1Zs4VANNZ2_6UNqHlwG5RRY9A-B3iMvpz1oQVGuzWV0S1PiMrCqCEwdRx2PSkc_b_mkrf5z5ZOxImxeuvOneaJ3vhfxjXJ312OXqkMLlE-pPduFwt7efgvL84QwDlwsJFClf89AaZJog0Fr1Ds5Nb9gX1eBXVnzx8wrfpMcQAoBqEeOcKUcwzRnvDNmG8sHLIhgYWMt");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
               </div>
             </div>
@@ -182,7 +182,7 @@
                 </div>
                 <div
                   class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-lg flex-1"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuBhBbmF3ez1FuQcNUL_5qYaVOhhWKdqrCEnUoOwD-hGxtNS-wJfV2n7iJy879wFLeFemEA2klXME0fxfs3pXZRuHDTzEvthYQnPNOJVD8jKSZTyeRp3G7LQwMH0Zzgek2hAjPgpPbn24_GBdm6f5R_WhP_XxDPXR4gZv1vf8hxwtiaDz4nulcDWz0pQuermVMY1__Dc2ehnpMqTi7wjVgS6Qs554EH4WGI1KPJigZPBhSetWlO2drU7I_zFhChqjkXENimRyLDGVi5S");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
               </div>
             </div>
@@ -195,7 +195,7 @@
                 </div>
                 <div
                   class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-lg flex-1"
-                  style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuDk5fMZO3C9lQNXio45zWqmHdZHFgZs9dWrWWhjlxyz_e4jQ8hhL2CY0xqAFCltNJbhqEdunwwgUdl1ft0ApLf3C21vW3LvYqiJjkOhcdi7e9ryaDu0xFTgPI2vkp8i7L2pNntSjuj6r6rFPQfQ2qosJIJk5B0gPtOm_VhjOZXA7mRMv8zFRqJDCEXEnFwh_AG2zeUuQ5Ilsid4rOBO1d2MRnRrcXEJrIUUDTl2ZsG-kQ2MeC4ycf8qhA4QvllsYUgQiFqIYF6CvCmE");'
+                  style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
                 ></div>
               </div>
             </div>

--- a/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor
@@ -67,7 +67,7 @@
         </button>
         <div
             class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
-            style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuBO65r24FZtTWlZ09uG_t4EAJSHwdHGvS1udzfEUhammSCvIr0dDFS49kfLQ_f5tFJ1FOZnpBj43YcArnXbh6Bc2rEkkig2nTrwLWVOq6k6AnSaU9lM-8NQVp3X16tP-jDjiT40NngtOILy4lnJAWI6qewyTqEuGrFcJOB6Jl7_JU5U9txy23OLj-V_Eyh0V3jvzG_WK2nQWlmm24kL7rnkQQlmp73g_Qf_UuRTnGqacH7dc2rCpLJXxHQNVRsScmwPHQ_U43mjLQ4U");'
+            style='background-image: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);'
         ></div>
         </div>
     </header>


### PR DESCRIPTION
## Summary
- replace the remote googleusercontent background images in the Blazor pages with inline gradients so the UI no longer requests unreachable assets

## Testing
- `dotnet build --configuration Release` *(fails: command not found: dotnet)*
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_68c881cd5a08832cb0e9b09ead04e7df