### PR TITLE
Add close control and logout divider to navigation menu

### DIFF
--- a/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.en-US.resx
@@ -15,6 +15,9 @@
   <data name="BulkSms" xml:space="preserve">
     <value>Bulk SMS</value>
   </data>
+  <data name="CloseMenu" xml:space="preserve">
+    <value>Close menu</value>
+  </data>
   <data name="CompanyInfo" xml:space="preserve">
     <value>Company Information</value>
   </data>

--- a/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.ko-KR.resx
@@ -15,6 +15,9 @@
   <data name="BulkSms" xml:space="preserve">
     <value>대량 문자</value>
   </data>
+  <data name="CloseMenu" xml:space="preserve">
+    <value>메뉴 닫기</value>
+  </data>
   <data name="CompanyInfo" xml:space="preserve">
     <value>회사 정보</value>
   </data>

--- a/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor
@@ -15,6 +15,15 @@
 
 <div @onclick:stopPropagation="true">
     <nav class="flex-column">
+        <div class="nav-header">
+            <button type="button"
+                    class="nav-close-button"
+                    title="@Localizer["CloseMenu"]"
+                    aria-label="@Localizer["CloseMenu"]"
+                    @onclick="CloseNavMenu">
+                <i class="bi bi-x-lg" aria-hidden="true"></i>
+            </button>
+        </div>
         <div class="nav-scroll-container">
             <!-- Always visible base menu -->
             <div class="nav-item px-3">
@@ -250,7 +259,7 @@
                     </div>
 
                     <!-- Logout button -->
-                    <div class="nav-item px-3 mt-auto">
+                    <div class="nav-item px-3 mt-auto logout-item">
                         <button class="nav-link btn btn-link" @onclick="Logout">
                             <i class="bi bi-box-arrow-right me-2" aria-hidden="true"></i> @Localizer["Logout"]
                         </button>

--- a/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor.css
+++ b/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor.css
@@ -21,3 +21,60 @@
     background-color: var(--primary-color);
     color: white !important; /* Ensure text is white on active background */
 }
+
+.nav-header {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    padding: 1rem 1.5rem 0.5rem;
+}
+
+.nav-close-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 0.75rem;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 1.25rem;
+    cursor: pointer;
+    transition: background-color var(--transition-fast, 0.2s ease),
+                color var(--transition-fast, 0.2s ease),
+                transform var(--transition-fast, 0.2s ease);
+}
+
+.nav-close-button:hover {
+    background-color: var(--hover-overlay);
+    color: var(--text-primary);
+    transform: scale(1.05);
+}
+
+.nav-close-button:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 0.2rem var(--focus-ring, rgba(33, 83, 200, 0.28));
+}
+
+.nav-close-button i {
+    pointer-events: none;
+}
+
+.logout-item {
+    position: relative;
+    padding-top: var(--spacing-md, 1rem);
+}
+
+.logout-item::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: calc(var(--spacing-md, 1rem) + 0.5rem);
+    right: calc(var(--spacing-md, 1rem) + 0.5rem);
+    border-top: 1px solid var(--divider-color);
+}
+
+.logout-item .nav-link {
+    margin-bottom: var(--spacing-sm, 0.5rem);
+}


### PR DESCRIPTION
## Summary
- add a dedicated close button with localization at the top of the navigation menu
- introduce styling for the close control and a divider above the logout entry to match the desired layout
- localize the close action caption in both English and Korean resource files

## Testing
- `dotnet build --configuration Release` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_68c8981c8298832cb94f46de531e81af