### PR TITLE
feat: refine mobile login styling

### DIFF
--- a/src/Web/NexaCRM.WebClient/Pages/LoginPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/LoginPage.razor
@@ -14,7 +14,7 @@
 <div class="login-container mobile-login-container">
   <div class="mobile-login-card">
     <div class="brand-section">
-      <span class="brand-logo">POOQ</span>
+      <span class="brand-logo">NexaCRM</span>
       <p class="brand-caption">@Localizer["SignInToYourAccount"]</p>
     </div>
 

--- a/src/Web/NexaCRM.WebClient/Pages/LoginPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/LoginPage.razor.css
@@ -114,6 +114,10 @@
     transform: translateY(-50%);
     border: none;
     background: transparent;
+    background-color: transparent;
+    box-shadow: none;
+    -webkit-appearance: none;
+    appearance: none;
     color: var(--brand-gradient-start);
     font-weight: 700;
     font-size: 0.7rem;
@@ -126,6 +130,7 @@
 .password-toggle:hover,
 .password-toggle:focus-visible {
     color: var(--brand-gradient-end);
+    background-color: transparent;
     outline: none;
 }
 
@@ -352,7 +357,7 @@
     .login-input {
         padding: 12px 16px;
         font-size: 15px;
-        border-radius: 16px;
+        border-radius: 18px;
     }
 
     .password-toggle {
@@ -404,8 +409,8 @@
     }
 
     .social-icon {
-        width: 48px;
-        height: 48px;
+        width: 40px;
+        height: 40px;
     }
 }
 
@@ -418,8 +423,8 @@
     }
 
     .social-icon {
-        width: 44px;
-        height: 44px;
+        width: 36px;
+        height: 36px;
     }
 }
 


### PR DESCRIPTION
## Summary
- update the mobile login brand label to NexaCRM
- align input border radii and make the password toggle fully transparent for mobile consistency
- resize the social login icons for better balance on small screens

## Testing
- dotnet build --configuration Release *(fails: command not found)*
- dotnet test ./tests/BlazorWebApp.Tests --configuration Release *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c8d12203e4832c8a4c035234888812