### PR TITLE
refactor: replace administrator labels with admin

### DIFF
--- a/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.en-US.resx
@@ -151,7 +151,7 @@
     <value>Statistics Dashboard</value>
   </data>
   <data name="SystemAdmin" xml:space="preserve">
-    <value>System Administrator</value>
+    <value>System Admin</value>
   </data>
   <data name="SystemInfo" xml:space="preserve">
     <value>System Info</value>

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IOrganizationService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IOrganizationService.cs
@@ -18,7 +18,7 @@ public interface IOrganizationService
     Task<IEnumerable<OrganizationUser>> GetUsersAsync();
     Task UpdateUserAsync(OrganizationUser user);
     Task DeleteUserAsync(int userId);
-    Task SetSystemAdministratorAsync(string userId);
+    Task SetSystemAdminAsync(string userId);
     Task RegisterUserAsync(NewUserModel user);
 }
 

--- a/src/Web/NexaCRM.WebClient/Services/OrganizationService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/OrganizationService.cs
@@ -29,14 +29,14 @@ public class OrganizationService : IOrganizationService
 
     private readonly List<OrganizationUser> _users =
     [
-        new() { Id = 1, Name = "Alice Kim", Email = "alice.kim@example.com", Role = "Administrator", Status = "Active" },
+        new() { Id = 1, Name = "Alice Kim", Email = "alice.kim@example.com", Role = "Admin", Status = "Active" },
         new() { Id = 2, Name = "Brian Lee", Email = "brian.lee@example.com", Role = "Manager", Status = "Active" },
         new() { Id = 3, Name = "Chloe Park", Email = "chloe.park@example.com", Role = "Analyst", Status = "Inactive" }
     ];
 
     private readonly List<AgentModel> _admins =
     [
-        new() { Id = 1, Name = "Alice Kim", Email = "alice.kim@example.com", Role = "Administrator" },
+        new() { Id = 1, Name = "Alice Kim", Email = "alice.kim@example.com", Role = "Admin" },
         new() { Id = 2, Name = "Brian Lee", Email = "brian.lee@example.com", Role = "Manager" }
     ];
 
@@ -96,7 +96,7 @@ public class OrganizationService : IOrganizationService
             Id = id,
             Name = $"Admin {id}",
             Email = $"admin{id}@example.com",
-            Role = "Administrator"
+            Role = "Admin"
         });
 
         return Task.CompletedTask;
@@ -131,7 +131,7 @@ public class OrganizationService : IOrganizationService
         return Task.CompletedTask;
     }
 
-    public Task SetSystemAdministratorAsync(string userId) => AddAdminAsync(userId);
+    public Task SetSystemAdminAsync(string userId) => AddAdminAsync(userId);
 
     public Task RegisterUserAsync(NewUserModel user)
     {


### PR DESCRIPTION
## Summary
- update organization service seed data to use the "Admin" role label consistently
- rename the system administrator helper on the organization service and interface to SetSystemAdminAsync
- adjust the navigation menu resource to display "System Admin"

## Testing
- dotnet build --configuration Release *(fails: dotnet not installed in container)*
- dotnet test ./tests/BlazorWebApp.Tests --configuration Release *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c89c9ff70c832cb65f4c9e2637b49f