### PR TITLE
Refine close control and logout divider in navigation menu

### DIFF
--- a/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.en-US.resx
@@ -15,6 +15,9 @@
   <data name="BulkSms" xml:space="preserve">
     <value>Bulk SMS</value>
   </data>
+  <data name="CloseMenu" xml:space="preserve">
+    <value>Close menu</value>
+  </data>
   <data name="CompanyInfo" xml:space="preserve">
     <value>Company Information</value>
   </data>

--- a/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.ko-KR.resx
@@ -15,6 +15,9 @@
   <data name="BulkSms" xml:space="preserve">
     <value>대량 문자</value>
   </data>
+  <data name="CloseMenu" xml:space="preserve">
+    <value>메뉴 닫기</value>
+  </data>
   <data name="CompanyInfo" xml:space="preserve">
     <value>회사 정보</value>
   </data>

--- a/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor
@@ -13,8 +13,17 @@
 @inject IJSRuntime JSRuntime
 @inject IRolePermissionService RolePermissionService
 
-<div @onclick:stopPropagation="true">
+<div class="nav-menu" @onclick:stopPropagation="true">
     <nav class="flex-column">
+        <div class="nav-header">
+            <button type="button"
+                    class="nav-close-button"
+                    title="@Localizer["CloseMenu"]"
+                    aria-label="@Localizer["CloseMenu"]"
+                    @onclick="CloseNavMenu">
+                <i class="bi bi-x-lg" aria-hidden="true"></i>
+            </button>
+        </div>
         <div class="nav-scroll-container">
             <!-- Always visible base menu -->
             <div class="nav-item px-3">
@@ -250,7 +259,7 @@
                     </div>
 
                     <!-- Logout button -->
-                    <div class="nav-item px-3 mt-auto">
+                    <div class="nav-item px-3 mt-auto logout-item">
                         <button class="nav-link btn btn-link" @onclick="Logout">
                             <i class="bi bi-box-arrow-right me-2" aria-hidden="true"></i> @Localizer["Logout"]
                         </button>

--- a/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor.css
+++ b/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor.css
@@ -1,12 +1,87 @@
+/* Navigation layout structure */
+.nav-menu {
+    height: 100%;
+}
+
+.nav-menu nav.flex-column {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+.nav-header {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    padding: var(--spacing-lg, 1.5rem) var(--spacing-lg, 1.5rem) var(--spacing-sm, 0.5rem);
+    background: var(--surface-color);
+    border-bottom: 1px solid var(--divider-color);
+}
+
+.nav-scroll-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs, 0.25rem);
+    padding: var(--spacing-sm, 0.5rem) 0 var(--spacing-xl, 2rem);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+}
+
+/* Close control styling */
+.nav-close-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--touch-target-min, 2.75rem);
+    height: var(--touch-target-min, 2.75rem);
+    border-radius: 0.75rem;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 1.25rem;
+    line-height: 1;
+    cursor: pointer;
+    transition: background-color var(--transition-fast, 0.2s ease),
+                color var(--transition-fast, 0.2s ease),
+                box-shadow var(--transition-fast, 0.2s ease),
+                transform var(--transition-fast, 0.2s ease);
+    touch-action: manipulation;
+}
+
+.nav-close-button:hover {
+    background-color: var(--hover-overlay);
+    color: var(--text-primary);
+    transform: scale(1.04);
+}
+
+.nav-close-button:active {
+    transform: scale(0.98);
+}
+
+.nav-close-button:focus-visible {
+    outline: none;
+    background-color: var(--hover-overlay);
+    border-color: var(--focus-ring, rgba(33, 83, 200, 0.28));
+    box-shadow: 0 0 0 0.2rem var(--focus-ring, rgba(33, 83, 200, 0.28));
+}
+
+.nav-close-button i {
+    pointer-events: none;
+}
+
 /* Override hardcoded colors to support dark mode theming */
 .nav-section-header {
     color: var(--text-primary);
 }
-/* 다크모드에서 DB 고객관리 텍스트 밝게 */
+
 .dark-mode .nav-section-header {
     color: #f5f5f5 !important;
     font-weight: 600;
-    text-shadow: 0 1px 4px rgba(0,0,0,0.3);
+    text-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
 }
 
 .submenu-link {
@@ -20,4 +95,24 @@
 .submenu-link.active {
     background-color: var(--primary-color);
     color: white !important; /* Ensure text is white on active background */
+}
+
+/* Logout divider */
+.logout-item {
+    position: relative;
+    margin-top: var(--spacing-sm, 0.5rem);
+    padding-top: var(--spacing-md, 1rem);
+}
+
+.logout-item::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: var(--spacing-md, 1rem);
+    right: var(--spacing-md, 1rem);
+    border-top: 1px solid var(--divider-color);
+}
+
+.logout-item .nav-link {
+    margin-bottom: var(--spacing-sm, 0.5rem);
 }


### PR DESCRIPTION
## Summary
- add a dedicated close button with localization at the top of the navigation menu
- refine the navigation header and logout divider styling so the close control stays visible, honors design spacing tokens, and matches the requested separator treatment
- localize the close action caption in both English and Korean resource files

## Testing
- `dotnet build --configuration Release` *(fails: command not found: dotnet)*
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_68c8981c8298832cb94f46de531e81af