### PR TITLE
Fix mobile header overlap hiding page content

### DIFF
--- a/src/Web/NexaCRM.WebClient/Shared/MainLayout.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/MainLayout.razor
@@ -227,6 +227,10 @@
             await JSRuntime.InvokeVoidAsync("updateMainThemeToggleIcon");
             isMobile = await DeviceService.IsMobileAsync();
             UpdateLayoutState();
+            if (isMobile)
+            {
+                await JSRuntime.InvokeVoidAsync("window.navigationHelper.syncMobileLayoutSpacing");
+            }
             StateHasChanged();
         }
 

--- a/src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css
+++ b/src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css
@@ -148,8 +148,11 @@
     }
 
     .mobile-layout main {
-        margin-top: calc(var(--mobile-header-height, 4.5rem) + env(safe-area-inset-top));
-        padding: 1rem 1rem calc(var(--mobile-footer-height, 5rem) + env(safe-area-inset-bottom));
+        margin-top: 0;
+        padding-top: calc(var(--mobile-header-height, 4.5rem) + env(safe-area-inset-top) + 1rem);
+        padding-right: 1rem;
+        padding-bottom: calc(var(--mobile-footer-height, 5rem) + env(safe-area-inset-bottom));
+        padding-left: 1rem;
         background: transparent;
         min-height: calc(100vh - var(--mobile-header-height, 4.5rem) - var(--mobile-footer-height, 5rem) - env(safe-area-inset-top) - env(safe-area-inset-bottom));
         box-sizing: border-box;


### PR DESCRIPTION
## Summary
- adjust the mobile layout spacing so page content clears the fixed header
- trigger the mobile spacing sync during the first render when on mobile to apply dynamic offsets immediately

## Testing
- `dotnet build NexaCrmSolution.sln --configuration Release` *(fails: dotnet CLI is not available in the execution environment)*
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c8bc26ab88832c9d5f350ebd999a01