### PR TITLE
feat: hide home link on mobile nav

### DIFF
--- a/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor
@@ -30,7 +30,7 @@
         <nav class="nav-drawer__content flex-column" aria-label='@Localizer["MainNavigation"]'>
             <div class="nav-scroll-container">
             <!-- Always visible base menu -->
-            <div class="nav-item px-3">
+            <div class="nav-item nav-item--home px-3">
                 <NavLink class="nav-link" href="" Match="NavLinkMatch.All" @onclick="CloseNavMenu">
                     <i class="bi bi-house me-2" aria-hidden="true"></i> @Localizer["Home"]
                 </NavLink>

--- a/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor.css
+++ b/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor.css
@@ -146,3 +146,9 @@
     color: white !important; /* Ensure text is white on active background */
     box-shadow: 0 16px 32px rgba(33, 83, 200, 0.18);
 }
+
+@media (max-width: 768px) {
+    .nav-item--home {
+        display: none;
+    }
+}


### PR DESCRIPTION
## Summary
- hide the Home entry in the navigation drawer on mobile viewports to avoid duplicating the dashboard link

## Testing
- `dotnet build --configuration Release` *(fails: command not found in container)*
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c8bb5fd7a8832cb3297ce01ed03532