### PR TITLE
Fix mobile header overlap hiding page content

### DIFF
--- a/src/Web/NexaCRM.WebClient/Shared/MainLayout.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/MainLayout.razor
@@ -227,6 +227,10 @@
             await JSRuntime.InvokeVoidAsync("updateMainThemeToggleIcon");
             isMobile = await DeviceService.IsMobileAsync();
             UpdateLayoutState();
+            if (isMobile)
+            {
+                await JSRuntime.InvokeVoidAsync("window.navigationHelper.syncMobileLayoutSpacing");
+            }
             StateHasChanged();
         }
 

--- a/src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css
+++ b/src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css
@@ -2,6 +2,8 @@
 @media (max-width: 768px) {
     .mobile-layout {
         --sidebar-width: min(90vw, 320px);
+        --mobile-header-clearance: clamp(1.25rem, 5vw, 1.75rem);
+        --mobile-footer-clearance: clamp(0.875rem, 4vw, 1.5rem);
         background: var(--app-background-gradient, var(--background-color));
         min-height: 100vh;
     }
@@ -148,17 +150,20 @@
     }
 
     .mobile-layout main {
-        margin-top: calc(var(--mobile-header-height, 4.5rem) + env(safe-area-inset-top));
-        padding: 1rem 1rem calc(var(--mobile-footer-height, 5rem) + env(safe-area-inset-bottom));
+        margin-top: 0;
+        padding-top: calc(var(--mobile-header-height, 4.5rem) + env(safe-area-inset-top) + var(--mobile-header-clearance, 1.5rem));
+        padding-right: 1rem;
+        padding-bottom: calc(var(--mobile-footer-height, 5rem) + env(safe-area-inset-bottom) + var(--mobile-footer-clearance, 1rem));
+        padding-left: 1rem;
         background: transparent;
-        min-height: calc(100vh - var(--mobile-header-height, 4.5rem) - var(--mobile-footer-height, 5rem) - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+        min-height: calc(100vh - var(--mobile-header-height, 4.5rem) - var(--mobile-footer-height, 5rem) - env(safe-area-inset-top) - env(safe-area-inset-bottom) - var(--mobile-header-clearance, 1.5rem) - var(--mobile-footer-clearance, 1rem));
         box-sizing: border-box;
-        scroll-padding-top: calc(var(--mobile-header-height, 4.5rem) + env(safe-area-inset-top) + 1rem);
-        scroll-padding-bottom: calc(var(--mobile-footer-height, 5rem) + env(safe-area-inset-bottom));
+        scroll-padding-top: calc(var(--mobile-header-height, 4.5rem) + env(safe-area-inset-top) + var(--mobile-header-clearance, 1.5rem));
+        scroll-padding-bottom: calc(var(--mobile-footer-height, 5rem) + env(safe-area-inset-bottom) + var(--mobile-footer-clearance, 1rem));
     }
 
     .mobile-layout .content {
-        scroll-margin-top: calc(var(--mobile-header-height, 4.5rem) + env(safe-area-inset-top));
+        scroll-margin-top: calc(var(--mobile-header-height, 4.5rem) + env(safe-area-inset-top) + var(--mobile-header-clearance, 1.5rem));
     }
 
     .mobile-layout .mobile-fixed-footer {


### PR DESCRIPTION
## Summary
- adjust the mobile layout spacing so page content clears the fixed header with extra breathing room
- trigger the mobile spacing sync during the first render when on mobile to apply dynamic offsets immediately

## Testing
- `dotnet build NexaCrmSolution.sln --configuration Release` *(fails: dotnet CLI is not available in the execution environment)*
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c8bc26ab88832c9d5f350ebd999a01