### PR TITLE
feat: refine navigation drawer layout

### DIFF
--- a/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.en-US.resx
@@ -21,6 +21,9 @@
   <data name="MenuBrandTitle" xml:space="preserve">
     <value>Company Logo</value>
   </data>
+  <data name="CloseMenu" xml:space="preserve">
+    <value>Close menu</value>
+  </data>
   <data name="Contacts" xml:space="preserve">
     <value>Contacts</value>
   </data>
@@ -74,6 +77,9 @@
   </data>
   <data name="Logout" xml:space="preserve">
     <value>Logout</value>
+  </data>
+  <data name="MainNavigation" xml:space="preserve">
+    <value>Main navigation</value>
   </data>
   <data name="ManagerDashboard" xml:space="preserve">
     <value>Manager Dashboard</value>

--- a/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.ko-KR.resx
@@ -21,6 +21,9 @@
   <data name="MenuBrandTitle" xml:space="preserve">
     <value>회사 로고</value>
   </data>
+  <data name="CloseMenu" xml:space="preserve">
+    <value>메뉴 닫기</value>
+  </data>
   <data name="Contacts" xml:space="preserve">
     <value>연락처</value>
   </data>
@@ -74,6 +77,9 @@
   </data>
   <data name="Logout" xml:space="preserve">
     <value>로그아웃</value>
+  </data>
+  <data name="MainNavigation" xml:space="preserve">
+    <value>주요 메뉴</value>
   </data>
   <data name="ManagerDashboard" xml:space="preserve">
     <value>매니저 대시보드</value>

--- a/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor
@@ -14,14 +14,21 @@
 @inject IRolePermissionService RolePermissionService
 
 <div class="nav-drawer" @onclick:stopPropagation="true">
-    <div class="nav-drawer__header">
-        <span class="nav-drawer__logo" aria-hidden="true">
-            <i class="bi bi-cube"></i>
-        </span>
-        <div class="nav-drawer__title">@Localizer["MenuBrandTitle"]</div>
-    </div>
-    <nav class="nav-drawer__content flex-column">
-        <div class="nav-scroll-container">
+    <div class="nav-drawer__container">
+        <header class="nav-drawer__header">
+            <div class="nav-drawer__brand">
+                <span class="nav-drawer__logo" aria-hidden="true">
+                    <i class="bi bi-cube"></i>
+                </span>
+                <div class="nav-drawer__title">@Localizer["MenuBrandTitle"]</div>
+            </div>
+            <button type="button" class="nav-drawer__close" @onclick="CloseNavMenu" @onclick:stopPropagation="true">
+                <span class="visually-hidden">@Localizer["CloseMenu"]</span>
+                <i class="bi bi-x-lg" aria-hidden="true"></i>
+            </button>
+        </header>
+        <nav class="nav-drawer__content flex-column" aria-label='@Localizer["MainNavigation"]'>
+            <div class="nav-scroll-container">
             <!-- Always visible base menu -->
             <div class="nav-item px-3">
                 <NavLink class="nav-link" href="" Match="NavLinkMatch.All" @onclick="CloseNavMenu">
@@ -337,12 +344,6 @@
                         </div>
                     </RoleBasedComponent>
 
-                    <!-- Logout button -->
-                    <div class="nav-item px-3 mt-auto">
-                        <button class="nav-link btn btn-link" @onclick="Logout">
-                            <i class="bi bi-box-arrow-right me-2" aria-hidden="true"></i> @Localizer["Logout"]
-                        </button>
-                    </div>
                 </Authorized>
                 <NotAuthorized>
                     <div class="nav-item px-3">
@@ -353,7 +354,20 @@
                 </NotAuthorized>
             </AuthorizeView>
         </div>
+        <AuthorizeView>
+            <Authorized>
+                <div class="nav-drawer__footer">
+                    <span class="nav-drawer__divider" aria-hidden="true"></span>
+                    <div class="nav-item px-3">
+                        <button type="button" class="nav-link btn btn-link nav-drawer__logout" @onclick="Logout" @onclick:stopPropagation="true">
+                            <i class="bi bi-box-arrow-right me-2" aria-hidden="true"></i> @Localizer["Logout"]
+                        </button>
+                    </div>
+                </div>
+            </Authorized>
+        </AuthorizeView>
     </nav>
+    </div>
 </div>
 
 @code {

--- a/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor.css
+++ b/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor.css
@@ -1,3 +1,125 @@
+/* Layout structure and sticky header support */
+.nav-drawer__container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+}
+
+.nav-drawer__header {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-md);
+    padding-bottom: var(--spacing-lg);
+    margin-bottom: var(--spacing-lg);
+    background: var(--surface-gradient, var(--surface-color));
+    border-bottom: 1px solid var(--divider-color);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+}
+
+.nav-drawer__brand {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+    min-width: 0;
+}
+
+.nav-drawer__title {
+    color: var(--text-primary);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+}
+
+.nav-drawer__close {
+    display: grid;
+    place-items: center;
+    width: var(--touch-target-min);
+    height: var(--touch-target-min);
+    border-radius: 999px;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    transition: background var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast), transform var(--transition-fast);
+}
+
+.nav-drawer__close:hover {
+    background: var(--hover-overlay);
+    color: var(--text-primary);
+    transform: translateY(-1px);
+}
+
+.nav-drawer__close:active {
+    background: var(--active-overlay);
+    transform: translateY(0);
+}
+
+.nav-drawer__close:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--focus-ring);
+    color: var(--text-primary);
+}
+
+.nav-drawer__content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    gap: var(--spacing-md);
+}
+
+.nav-scroll-container {
+    flex: 1;
+    min-height: 0;
+}
+
+.nav-drawer__footer {
+    flex-shrink: 0;
+    margin-top: auto;
+    padding-top: var(--spacing-lg);
+}
+
+.nav-drawer__divider {
+    display: block;
+    width: 100%;
+    height: 1px;
+    margin-bottom: var(--spacing-md);
+    background: var(--divider-color);
+    border-radius: 999px;
+}
+
+.nav-drawer__logout {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    width: 100%;
+    justify-content: flex-start;
+    padding: var(--spacing-sm) 0;
+    color: var(--text-secondary);
+    border-radius: 0.75rem;
+    text-decoration: none;
+    transition: color var(--transition-fast), background var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.nav-drawer__logout:hover {
+    color: var(--primary-color);
+}
+
+.nav-drawer__logout:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--focus-ring);
+    background: var(--hover-overlay);
+    color: var(--text-primary);
+}
+
+.nav-drawer__logout:active {
+    background: var(--active-overlay);
+}
+
 /* Override hardcoded colors to support dark mode theming */
 .nav-section-header {
     color: var(--text-secondary);


### PR DESCRIPTION
## Summary
- wrap the nav drawer content in a scoped container with a sticky header and dedicated close control
- relocate the logout action into a footer section with localized labels and theme spacing
- refresh the component CSS to follow design tokens and add resource strings for the new text

## Testing
- dotnet test ./tests/BlazorWebApp.Tests --configuration Release *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c8b62c4b50832c871217a946a15b2c