### PR TITLE
Add developer role permissions and persistence

### DIFF
--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IRolePermissionService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IRolePermissionService.cs
@@ -5,25 +5,25 @@ namespace NexaCRM.WebClient.Services.Interfaces
     public interface IRolePermissionService
     {
         /// <summary>
-        /// 사용자가 고객 관리 페이지들에 접근할 수 있는지 확인
+        /// 사용자가 고객 관리 페이지들에 접근할 수 있는지 확인 (Sales, Manager, Admin, Developer 허용)
         /// </summary>
         Task<bool> CanAccessCustomerManagementAsync(ClaimsPrincipal user);
-        
+
         /// <summary>
-        /// 사용자가 신규 고객 등록 기능을 사용할 수 있는지 확인 (Sales 역할 제한)
+        /// 사용자가 신규 고객 등록 기능을 사용할 수 있는지 확인 (Sales 역할 제한, Developer 허용)
         /// </summary>
         Task<bool> CanCreateNewCustomerAsync(ClaimsPrincipal user);
-        
+
         /// <summary>
-        /// 사용자가 고객 정보를 수정할 수 있는지 확인
+        /// 사용자가 고객 정보를 수정할 수 있는지 확인 (Developer 포함)
         /// </summary>
         Task<bool> CanEditCustomerAsync(ClaimsPrincipal user);
-        
+
         /// <summary>
-        /// 사용자가 고객 정보를 조회할 수 있는지 확인
+        /// 사용자가 고객 정보를 조회할 수 있는지 확인 (Developer 포함)
         /// </summary>
         Task<bool> CanViewCustomerAsync(ClaimsPrincipal user);
-        
+
         /// <summary>
         /// 사용자의 역할을 확인
         /// </summary>

--- a/src/Web/NexaCRM.WebClient/Services/RolePermissionService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/RolePermissionService.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
 using NexaCRM.WebClient.Services.Interfaces;
 
@@ -5,40 +7,57 @@ namespace NexaCRM.WebClient.Services
 {
     public class RolePermissionService : IRolePermissionService
     {
+        private const string DeveloperRoleName = "Developer";
+
+        private static readonly string[] CustomerManagementRoles =
+        {
+            "Sales",
+            "Manager",
+            "Admin",
+            DeveloperRoleName
+        };
+
+        private static readonly string[] CreateCustomerRoles =
+        {
+            "Manager",
+            "Admin",
+            DeveloperRoleName
+        };
+
+        private static readonly string[] EditCustomerRoles =
+        {
+            "Sales",
+            "Manager",
+            "Admin",
+            DeveloperRoleName
+        };
+
+        private static readonly string[] ViewCustomerRoles =
+        {
+            "Sales",
+            "Manager",
+            "Admin",
+            DeveloperRoleName
+        };
+
         public Task<bool> CanAccessCustomerManagementAsync(ClaimsPrincipal user)
         {
-            // Sales 및 Manager 역할 모두 고객 관리 페이지에 접근 가능
-            return Task.FromResult(
-                user.Identity?.IsAuthenticated == true && 
-                (user.IsInRole("Sales") || user.IsInRole("Manager") || user.IsInRole("Admin"))
-            );
+            return Task.FromResult(HasRequiredRole(user, CustomerManagementRoles));
         }
 
         public Task<bool> CanCreateNewCustomerAsync(ClaimsPrincipal user)
         {
-            // Manager와 Admin만 신규 고객 등록 가능 (Sales 역할 제한)
-            return Task.FromResult(
-                user.Identity?.IsAuthenticated == true && 
-                (user.IsInRole("Manager") || user.IsInRole("Admin"))
-            );
+            return Task.FromResult(HasRequiredRole(user, CreateCustomerRoles));
         }
 
         public Task<bool> CanEditCustomerAsync(ClaimsPrincipal user)
         {
-            // Sales, Manager, Admin 모두 고객 정보 수정 가능
-            return Task.FromResult(
-                user.Identity?.IsAuthenticated == true && 
-                (user.IsInRole("Sales") || user.IsInRole("Manager") || user.IsInRole("Admin"))
-            );
+            return Task.FromResult(HasRequiredRole(user, EditCustomerRoles));
         }
 
         public Task<bool> CanViewCustomerAsync(ClaimsPrincipal user)
         {
-            // Sales, Manager, Admin 모두 고객 정보 조회 가능
-            return Task.FromResult(
-                user.Identity?.IsAuthenticated == true && 
-                (user.IsInRole("Sales") || user.IsInRole("Manager") || user.IsInRole("Admin"))
-            );
+            return Task.FromResult(HasRequiredRole(user, ViewCustomerRoles));
         }
 
         public Task<string[]> GetUserRolesAsync(ClaimsPrincipal user)
@@ -54,6 +73,24 @@ namespace NexaCRM.WebClient.Services
                 .ToArray();
 
             return Task.FromResult(roles);
+        }
+
+        private static bool HasRequiredRole(ClaimsPrincipal user, IEnumerable<string> allowedRoles)
+        {
+            if (user.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            foreach (var role in allowedRoles)
+            {
+                if (user.IsInRole(role))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/Web/NexaCRM.WebClient/wwwroot/js/auth-manager.js
+++ b/src/Web/NexaCRM.WebClient/wwwroot/js/auth-manager.js
@@ -2,50 +2,92 @@
 window.authManager = {
     // 세션 타임아웃: 30분 (밀리초)
     SESSION_TIMEOUT: 30 * 60 * 1000,
-    
+
+    // 로컬 스토리지 키
+    STORAGE_KEYS: {
+        USERNAME: 'username',
+        ROLES: 'roles',
+        DEVELOPER: 'isDeveloper'
+    },
+
     // 타이머 변수들
     sessionTimeoutId: null,
     lastActivityTime: Date.now(),
-    
+
     // 인증 상태 확인
     isAuthenticated: () => {
-        const username = localStorage.getItem('username');
-        const roles = localStorage.getItem('roles');
-        return !!(username && roles && username !== 'null' && roles !== 'null');
+        const username = localStorage.getItem(window.authManager.STORAGE_KEYS.USERNAME);
+        const roles = localStorage.getItem(window.authManager.STORAGE_KEYS.ROLES);
+        const developerFlag = localStorage.getItem(window.authManager.STORAGE_KEYS.DEVELOPER);
+
+        if (!username || username === 'null') {
+            return false;
+        }
+
+        if (roles && roles !== 'null') {
+            return true;
+        }
+
+        return developerFlag === 'true';
     },
-    
+
+    // Developer 역할 확인
+    isDeveloper: () => {
+        const developerFlag = localStorage.getItem(window.authManager.STORAGE_KEYS.DEVELOPER);
+        if (developerFlag === 'true') {
+            return true;
+        }
+
+        const roles = localStorage.getItem(window.authManager.STORAGE_KEYS.ROLES);
+        if (!roles || roles === 'null') {
+            return false;
+        }
+
+        try {
+            const parsedRoles = JSON.parse(roles);
+            if (Array.isArray(parsedRoles)) {
+                return parsedRoles.some(role => typeof role === 'string' && role.toLowerCase() === 'developer');
+            }
+        } catch (error) {
+            console.warn('Failed to parse stored roles for developer detection', error);
+        }
+
+        return false;
+    },
+
     // 로그아웃 처리
     logout: (reason = 'manual') => {
         console.log(`Logging out user: ${reason}`);
-        
+
         // localStorage 정리
-        localStorage.removeItem('username');
-        localStorage.removeItem('roles');
-        
+        localStorage.removeItem(window.authManager.STORAGE_KEYS.USERNAME);
+        localStorage.removeItem(window.authManager.STORAGE_KEYS.ROLES);
+        localStorage.removeItem(window.authManager.STORAGE_KEYS.DEVELOPER);
+
         // sessionStorage 정리
         sessionStorage.clear();
-        
+
         // 타이머 정리
         if (window.authManager.sessionTimeoutId) {
             clearTimeout(window.authManager.sessionTimeoutId);
             window.authManager.sessionTimeoutId = null;
         }
-        
+
         // 로그인 페이지로 리다이렉트 (현재 페이지가 로그인 페이지가 아닌 경우)
         if (!window.location.pathname.includes('/login')) {
             window.location.href = '/login';
         }
     },
-    
+
     // 세션 타임아웃 리셋
     resetSessionTimeout: () => {
         window.authManager.lastActivityTime = Date.now();
-        
+
         // 기존 타이머 클리어
         if (window.authManager.sessionTimeoutId) {
             clearTimeout(window.authManager.sessionTimeoutId);
         }
-        
+
         // 새로운 타이머 설정 (인증된 사용자에게만)
         if (window.authManager.isAuthenticated()) {
             window.authManager.sessionTimeoutId = setTimeout(() => {
@@ -53,7 +95,7 @@ window.authManager = {
             }, window.authManager.SESSION_TIMEOUT);
         }
     },
-    
+
     // 브라우저 종료 감지 및 처리
     setupBrowserCloseDetection: () => {
         // beforeunload 이벤트: 브라우저 종료, 탭 닫기, 새로고침 등
@@ -62,14 +104,14 @@ window.authManager = {
                 // 세션 정보 저장 (브라우저 종료 vs 새로고침 구분용)
                 sessionStorage.setItem('lastActiveTime', Date.now().toString());
                 sessionStorage.setItem('isClosing', 'true');
-                
+
                 // 짧은 지연 후 플래그 제거 (새로고침인 경우)
                 setTimeout(() => {
                     sessionStorage.removeItem('isClosing');
                 }, 100);
             }
         });
-        
+
         // pagehide 이벤트: 페이지가 숨겨질 때 (더 안정적)
         window.addEventListener('pagehide', (event) => {
             if (event.persisted) {
@@ -82,7 +124,7 @@ window.authManager = {
                 }
             }
         });
-        
+
         // pageshow 이벤트: 페이지가 표시될 때
         window.addEventListener('pageshow', (event) => {
             if (event.persisted) {
@@ -91,20 +133,20 @@ window.authManager = {
             }
         });
     },
-    
+
     // 페이지 로드 시 브라우저 종료 확인
     checkBrowserClosure: () => {
         const wasClosing = sessionStorage.getItem('isClosing');
         const pageUnloaded = sessionStorage.getItem('pageUnloaded');
         const lastActiveTime = sessionStorage.getItem('lastActiveTime');
-        
+
         if (pageUnloaded && !wasClosing) {
             // 브라우저가 완전히 종료되었다가 다시 시작됨
-            console.log('Browser was completely closed, clearing authentication');  
+            console.log('Browser was completely closed, clearing authentication');
             window.authManager.logout('browser_closed');
             return;
         }
-        
+
         if (lastActiveTime) {
             const timeDiff = Date.now() - parseInt(lastActiveTime);
             // 1시간 이상 지났으면 자동 로그아웃
@@ -114,34 +156,34 @@ window.authManager = {
                 return;
             }
         }
-        
+
         // cleanup
         sessionStorage.removeItem('isClosing');
         sessionStorage.removeItem('pageUnloaded');
         sessionStorage.removeItem('lastActiveTime');
     },
-    
+
     // 사용자 활동 추적 설정
     setupActivityTracking: () => {
         // 사용자 활동을 감지하는 이벤트들
         const activityEvents = [
-            'mousedown', 'mousemove', 'keypress', 'scroll', 
+            'mousedown', 'mousemove', 'keypress', 'scroll',
             'touchstart', 'click', 'keydown', 'keyup'
         ];
-        
+
         // 각 이벤트에 대해 리스너 등록
         activityEvents.forEach(eventName => {
             document.addEventListener(eventName, () => {
                 window.authManager.resetSessionTimeout();
             }, true);
         });
-        
+
         // 페이지 가시성 변경 감지
         document.addEventListener('visibilitychange', () => {
             if (!document.hidden) {
                 // 탭이 다시 활성화됨
                 window.authManager.resetSessionTimeout();
-                
+
                 // 오랜 시간 비활성화 후 활성화된 경우 인증 상태 재확인
                 const timeSinceLastActivity = Date.now() - window.authManager.lastActivityTime;
                 if (timeSinceLastActivity > window.authManager.SESSION_TIMEOUT) {
@@ -150,25 +192,25 @@ window.authManager = {
             }
         });
     },
-    
+
     // 초기화 함수
     initialize: () => {
         console.log('Initializing auth manager...');
-        
+
         // 브라우저 종료 감지 설정
         window.authManager.setupBrowserCloseDetection();
-        
+
         // 페이지 로드 시 브라우저 종료 확인
         window.authManager.checkBrowserClosure();
-        
+
         // 사용자 활동 추적 설정
         window.authManager.setupActivityTracking();
-        
+
         // 인증된 사용자인 경우 세션 타임아웃 시작
         if (window.authManager.isAuthenticated()) {
             window.authManager.resetSessionTimeout();
         }
-        
+
         console.log('Auth manager initialized');
     }
 };

--- a/src/Web/NexaCRM.WebClient/wwwroot/js/navigation.js
+++ b/src/Web/NexaCRM.WebClient/wwwroot/js/navigation.js
@@ -455,6 +455,7 @@ window.navigationHelper = {
                     console.log('Browser was closed, clearing authentication data');
                     localStorage.removeItem('username');
                     localStorage.removeItem('roles');
+                    localStorage.removeItem('isDeveloper');
                 }
             }
             // cleanup
@@ -475,6 +476,7 @@ window.navigationHelper = {
                     console.log('Session timeout, clearing authentication data');
                     localStorage.removeItem('username');
                     localStorage.removeItem('roles');
+                    localStorage.removeItem('isDeveloper');
                     window.location.href = '/login';
                 }
             }, 30 * 60 * 1000); // 30분

--- a/tests/NexaCRM.WebClient.UnitTests/RolePermissionServiceTests.cs
+++ b/tests/NexaCRM.WebClient.UnitTests/RolePermissionServiceTests.cs
@@ -1,0 +1,87 @@
+using System.Security.Claims;
+using System.Threading.Tasks;
+using NexaCRM.WebClient.Services;
+using Xunit;
+
+namespace NexaCRM.WebClient.UnitTests
+{
+    public class RolePermissionServiceTests
+    {
+        private readonly RolePermissionService _service = new();
+
+        [Fact]
+        public async Task CanAccessCustomerManagementAsync_DeveloperRole_ReturnsTrue()
+        {
+            var user = CreateAuthenticatedUser("Developer");
+
+            var result = await _service.CanAccessCustomerManagementAsync(user);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task CanCreateNewCustomerAsync_DeveloperRole_ReturnsTrue()
+        {
+            var user = CreateAuthenticatedUser("Developer");
+
+            var result = await _service.CanCreateNewCustomerAsync(user);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task CanEditCustomerAsync_DeveloperRole_ReturnsTrue()
+        {
+            var user = CreateAuthenticatedUser("Developer");
+
+            var result = await _service.CanEditCustomerAsync(user);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task CanViewCustomerAsync_DeveloperRole_ReturnsTrue()
+        {
+            var user = CreateAuthenticatedUser("Developer");
+
+            var result = await _service.CanViewCustomerAsync(user);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task GetUserRolesAsync_IncludesDeveloperRole()
+        {
+            var user = CreateAuthenticatedUser("Developer", "Sales");
+
+            var roles = await _service.GetUserRolesAsync(user);
+
+            Assert.Contains("Developer", roles);
+            Assert.Contains("Sales", roles);
+        }
+
+        [Fact]
+        public async Task DeveloperPermissions_RequireAuthentication()
+        {
+            var unauthenticatedUser = new ClaimsPrincipal(new ClaimsIdentity());
+
+            Assert.False(await _service.CanAccessCustomerManagementAsync(unauthenticatedUser));
+            Assert.False(await _service.CanCreateNewCustomerAsync(unauthenticatedUser));
+            Assert.False(await _service.CanEditCustomerAsync(unauthenticatedUser));
+            Assert.False(await _service.CanViewCustomerAsync(unauthenticatedUser));
+        }
+
+        private static ClaimsPrincipal CreateAuthenticatedUser(params string[] roles)
+        {
+            var identity = new ClaimsIdentity("TestAuth");
+            identity.AddClaim(new Claim(ClaimTypes.Name, "test-user"));
+
+            foreach (var role in roles)
+            {
+                identity.AddClaim(new Claim(ClaimTypes.Role, role));
+            }
+
+            return new ClaimsPrincipal(identity);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow the Developer role to access customer permissions via RolePermissionService and update the interface docs
- persist the developer role through CustomAuthStateProvider and auth-manager.js, and ensure navigation cleanup removes it
- add RolePermissionService unit tests covering developer role behaviors

## Testing
- dotnet test ./tests/BlazorWebApp.Tests --configuration Release
- dotnet test ./tests/NexaCRM.WebClient.UnitTests --configuration Release

------
https://chatgpt.com/codex/tasks/task_b_68c89ca0d9b8832ca287c1d85b482244