### PR TITLE
Fix mobile content offset under fixed header

### DIFF
--- a/src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css
+++ b/src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css
@@ -148,12 +148,17 @@
     }
 
     .mobile-layout main {
-        padding: calc(var(--mobile-header-height, 4.5rem) + env(safe-area-inset-top)) 1rem calc(var(--mobile-footer-height, 5rem) + env(safe-area-inset-bottom));
+        margin-top: calc(var(--mobile-header-height, 4.5rem) + env(safe-area-inset-top));
+        padding: 1rem 1rem calc(var(--mobile-footer-height, 5rem) + env(safe-area-inset-bottom));
         background: transparent;
         min-height: calc(100vh - var(--mobile-header-height, 4.5rem) - var(--mobile-footer-height, 5rem) - env(safe-area-inset-top) - env(safe-area-inset-bottom));
         box-sizing: border-box;
-        scroll-padding-top: calc(var(--mobile-header-height, 4.5rem) + env(safe-area-inset-top));
+        scroll-padding-top: calc(var(--mobile-header-height, 4.5rem) + env(safe-area-inset-top) + 1rem);
         scroll-padding-bottom: calc(var(--mobile-footer-height, 5rem) + env(safe-area-inset-bottom));
+    }
+
+    .mobile-layout .content {
+        scroll-margin-top: calc(var(--mobile-header-height, 4.5rem) + env(safe-area-inset-top));
     }
 
     .mobile-layout .mobile-fixed-footer {


### PR DESCRIPTION
## Summary
- offset the mobile layout main region so content renders beneath the fixed header
- add scroll margin to page content so anchored sections respect the mobile header height

## Testing
- `dotnet build --configuration Release` *(fails: `dotnet` command not available in container)*
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c8b71cea40832cba23cd878514f5cf