### PR TITLE
feat: add vibrant styling for mobile favorites

### DIFF
--- a/src/Web/NexaCRM.WebClient/Shared/MainLayout.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/MainLayout.razor
@@ -393,15 +393,127 @@
 
     private static string BuildFavoriteStyle(UserFavoriteShortcut shortcut)
     {
-        var background = string.IsNullOrWhiteSpace(shortcut.BackgroundColor)
-            ? "rgba(33, 83, 200, 0.12)"
-            : shortcut.BackgroundColor;
-
         var iconColor = string.IsNullOrWhiteSpace(shortcut.IconColor)
-            ? "var(--primary-color)"
+            ? "#2153C8"
             : shortcut.IconColor;
 
-        return $"--favorite-background: {background}; --favorite-icon-color: {iconColor};";
+        var baseColor = TryParseColor(iconColor) ?? DefaultFavoriteColor;
+        var background = BuildFavoriteBackground(shortcut.BackgroundColor, baseColor);
+
+        var iconShadow = baseColor.ToRgba(0.3d);
+        var border = baseColor.Lighten(0.6d).ToRgba(0.65d);
+        var highlight = baseColor.Lighten(0.45d).ToRgba(0.35d);
+        var glow = baseColor.Lighten(0.1d).ToRgba(0.4d);
+        var chipBackground = baseColor.ToRgba(0.12d);
+
+        return string.Join(' ',
+            $"--favorite-background: {background};",
+            $"--favorite-icon-color: {iconColor};",
+            $"--favorite-icon-shadow: {iconShadow};",
+            $"--favorite-border: {border};",
+            $"--favorite-highlight: {highlight};",
+            $"--favorite-icon-glow: {glow};",
+            $"--favorite-chip-background: {chipBackground};");
+    }
+
+    private static string BuildFavoriteBackground(string? configuredBackground, RgbColor baseColor)
+    {
+        var gradient = FormattableString.Invariant(
+            $"linear-gradient(135deg, {baseColor.Lighten(0.55d).ToRgba(0.95d)} 0%, {baseColor.Lighten(0.2d).ToRgba(0.92d)} 48%, {baseColor.Darken(0.1d).ToRgba(0.98d)} 100%)");
+
+        if (string.IsNullOrWhiteSpace(configuredBackground) || string.Equals(configuredBackground, "transparent", StringComparison.OrdinalIgnoreCase))
+        {
+            return gradient;
+        }
+
+        if (configuredBackground.Contains("gradient", StringComparison.OrdinalIgnoreCase))
+        {
+            return configuredBackground;
+        }
+
+        var parsed = TryParseColor(configuredBackground);
+        if (parsed is not null)
+        {
+            return FormattableString.Invariant(
+                $"linear-gradient(135deg, {parsed.Value.Lighten(0.45d).ToRgba(0.95d)} 0%, {parsed.Value.Blend(baseColor, 0.35d).ToRgba(0.9d)} 55%, {baseColor.Darken(0.12d).ToRgba(0.98d)} 100%)");
+        }
+
+        return gradient;
+    }
+
+    private static RgbColor? TryParseColor(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+
+        if (trimmed.StartsWith('#'))
+        {
+            var hex = trimmed[1..];
+            if (hex.Length == 3)
+            {
+                hex = string.Concat(hex.Select(c => new string(c, 2)));
+            }
+
+            if (hex.Length == 6 &&
+                int.TryParse(hex[..2], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var r) &&
+                int.TryParse(hex.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var g) &&
+                int.TryParse(hex.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var b))
+            {
+                return new RgbColor(r, g, b);
+            }
+        }
+
+        if (trimmed.StartsWith("rgb", StringComparison.OrdinalIgnoreCase))
+        {
+            var start = trimmed.IndexOf('(');
+            var end = trimmed.IndexOf(')');
+            if (start > -1 && end > start)
+            {
+                var segments = trimmed.Substring(start + 1, end - start - 1)
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+                if (segments.Length >= 3 &&
+                    double.TryParse(segments[0], NumberStyles.Number, CultureInfo.InvariantCulture, out var r) &&
+                    double.TryParse(segments[1], NumberStyles.Number, CultureInfo.InvariantCulture, out var g) &&
+                    double.TryParse(segments[2], NumberStyles.Number, CultureInfo.InvariantCulture, out var b))
+                {
+                    return new RgbColor(r, g, b);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static readonly RgbColor DefaultFavoriteColor = new(33, 83, 200);
+
+    private readonly record struct RgbColor(double R, double G, double B)
+    {
+        private static readonly RgbColor White = new(255, 255, 255);
+        private static readonly RgbColor Black = new(0, 0, 0);
+
+        public RgbColor Lighten(double amount) => Blend(White, amount);
+        public RgbColor Darken(double amount) => Blend(Black, amount);
+
+        public RgbColor Blend(RgbColor target, double amount)
+        {
+            var t = Math.Clamp(amount, 0d, 1d);
+            return new RgbColor(
+                R + ((target.R - R) * t),
+                G + ((target.G - G) * t),
+                B + ((target.B - B) * t));
+        }
+
+        public string ToRgba(double alpha = 1d)
+        {
+            var clampedAlpha = Math.Clamp(alpha, 0d, 1d);
+            return FormattableString.Invariant(
+                $"rgba({Math.Clamp((int)Math.Round(R), 0, 255)}, {Math.Clamp((int)Math.Round(G), 0, 255)}, {Math.Clamp((int)Math.Round(B), 0, 255)}, {clampedAlpha:0.##})");
+        }
     }
 
     private void UpdateUserInfo(ClaimsPrincipal user)

--- a/src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css
+++ b/src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css
@@ -187,37 +187,98 @@
         display: flex;
         flex-direction: column;
         align-items: center;
-        gap: 0.45rem;
+        gap: 0.5rem;
         border: none;
-        background: none;
+        background: var(--favorite-chip-background, rgba(15, 23, 42, 0.04));
         color: var(--text-primary);
         font-weight: 600;
-        padding: 0.35rem 0.25rem;
-        border-radius: 1rem;
-        transition: transform 0.2s ease, color 0.2s ease;
+        padding: 0.45rem 0.35rem;
+        border-radius: 1.1rem;
+        transition: transform 0.2s ease, color 0.2s ease, box-shadow 0.3s ease, background-color 0.3s ease;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        backdrop-filter: blur(6px);
+        -webkit-backdrop-filter: blur(6px);
     }
 
     .mobile-layout .favorite-button:active {
         transform: translateY(1px);
     }
 
-    .mobile-layout .favorite-button:focus-visible .favorite-icon,
-    .mobile-layout .favorite-button:hover .favorite-icon {
-        transform: translateY(-2px);
-        box-shadow: 0 16px 34px var(--favorite-icon-shadow, rgba(15, 23, 42, 0.16));
+    .mobile-layout .favorite-button:focus-visible,
+    .mobile-layout .favorite-button:hover {
+        color: var(--favorite-icon-color, var(--primary-color));
+        transform: translateY(-1px);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12), 0 8px 18px rgba(15, 23, 42, 0.12);
+    }
+
+    .mobile-layout .favorite-button:focus-visible {
+        outline: none;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14), 0 0 0 3px rgba(255, 255, 255, 0.24), 0 0 0 4px var(--favorite-border, rgba(33, 83, 200, 0.24));
     }
 
     .mobile-layout .favorite-button .favorite-icon {
-        width: 2.9rem;
-        height: 2.9rem;
+        position: relative;
+        width: 3rem;
+        height: 3rem;
         border-radius: 1rem;
         display: grid;
         place-items: center;
-        background: var(--favorite-background, var(--favorite-surface, rgba(33, 83, 200, 0.12)));
+        background: var(--favorite-background, var(--favorite-surface, rgba(33, 83, 200, 0.18)));
         color: var(--favorite-icon-color, var(--primary-color));
-        box-shadow: 0 12px 30px var(--favorite-icon-shadow, rgba(15, 23, 42, 0.12));
+        box-shadow: 0 12px 30px var(--favorite-icon-shadow, rgba(15, 23, 42, 0.14));
         font-size: 1.1rem;
-        transition: box-shadow 0.2s ease, transform 0.2s ease;
+        transition: box-shadow 0.3s ease, transform 0.3s ease;
+        border: 1px solid var(--favorite-border, rgba(148, 163, 184, 0.28));
+        overflow: hidden;
+        isolation: isolate;
+    }
+
+    .mobile-layout .favorite-button .favorite-icon::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        background: radial-gradient(circle at 25% 25%, rgba(255, 255, 255, 0.55), transparent 65%);
+        opacity: 0.6;
+        transition: opacity 0.35s ease, transform 0.35s ease;
+        pointer-events: none;
+    }
+
+    .mobile-layout .favorite-button .favorite-icon::after {
+        content: "";
+        position: absolute;
+        inset: -40%;
+        border-radius: 50%;
+        background: radial-gradient(circle, var(--favorite-highlight, rgba(255, 255, 255, 0.35)) 0%, transparent 60%);
+        opacity: 0;
+        transform: scale(0.6);
+        transition: opacity 0.4s ease, transform 0.4s ease;
+        pointer-events: none;
+    }
+
+    .mobile-layout .favorite-button:focus-visible .favorite-icon,
+    .mobile-layout .favorite-button:hover .favorite-icon {
+        transform: translateY(-3px);
+        box-shadow: 0 18px 36px var(--favorite-icon-shadow, rgba(15, 23, 42, 0.2));
+    }
+
+    .mobile-layout .favorite-button:focus-visible .favorite-icon::before,
+    .mobile-layout .favorite-button:hover .favorite-icon::before {
+        opacity: 0.85;
+        transform: scale(1.05);
+    }
+
+    .mobile-layout .favorite-button:focus-visible .favorite-icon::after,
+    .mobile-layout .favorite-button:hover .favorite-icon::after {
+        opacity: 0.9;
+        transform: scale(1);
+    }
+
+    .mobile-layout .favorite-button .favorite-icon i {
+        position: relative;
+        z-index: 1;
+        filter: drop-shadow(0 8px 18px var(--favorite-icon-glow, rgba(15, 23, 42, 0.28)));
     }
 
     .mobile-layout .favorite-button .favorite-label {
@@ -226,12 +287,12 @@
         letter-spacing: 0.12em;
         color: var(--text-secondary);
         text-align: center;
-        transition: color 0.2s ease;
+        transition: color 0.3s ease;
     }
 
     .mobile-layout .favorite-button:focus-visible .favorite-label,
     .mobile-layout .favorite-button:hover .favorite-label {
-        color: var(--text-primary);
+        color: var(--favorite-icon-color, var(--primary-color));
     }
 
     body.nav-open .mobile-layout .mobile-fixed-header,


### PR DESCRIPTION
## Summary
- derive gradient, shadow, and glow values for mobile favorites from their assigned icon colours
- refresh the mobile favourites footer UI with colourful backgrounds, animated highlights, and clearer focus states

## Testing
- `dotnet build --configuration Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c8bbae8500832cb8bac1e50ed3f3f2