### PR TITLE
feat: elevate statistics dashboard experience

### DIFF
--- a/src/Web/NexaCRM.WebClient/Pages/StatisticsDashboardPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/StatisticsDashboardPage.razor
@@ -1,5 +1,6 @@
 @page "/statistics/dashboard"
 @using System.Collections.Generic
+@using System.Globalization
 @using System.Linq
 @using NexaCRM.WebClient.Components.UI
 @using NexaCRM.WebClient.Models.Statistics
@@ -7,13 +8,57 @@
 @inject IStatisticsService StatisticsService
 
 <ResponsivePage>
-    <h3>Statistics Dashboard</h3>
+    <section class="dashboard-header">
+        <div class="dashboard-header__copy">
+            <p class="dashboard-header__eyebrow">Engagement overview</p>
+            <h3>Statistics Dashboard</h3>
+            <p class="dashboard-header__subtitle">
+                Monitor how your community is growing and how resources are being adopted across the selected time window.
+            </p>
+        </div>
+        <div class="dashboard-header__meta" aria-live="polite">
+            <span class="dashboard-header__range">@GetRangeSummaryText()</span>
+            <span class="dashboard-header__window">@GetRangeWindowText()</span>
+        </div>
+    </section>
 
-    <div class="date-range">
-        <input type="date" @bind="startDate" @bind:format="yyyy-MM-dd" />
-        <input type="date" @bind="endDate" @bind:format="yyyy-MM-dd" />
-        <button @onclick="LoadStatistics">Update</button>
-    </div>
+    <section class="dashboard-toolbar" aria-label="Statistics dashboard controls">
+        <div class="quick-ranges" role="group" aria-label="Quick date ranges">
+            @foreach (var option in quickRangeOptions)
+            {
+                <button type="button"
+                        class="quick-range-button @GetQuickRangeClass(option.Days)"
+                        aria-pressed="@(activeQuickRangeDays == option.Days ? "true" : "false")"
+                        disabled="@isLoading"
+                        title="@option.Description"
+                        @onclick="async () => await ApplyQuickRangeAsync(option.Days)">
+                    <span class="quick-range-button__label">@option.Label</span>
+                    <span class="quick-range-button__caption">@option.Description</span>
+                </button>
+            }
+        </div>
+
+        <div class="date-range" role="group" aria-label="Custom date range selection">
+            <label class="date-field">
+                <span>Start</span>
+                <input type="date"
+                       @bind="StartDate"
+                       @bind:format="yyyy-MM-dd"
+                       max="@EndDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)" />
+            </label>
+            <label class="date-field">
+                <span>End</span>
+                <input type="date"
+                       @bind="EndDate"
+                       @bind:format="yyyy-MM-dd"
+                       min="@StartDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)"
+                       max="@DateTime.Today.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)" />
+            </label>
+            <button type="button" class="btn-refresh" @onclick="LoadStatistics" disabled="@isLoading">
+                <span>@(isLoading ? "Refreshing…" : "Refresh")</span>
+            </button>
+        </div>
+    </section>
 
     @if (isLoading)
     {
@@ -26,38 +71,179 @@
     }
     else
     {
-        <div class="summary-tiles">
-            <div class="tile">Total Members: @stats.Summary.TotalMembers</div>
-            <div class="tile">Total Logins: @stats.Summary.TotalLogins</div>
-            <div class="tile">Total Downloads: @stats.Summary.TotalDownloads</div>
-        </div>
+        <section class="summary-tiles" aria-label="Key metrics summary">
+            <article class="tile tile--members" style="--tile-accent: #6366f1; --tile-accent-rgb: 99, 102, 241;">
+                <div class="tile__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+                        <circle cx="8" cy="9" r="3" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+                        <path d="M3 18c0-2.7 2.6-4 5-4s5 1.3 5 4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+                        <circle cx="17" cy="8" r="2.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+                        <path d="M14 18c0-1.9 1.8-2.8 3-2.8 1.2 0 3 .9 3 2.8" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+                    </svg>
+                </div>
+                <div class="tile__content">
+                    <span class="tile__label">Total Members</span>
+                    <span class="tile__value">@FormatCount(stats.Summary.TotalMembers)</span>
+                    <span class="tile__hint">As of @EndDate.ToString("MMM d, yyyy", CultureInfo.CurrentCulture)</span>
+                </div>
+            </article>
+            <article class="tile tile--logins" style="--tile-accent: #2563eb; --tile-accent-rgb: 37, 99, 235;">
+                <div class="tile__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+                        <polyline points="4 15 10 9 14 13 20 7" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+                        <path d="M4 11V7h4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+                    </svg>
+                </div>
+                <div class="tile__content">
+                    <span class="tile__label">Total Logins</span>
+                    <span class="tile__value">@FormatCount(stats.Summary.TotalLogins)</span>
+                    <div class="tile__meta">
+                        <span class="tile__delta @GetTrendBadgeClass(stats.LoginTrend)">@GetTrendChangeText(stats.LoginTrend)</span>
+                        <span class="tile__caption">vs previous day</span>
+                    </div>
+                    <span class="tile__hint">Sign-ins captured for the selected range</span>
+                </div>
+            </article>
+            <article class="tile tile--downloads" style="--tile-accent: #0ea5e9; --tile-accent-rgb: 14, 165, 233;">
+                <div class="tile__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+                        <path d="M12 4v9" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+                        <polyline points="8 10 12 14 16 10" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+                        <rect x="4" y="16" width="16" height="4" rx="1.2" fill="none" stroke="currentColor" stroke-width="1.6" />
+                    </svg>
+                </div>
+                <div class="tile__content">
+                    <span class="tile__label">Total Downloads</span>
+                    <span class="tile__value">@FormatCount(stats.Summary.TotalDownloads)</span>
+                    <div class="tile__meta">
+                        <span class="tile__delta @GetTrendBadgeClass(stats.DownloadTrend)">@GetTrendChangeText(stats.DownloadTrend)</span>
+                        <span class="tile__caption">vs previous day</span>
+                    </div>
+                    <span class="tile__hint">Resource downloads completed in the range</span>
+                </div>
+            </article>
+        </section>
 
         <div class="trend-charts">
-            <div class="chart">
-                <h4>Logins Trend</h4>
+            <div class="chart-card" style="--chart-accent: #4c6ef5; --chart-accent-rgb: 76, 110, 245;">
+                <div class="chart-card__header">
+                    <div class="chart-card__titles">
+                        <span class="chart-card__eyebrow">Activity</span>
+                        <h4>Logins Trend</h4>
+                        <span class="chart-card__subtitle">@GetTrendSubtitle(stats.LoginTrend)</span>
+                    </div>
+                    <div class="chart-card__value">
+                        <span class="chart-card__number">@GetTrendLatestValue(stats.LoginTrend)</span>
+                        <span class="chart-card__badge @GetTrendBadgeClass(stats.LoginTrend)">@GetTrendChangeText(stats.LoginTrend)</span>
+                    </div>
+                </div>
                 @if (stats.LoginTrend.Any())
                 {
-                    <svg width="100%" height="100" viewBox="0 0 100 100">
-                        <polyline fill="none" stroke="blue" stroke-width="2" points="@GetTrendPoints(stats.LoginTrend)" />
-                    </svg>
+                    var gradientId = GetGradientId("logins");
+                    var lastPoint = GetTrendLastPoint(stats.LoginTrend);
+                    <div class="chart-card__chart">
+                        <svg viewBox="0 0 100 100" preserveAspectRatio="none" role="img" aria-label="Logins trend">
+                            <defs>
+                                <linearGradient id="@gradientId" x1="0" y1="0" x2="0" y2="1">
+                                    <stop offset="0%" stop-color="#4c6ef5" stop-opacity="0.38" />
+                                    <stop offset="100%" stop-color="#4c6ef5" stop-opacity="0" />
+                                </linearGradient>
+                            </defs>
+                            <g class="chart-grid">
+                                @foreach (var y in GetHorizontalGridLines(4))
+                                {
+                                    <line x1="0" x2="100" y1="@FormatDouble(y)" y2="@FormatDouble(y)" vector-effect="non-scaling-stroke" />
+                                }
+                            </g>
+                            <polygon class="chart-area" points="@GetTrendFillPoints(stats.LoginTrend)" fill="@($"url(#{gradientId})")" />
+                            <polyline class="chart-line" points="@GetTrendLinePoints(stats.LoginTrend)" stroke="#4c6ef5" stroke-width="1.6" stroke-linecap="round" fill="none" vector-effect="non-scaling-stroke" />
+                            @if (lastPoint is { } point)
+                            {
+                                <circle class="chart-dot" cx="@FormatDouble(point.X)" cy="@FormatDouble(point.Y)" r="1.8" fill="#4c6ef5" />
+                            }
+                        </svg>
+                    </div>
+                    <div class="chart-card__axis">
+                        @foreach (var label in GetTrendAxisLabels(stats.LoginTrend))
+                        {
+                            <span>@label</span>
+                        }
+                    </div>
+                    <div class="chart-card__insights" role="list">
+                        <div class="chart-insight" role="listitem">
+                            <span class="chart-insight__label">Peak day</span>
+                            <span class="chart-insight__value">@GetTrendPeakInsight(stats.LoginTrend)</span>
+                        </div>
+                        <div class="chart-insight" role="listitem">
+                            <span class="chart-insight__label">Daily average</span>
+                            <span class="chart-insight__value">@GetTrendAverageInsight(stats.LoginTrend)</span>
+                        </div>
+                    </div>
                 }
                 else
                 {
-                    <p>No data.</p>
+                    <div class="chart-card__empty">No data.</div>
                 }
             </div>
 
-            <div class="chart">
-                <h4>Downloads Trend</h4>
+            <div class="chart-card" style="--chart-accent: #0ea5e9; --chart-accent-rgb: 14, 165, 233;">
+                <div class="chart-card__header">
+                    <div class="chart-card__titles">
+                        <span class="chart-card__eyebrow">Resources</span>
+                        <h4>Downloads Trend</h4>
+                        <span class="chart-card__subtitle">@GetTrendSubtitle(stats.DownloadTrend)</span>
+                    </div>
+                    <div class="chart-card__value">
+                        <span class="chart-card__number">@GetTrendLatestValue(stats.DownloadTrend)</span>
+                        <span class="chart-card__badge @GetTrendBadgeClass(stats.DownloadTrend)">@GetTrendChangeText(stats.DownloadTrend)</span>
+                    </div>
+                </div>
                 @if (stats.DownloadTrend.Any())
                 {
-                    <svg width="100%" height="100" viewBox="0 0 100 100">
-                        <polyline fill="none" stroke="green" stroke-width="2" points="@GetTrendPoints(stats.DownloadTrend)" />
-                    </svg>
+                    var gradientId = GetGradientId("downloads");
+                    var lastPoint = GetTrendLastPoint(stats.DownloadTrend);
+                    <div class="chart-card__chart">
+                        <svg viewBox="0 0 100 100" preserveAspectRatio="none" role="img" aria-label="Downloads trend">
+                            <defs>
+                                <linearGradient id="@gradientId" x1="0" y1="0" x2="0" y2="1">
+                                    <stop offset="0%" stop-color="#0ea5e9" stop-opacity="0.38" />
+                                    <stop offset="100%" stop-color="#0ea5e9" stop-opacity="0" />
+                                </linearGradient>
+                            </defs>
+                            <g class="chart-grid">
+                                @foreach (var y in GetHorizontalGridLines(4))
+                                {
+                                    <line x1="0" x2="100" y1="@FormatDouble(y)" y2="@FormatDouble(y)" vector-effect="non-scaling-stroke" />
+                                }
+                            </g>
+                            <polygon class="chart-area" points="@GetTrendFillPoints(stats.DownloadTrend)" fill="@($"url(#{gradientId})")" />
+                            <polyline class="chart-line" points="@GetTrendLinePoints(stats.DownloadTrend)" stroke="#0ea5e9" stroke-width="1.6" stroke-linecap="round" fill="none" vector-effect="non-scaling-stroke" />
+                            @if (lastPoint is { } point)
+                            {
+                                <circle class="chart-dot" cx="@FormatDouble(point.X)" cy="@FormatDouble(point.Y)" r="1.8" fill="#0ea5e9" />
+                            }
+                        </svg>
+                    </div>
+                    <div class="chart-card__axis">
+                        @foreach (var label in GetTrendAxisLabels(stats.DownloadTrend))
+                        {
+                            <span>@label</span>
+                        }
+                    </div>
+                    <div class="chart-card__insights" role="list">
+                        <div class="chart-insight" role="listitem">
+                            <span class="chart-insight__label">Peak day</span>
+                            <span class="chart-insight__value">@GetTrendPeakInsight(stats.DownloadTrend)</span>
+                        </div>
+                        <div class="chart-insight" role="listitem">
+                            <span class="chart-insight__label">Daily average</span>
+                            <span class="chart-insight__value">@GetTrendAverageInsight(stats.DownloadTrend)</span>
+                        </div>
+                    </div>
                 }
                 else
                 {
-                    <p>No data.</p>
+                    <div class="chart-card__empty">No data.</div>
                 }
             </div>
         </div>
@@ -65,10 +251,43 @@
 </ResponsivePage>
 
 @code {
-    private DateTime startDate = DateTime.Today.AddDays(-7);
+    private DateTime startDate = DateTime.Today.AddDays(-6);
     private DateTime endDate = DateTime.Today;
+    private readonly QuickRangeOption[] quickRangeOptions = new[]
+    {
+        new QuickRangeOption("7D", "Last 7 days", 7),
+        new QuickRangeOption("14D", "Last 14 days", 14),
+        new QuickRangeOption("30D", "Last 30 days", 30),
+    };
+    private int? activeQuickRangeDays = 7;
     private StatisticsResult? stats;
     private bool isLoading = true;
+
+    private DateTime StartDate
+    {
+        get => startDate;
+        set
+        {
+            if (startDate != value)
+            {
+                startDate = value.Date;
+                activeQuickRangeDays = null;
+            }
+        }
+    }
+
+    private DateTime EndDate
+    {
+        get => endDate;
+        set
+        {
+            if (endDate != value)
+            {
+                endDate = value.Date;
+                activeQuickRangeDays = null;
+            }
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -78,26 +297,284 @@
     private async Task LoadStatistics()
     {
         isLoading = true;
+
+        if (startDate > endDate)
+        {
+            (startDate, endDate) = (endDate, startDate);
+        }
+
         stats = await StatisticsService.GetStatisticsAsync(startDate, endDate);
+        AlignActiveQuickRange();
         isLoading = false;
     }
 
-    private static string GetTrendPoints(List<TrendPoint> trend)
+    private async Task ApplyQuickRangeAsync(int days)
     {
-        if (trend.Count == 0) return string.Empty;
+        endDate = DateTime.Today;
+        startDate = endDate.AddDays(-(days - 1));
+        activeQuickRangeDays = days;
+        await LoadStatistics();
+    }
+
+    private string GetQuickRangeClass(int days) => activeQuickRangeDays == days ? "active" : string.Empty;
+
+    private string GetRangeSummaryText()
+    {
+        if (StartDate.Date == EndDate.Date)
+        {
+            return EndDate.ToString("MMM d, yyyy", CultureInfo.CurrentCulture);
+        }
+
+        return string.Format(CultureInfo.CurrentCulture, "{0:MMM d} – {1:MMM d, yyyy}", StartDate, EndDate);
+    }
+
+    private string GetRangeWindowText()
+    {
+        var window = CalculateRangeDays(StartDate, EndDate);
+        return FormatDayWindowText(window);
+    }
+
+    private static string FormatCount(int value) => value.ToString("N0", CultureInfo.CurrentCulture);
+
+    private static string GetGradientId(string key) => $"trend-gradient-{key}";
+
+    private static string GetTrendSubtitle(List<TrendPoint> trend)
+    {
+        if (trend.Count == 0)
+        {
+            return "Awaiting data";
+        }
+
+        var first = trend.First().Date;
+        var last = trend.Last().Date;
+
+        if (first.Date == last.Date)
+        {
+            return first.ToString("MMM d, yyyy", CultureInfo.CurrentCulture);
+        }
+
+        return $"{first.ToString("MMM d", CultureInfo.CurrentCulture)} - {last.ToString("MMM d", CultureInfo.CurrentCulture)}";
+    }
+
+    private static string GetTrendLatestValue(List<TrendPoint> trend)
+        => trend.Count == 0
+            ? "0"
+            : trend[^1].Value.ToString("N0", CultureInfo.CurrentCulture);
+
+    private static string GetTrendChangeText(List<TrendPoint> trend)
+    {
+        if (trend.Count < 2)
+        {
+            return "0";
+        }
+
+        var delta = trend[^1].Value - trend[^2].Value;
+        return delta.ToString("+#;-#;0", CultureInfo.CurrentCulture);
+    }
+
+    private static string GetTrendBadgeClass(List<TrendPoint> trend)
+    {
+        if (trend.Count < 2)
+        {
+            return "neutral";
+        }
+
+        var delta = trend[^1].Value - trend[^2].Value;
+        if (delta > 0)
+        {
+            return "positive";
+        }
+
+        if (delta < 0)
+        {
+            return "negative";
+        }
+
+        return "neutral";
+    }
+
+    private static List<(double X, double Y)> NormalizeTrend(List<TrendPoint> trend)
+    {
+        var normalized = new List<(double X, double Y)>(trend.Count);
+        if (trend.Count == 0)
+        {
+            return normalized;
+        }
+
         var max = trend.Max(p => p.Value);
         var min = trend.Min(p => p.Value);
         var range = max - min;
-        if (range == 0) range = 1;
-
-        var points = new System.Text.StringBuilder();
-        for (int i = 0; i < trend.Count; i++)
+        if (range == 0)
         {
-            var x = (double)i / (trend.Count - 1) * 100;
-            var y = 100 - ((double)(trend[i].Value - min) / range * 100);
-            points.AppendFormat(System.Globalization.CultureInfo.InvariantCulture, "{0:F2},{1:F2} ", x, y);
+            range = 1;
         }
-        return points.ToString();
+
+        var denominator = Math.Max(trend.Count - 1, 1);
+
+        for (var i = 0; i < trend.Count; i++)
+        {
+            var x = (double)i / denominator * 100d;
+            var y = 100d - ((trend[i].Value - min) / (double)range * 100d);
+            normalized.Add((x, y));
+        }
+
+        return normalized;
     }
+
+    private static string GetTrendLinePoints(List<TrendPoint> trend)
+    {
+        var normalized = NormalizeTrend(trend);
+        if (normalized.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var builder = new System.Text.StringBuilder(normalized.Count * 10);
+        foreach (var point in normalized)
+        {
+            builder.AppendFormat(CultureInfo.InvariantCulture, "{0:F2},{1:F2} ", point.X, point.Y);
+        }
+
+        return builder.ToString().TrimEnd();
+    }
+
+    private static string GetTrendFillPoints(List<TrendPoint> trend)
+    {
+        var normalized = NormalizeTrend(trend);
+        if (normalized.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var builder = new System.Text.StringBuilder(normalized.Count * 12);
+        builder.AppendFormat(CultureInfo.InvariantCulture, "{0:F2},{1:F2} ", normalized[0].X, 100d);
+        foreach (var point in normalized)
+        {
+            builder.AppendFormat(CultureInfo.InvariantCulture, "{0:F2},{1:F2} ", point.X, point.Y);
+        }
+        builder.AppendFormat(CultureInfo.InvariantCulture, "{0:F2},{1:F2}", normalized[^1].X, 100d);
+
+        return builder.ToString();
+    }
+
+    private static (double X, double Y)? GetTrendLastPoint(List<TrendPoint> trend)
+    {
+        var normalized = NormalizeTrend(trend);
+        if (normalized.Count == 0)
+        {
+            return null;
+        }
+
+        var point = normalized[^1];
+        return (point.X, point.Y);
+    }
+
+    private static IEnumerable<double> GetHorizontalGridLines(int count)
+    {
+        if (count <= 0)
+        {
+            yield break;
+        }
+
+        for (var i = 1; i <= count; i++)
+        {
+            yield return (double)i / (count + 1) * 100d;
+        }
+    }
+
+    private static string FormatDouble(double value) => value.ToString("F2", CultureInfo.InvariantCulture);
+
+    private static IEnumerable<string> GetTrendAxisLabels(List<TrendPoint> trend)
+    {
+        if (trend.Count == 0)
+        {
+            yield break;
+        }
+
+        if (trend.Count == 1)
+        {
+            yield return trend[0].Date.ToString("MMM d", CultureInfo.CurrentCulture);
+            yield break;
+        }
+
+        yield return trend.First().Date.ToString("MMM d", CultureInfo.CurrentCulture);
+
+        if (trend.Count > 2)
+        {
+            yield return trend[trend.Count / 2].Date.ToString("MMM d", CultureInfo.CurrentCulture);
+        }
+
+        yield return trend.Last().Date.ToString("MMM d", CultureInfo.CurrentCulture);
+    }
+
+    private string GetTrendPeakInsight(List<TrendPoint> trend)
+    {
+        var peak = FindPeakPoint(trend);
+        if (peak is null)
+        {
+            return "Awaiting data";
+        }
+
+        return string.Format(CultureInfo.CurrentCulture, "{0:N0} on {1:MMM d}", peak.Value, peak.Date);
+    }
+
+    private string GetTrendAverageInsight(List<TrendPoint> trend)
+    {
+        if (trend.Count == 0)
+        {
+            return "Awaiting data";
+        }
+
+        var average = trend.Average(point => point.Value);
+        return string.Format(CultureInfo.CurrentCulture, "{0:N0} avg / day", average);
+    }
+
+    private static TrendPoint? FindPeakPoint(List<TrendPoint> trend)
+    {
+        TrendPoint? peak = null;
+        foreach (var point in trend)
+        {
+            if (peak is null || point.Value > peak.Value)
+            {
+                peak = point;
+            }
+        }
+
+        return peak;
+    }
+
+    private static int CalculateRangeDays(DateTime start, DateTime end)
+    {
+        var normalizedStart = start.Date;
+        var normalizedEnd = end.Date;
+        if (normalizedStart > normalizedEnd)
+        {
+            (normalizedStart, normalizedEnd) = (normalizedEnd, normalizedStart);
+        }
+
+        return (normalizedEnd - normalizedStart).Days + 1;
+    }
+
+    private static string FormatDayWindowText(int dayCount)
+        => dayCount <= 1
+            ? "Single day view"
+            : string.Format(CultureInfo.CurrentCulture, "{0} day window", dayCount);
+
+    private void AlignActiveQuickRange()
+    {
+        var window = CalculateRangeDays(startDate, endDate);
+        foreach (var option in quickRangeOptions)
+        {
+            if (option.Days == window)
+            {
+                activeQuickRangeDays = option.Days;
+                return;
+            }
+        }
+
+        activeQuickRangeDays = null;
+    }
+
+    private sealed record QuickRangeOption(string Label, string Description, int Days);
 }
 

--- a/src/Web/NexaCRM.WebClient/Pages/StatisticsDashboardPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/StatisticsDashboardPage.razor.css
@@ -1,50 +1,639 @@
 /* StatisticsDashboardPage styles */
 
-.summary-tiles {
+.dashboard-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: clamp(1.25rem, 4vw, 3rem);
+    margin-bottom: clamp(1.5rem, 4vw, 2.75rem);
+}
+
+.dashboard-header__copy h3 {
+    margin: 0;
+    font-size: clamp(1.75rem, 4vw, 2.25rem);
+    color: #0f172a;
+}
+
+.dashboard-header__eyebrow {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(15, 23, 42, 0.55);
+    margin-bottom: 0.35rem;
+}
+
+.dashboard-header__subtitle {
+    margin-top: 0.5rem;
+    margin-bottom: 0;
+    max-width: 46ch;
+    color: #475569;
+    line-height: 1.55;
+}
+
+.dashboard-header__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    align-items: flex-end;
+    font-weight: 600;
+    color: #1e293b;
+}
+
+.dashboard-header__range {
+    font-size: 0.95rem;
+}
+
+.dashboard-header__window {
+    font-size: 0.8rem;
+    font-weight: 500;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(59, 130, 246, 0.08);
+    color: #2563eb;
+}
+
+.dashboard-toolbar {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--spacing-md, 1rem);
-    margin: var(--spacing-md, 1rem) 0;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: clamp(1rem, 3vw, 1.75rem);
+    margin-bottom: clamp(1.5rem, 3vw, 2rem);
 }
 
-.summary-tiles .tile {
-    flex: 1;
-    padding: var(--spacing-md, 1rem);
-    border: 1px solid var(--border-color, #d0d9e7);
-    border-radius: 0.5rem;
-    text-align: center;
-}
-
-.trend-charts {
+.quick-ranges {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--spacing-md, 1rem);
+    gap: 0.75rem;
 }
 
-.trend-charts .chart {
-    flex: 1;
-    min-width: 250px;
+.quick-range-button {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+    padding: 0.65rem 1.1rem;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    border-radius: 0.85rem;
+    background: rgba(255, 255, 255, 0.85);
+    box-shadow: 0 18px 36px -28px rgba(15, 23, 42, 0.45);
+    color: #0f172a;
+    cursor: pointer;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease, background 0.25s ease;
+    min-width: 110px;
+}
+
+.quick-range-button:hover:not(:disabled),
+.quick-range-button:focus-visible:not(:disabled) {
+    transform: translateY(-2px);
+    border-color: rgba(59, 130, 246, 0.4);
+    box-shadow: 0 22px 44px -28px rgba(59, 130, 246, 0.45);
+}
+
+.quick-range-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.quick-range-button.active {
+    border-color: rgba(37, 99, 235, 0.65);
+    background: linear-gradient(150deg, rgba(37, 99, 235, 0.16) 0%, rgba(14, 165, 233, 0.12) 100%);
+    box-shadow: 0 24px 48px -26px rgba(37, 99, 235, 0.55);
+}
+
+.quick-range-button__label {
+    font-weight: 700;
+    font-size: 0.95rem;
+}
+
+.quick-range-button__caption {
+    font-size: 0.75rem;
+    color: #64748b;
 }
 
 .date-range {
     display: flex;
     flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 0.85rem;
+}
+
+.date-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #475569;
+}
+
+.date-field input[type="date"] {
+    padding: 0.55rem 0.75rem;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(148, 163, 184, 0.55);
+    background: #f8fafc;
+    color: #0f172a;
+    font-size: 0.85rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.date-field input[type="date"]:focus {
+    outline: none;
+    border-color: rgba(37, 99, 235, 0.7);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+    background: #ffffff;
+}
+
+.btn-refresh {
+    display: inline-flex;
     align-items: center;
-    gap: var(--spacing-sm, 0.5rem);
-    margin-bottom: var(--spacing-md, 1rem);
+    justify-content: center;
+    padding: 0.65rem 1.35rem;
+    border-radius: 0.85rem;
+    border: none;
+    background: linear-gradient(135deg, #2563eb 0%, #4338ca 100%);
+    color: #ffffff;
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+    min-width: 120px;
+}
+
+.btn-refresh:hover:not(:disabled),
+.btn-refresh:focus-visible:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 38px -20px rgba(37, 99, 235, 0.6);
+}
+
+.btn-refresh:disabled {
+    cursor: not-allowed;
+    filter: grayscale(0.25);
+    opacity: 0.8;
+}
+
+.summary-tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: clamp(1.25rem, 3vw, 1.75rem);
+    margin: var(--spacing-md, 1rem) 0 clamp(1.5rem, 3vw, 2.25rem);
+}
+
+.summary-tiles .tile {
+    position: relative;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 1.25rem;
+    align-items: center;
+    padding: clamp(1.2rem, 3vw, 1.65rem);
+    border-radius: 1.25rem;
+    border: 1px solid rgba(var(--tile-accent-rgb, 59, 130, 246), 0.25);
+    background: linear-gradient(150deg, rgba(var(--tile-accent-rgb, 59, 130, 246), 0.18) 0%, rgba(255, 255, 255, 0.95) 78%);
+    box-shadow: 0 24px 48px -28px rgba(15, 23, 42, 0.45);
+    color: #0f172a;
+    overflow: hidden;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.summary-tiles .tile::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(120% 120% at 0% 0%, rgba(var(--tile-accent-rgb, 59, 130, 246), 0.25) 0%, rgba(var(--tile-accent-rgb, 59, 130, 246), 0) 68%);
+    opacity: 0.9;
+    pointer-events: none;
+}
+
+.summary-tiles .tile:hover,
+.summary-tiles .tile:focus-within {
+    transform: translateY(-4px);
+    box-shadow: 0 28px 56px -28px rgba(15, 23, 42, 0.55);
+}
+
+.tile__icon {
+    position: relative;
+    z-index: 1;
+    width: 3rem;
+    height: 3rem;
+    border-radius: 1rem;
+    display: grid;
+    place-items: center;
+    background: rgba(255, 255, 255, 0.7);
+    color: var(--tile-accent, #2563eb);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65), 0 10px 24px -16px rgba(15, 23, 42, 0.45);
+}
+
+.tile__icon svg {
+    width: 1.6rem;
+    height: 1.6rem;
+}
+
+.tile__content {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.tile__label {
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(15, 23, 42, 0.6);
+}
+
+.tile__value {
+    font-size: clamp(1.7rem, 3.5vw, 2.1rem);
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.tile__meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-top: 0.1rem;
+}
+
+.tile__delta {
+    padding: 0.25rem 0.65rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    background: rgba(37, 99, 235, 0.1);
+    color: #2563eb;
+}
+
+.tile__delta.positive {
+    background: rgba(34, 197, 94, 0.18);
+    color: #16a34a;
+}
+
+.tile__delta.negative {
+    background: rgba(248, 113, 113, 0.2);
+    color: #f43f5e;
+}
+
+.tile__delta.neutral {
+    background: rgba(148, 163, 184, 0.18);
+    color: #64748b;
+}
+
+.tile__caption {
+    font-size: 0.75rem;
+    color: #64748b;
+}
+
+.tile__hint {
+    margin-top: 0.25rem;
+    font-size: 0.78rem;
+    color: rgba(71, 85, 105, 0.85);
+}
+
+.trend-charts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: clamp(1.5rem, 3vw, 2rem);
+    align-items: stretch;
+    margin-top: clamp(1.75rem, 3vw, 2.25rem);
+}
+
+.chart-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.35rem, 3vw, 1.85rem);
+    padding: clamp(1.45rem, 3vw, 2rem);
+    border-radius: 1.25rem;
+    background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    box-shadow: 0 24px 48px -28px rgba(15, 23, 42, 0.4);
+    overflow: hidden;
+    --chart-accent: #4c6ef5;
+    --chart-accent-rgb: 76, 110, 245;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.chart-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(135% 135% at 0% 0%, rgba(var(--chart-accent-rgb), 0.2) 0%, rgba(var(--chart-accent-rgb), 0) 68%);
+    opacity: 0.75;
+    pointer-events: none;
+}
+
+.chart-card:hover,
+.chart-card:focus-within {
+    transform: translateY(-4px);
+    box-shadow: 0 32px 64px -30px rgba(15, 23, 42, 0.55);
+}
+
+.chart-card__header,
+.chart-card__chart,
+.chart-card__axis,
+.chart-card__empty {
+    position: relative;
+    z-index: 1;
+}
+
+.chart-card__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.chart-card__titles {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.chart-card__eyebrow {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(15, 23, 42, 0.58);
+}
+
+.chart-card__titles h4 {
+    margin: 0;
+    font-size: clamp(1.05rem, 2.6vw, 1.25rem);
+    color: #0f172a;
+}
+
+.chart-card__subtitle {
+    font-size: 0.85rem;
+    color: #64748b;
+}
+
+.chart-card__value {
+    display: flex;
+    align-items: flex-end;
+    gap: 0.75rem;
+    text-align: right;
+}
+
+.chart-card__number {
+    font-size: clamp(1.6rem, 3vw, 1.95rem);
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.chart-card__badge {
+    align-self: center;
+    padding: 0.3rem 0.85rem;
+    border-radius: 9999px;
+    font-weight: 600;
+    font-size: 0.75rem;
+    background: rgba(37, 99, 235, 0.12);
+    color: #2563eb;
+}
+
+.chart-card__badge.positive {
+    background: rgba(34, 197, 94, 0.18);
+    color: #16a34a;
+}
+
+.chart-card__badge.negative {
+    background: rgba(248, 113, 113, 0.2);
+    color: #f43f5e;
+}
+
+.chart-card__badge.neutral {
+    background: rgba(148, 163, 184, 0.18);
+    color: #64748b;
+}
+
+.chart-card__chart {
+    position: relative;
+    height: clamp(180px, 32vw, 220px);
+}
+
+.chart-card__chart svg {
+    width: 100%;
+    height: 100%;
+    overflow: visible;
+}
+
+.chart-grid line {
+    stroke: rgba(148, 163, 184, 0.22);
+    stroke-width: 0.6;
+    stroke-dasharray: 2 6;
+}
+
+.chart-line {
+    fill: none;
+    stroke-dasharray: 320;
+    stroke-dashoffset: 320;
+    animation: chartLineDraw 1.3s cubic-bezier(0.33, 1, 0.68, 1) forwards;
+}
+
+.chart-dot {
+    stroke: #ffffff;
+    stroke-width: 0.6;
+    opacity: 0;
+    animation: chartDotPop 0.65s ease forwards 0.85s;
+}
+
+.chart-area {
+    transform-box: fill-box;
+    transform-origin: bottom center;
+    transform: scaleY(0.05);
+    opacity: 0;
+    animation: chartAreaReveal 1.1s ease forwards;
+}
+
+.chart-card__axis {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+    font-size: 0.75rem;
+    color: #94a3b8;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.chart-card__axis span {
+    white-space: nowrap;
+}
+
+.chart-card__insights {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.75rem;
+    padding-top: 0.25rem;
+}
+
+.chart-insight {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    padding: 0.75rem;
+    border-radius: 0.85rem;
+    background: rgba(var(--chart-accent-rgb, 148, 163, 184), 0.12);
+    border: 1px solid rgba(var(--chart-accent-rgb, 148, 163, 184), 0.18);
+    color: #1e293b;
+}
+
+.chart-insight__label {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(71, 85, 105, 0.85);
+}
+
+.chart-insight__value {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.chart-card__empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 140px;
+    font-size: 0.95rem;
+    color: #64748b;
+    background: rgba(148, 163, 184, 0.08);
+    border-radius: 1rem;
+}
+
+@keyframes chartLineDraw {
+    to {
+        stroke-dashoffset: 0;
+    }
+}
+
+@keyframes chartAreaReveal {
+    from {
+        transform: scaleY(0.05);
+        opacity: 0;
+    }
+
+    to {
+        transform: scaleY(1);
+        opacity: 1;
+    }
+}
+
+@keyframes chartDotPop {
+    from {
+        opacity: 0;
+        transform: scale(0.65);
+    }
+
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .quick-range-button,
+    .summary-tiles .tile,
+    .chart-card,
+    .chart-line,
+    .chart-area,
+    .chart-dot {
+        transition-duration: 0s !important;
+        animation: none !important;
+        transform: none !important;
+        stroke-dashoffset: 0 !important;
+        opacity: 1 !important;
+    }
+}
+
+@media (max-width: 1024px) {
+    .dashboard-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .dashboard-header__meta {
+        align-items: flex-start;
+    }
+}
+
+@media (max-width: 900px) {
+    .dashboard-toolbar {
+        gap: 1.25rem;
+    }
+
+    .quick-range-button {
+        min-width: 100px;
+    }
+
+    .chart-card__header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .chart-card__value {
+        align-items: center;
+        text-align: left;
+    }
+
+    .chart-card__insights {
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    }
+}
+
+@media (max-width: 768px) {
+    .dashboard-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .quick-ranges {
+        width: 100%;
+    }
+
+    .quick-range-button {
+        flex: 1 1 130px;
+        width: 100%;
+    }
+
+    .date-range {
+        width: 100%;
+        justify-content: space-between;
+    }
 }
 
 @media (max-width: 600px) {
     .summary-tiles {
-        flex-direction: column;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     }
 
-    .trend-charts {
-        flex-direction: column;
+    .summary-tiles .tile {
+        grid-template-columns: 1fr;
+        text-align: left;
     }
 
-    .trend-charts .chart {
-        min-width: 100%;
+    .tile__icon {
+        width: 2.75rem;
+        height: 2.75rem;
+    }
+
+    .dashboard-header__meta {
+        width: 100%;
+        align-items: flex-start;
+    }
+
+    .chart-card {
+        padding: 1.3rem;
+    }
+
+    .chart-card__insights {
+        grid-template-columns: repeat(auto-fit, minmax(100%, 1fr));
     }
 
     .date-range {


### PR DESCRIPTION
## Summary
- add a richer dashboard header with quick range presets, accessible date inputs, and live range labels for the statistics view
- refresh the summary metric tiles with iconography, change badges, and supporting copy alongside updated styling
- animate the trend charts, surface peak and average insights, and refine responsive chart/card visuals

## Testing
- `dotnet build --configuration Release` *(fails: `dotnet` command is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c88e9d9718832ca93801cd8f58c0ab