### PR TITLE
feat: restrict system admin settings to admins

### DIFF
--- a/src/Web/NexaCRM.WebClient/Pages/SystemAdminSettingsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SystemAdminSettingsPage.razor
@@ -1,4 +1,5 @@
 @page "/organization/system-admin"
+@attribute [Authorize(Roles = "Admin")]
 @using System.Linq
 @using NexaCRM.WebClient.Services.Interfaces
 @using NexaCRM.WebClient.Components.UI


### PR DESCRIPTION
## Summary
- restrict access to the System Admin Settings page to administrators by adding an Authorize attribute

## Testing
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release` *(fails: dotnet command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68c89ca18f10832cace69d57a8c98202