### PR TITLE
fix: align mobile body spacing with header height

### DIFF
--- a/src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css
+++ b/src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css
@@ -4,6 +4,11 @@
         --sidebar-width: min(90vw, 320px);
         --mobile-header-clearance: clamp(1.25rem, 5vw, 1.75rem);
         --mobile-footer-clearance: clamp(0.875rem, 4vw, 1.5rem);
+        --mobile-safe-area-top: calc(var(--mobile-header-height, 4.5rem) + env(safe-area-inset-top));
+        --mobile-safe-area-bottom: calc(var(--mobile-footer-height, 5rem) + env(safe-area-inset-bottom));
+        --mobile-body-offset-top: calc(var(--mobile-safe-area-top) + var(--mobile-header-clearance));
+        --mobile-body-offset-bottom: calc(var(--mobile-safe-area-bottom) + var(--mobile-footer-clearance));
+        --mobile-body-padding: clamp(1rem, 4vw, 1.25rem);
         background: var(--app-background-gradient, var(--background-color));
         min-height: 100vh;
     }
@@ -151,19 +156,35 @@
 
     .mobile-layout main {
         margin-top: 0;
-        padding-top: calc(var(--mobile-header-height, 4.5rem) + env(safe-area-inset-top) + var(--mobile-header-clearance, 1.5rem));
+        padding-top: var(--mobile-body-offset-top);
         padding-right: 1rem;
-        padding-bottom: calc(var(--mobile-footer-height, 5rem) + env(safe-area-inset-bottom) + var(--mobile-footer-clearance, 1rem));
+        padding-bottom: var(--mobile-body-offset-bottom);
         padding-left: 1rem;
         background: transparent;
-        min-height: calc(100vh - var(--mobile-header-height, 4.5rem) - var(--mobile-footer-height, 5rem) - env(safe-area-inset-top) - env(safe-area-inset-bottom) - var(--mobile-header-clearance, 1.5rem) - var(--mobile-footer-clearance, 1rem));
+        min-height: max(0px, calc(100vh - var(--mobile-body-offset-top) - var(--mobile-body-offset-bottom)));
         box-sizing: border-box;
-        scroll-padding-top: calc(var(--mobile-header-height, 4.5rem) + env(safe-area-inset-top) + var(--mobile-header-clearance, 1.5rem));
-        scroll-padding-bottom: calc(var(--mobile-footer-height, 5rem) + env(safe-area-inset-bottom) + var(--mobile-footer-clearance, 1rem));
+        scroll-padding-top: var(--mobile-body-offset-top);
+        scroll-padding-bottom: var(--mobile-body-offset-bottom);
+    }
+
+    @supports (height: 100dvh) {
+        .mobile-layout main {
+            min-height: max(0px, calc(100dvh - var(--mobile-body-offset-top) - var(--mobile-body-offset-bottom)));
+        }
     }
 
     .mobile-layout .content {
-        scroll-margin-top: calc(var(--mobile-header-height, 4.5rem) + env(safe-area-inset-top) + var(--mobile-header-clearance, 1.5rem));
+        scroll-margin-top: var(--mobile-body-offset-top);
+        padding-top: var(--mobile-body-padding);
+        padding-bottom: max(var(--mobile-body-padding), var(--mobile-footer-clearance, 1rem));
+        min-height: max(0px, calc(100vh - var(--mobile-body-offset-top) - var(--mobile-body-offset-bottom)));
+        box-sizing: border-box;
+    }
+
+    @supports (height: 100dvh) {
+        .mobile-layout .content {
+            min-height: max(0px, calc(100dvh - var(--mobile-body-offset-top) - var(--mobile-body-offset-bottom)));
+        }
     }
 
     .mobile-layout .mobile-fixed-footer {

--- a/src/Web/NexaCRM.WebClient/wwwroot/js/navigation.js
+++ b/src/Web/NexaCRM.WebClient/wwwroot/js/navigation.js
@@ -190,7 +190,7 @@ window.navigationHelper = {
 
         const state = window.navigationHelper._mobileSpacingState || (window.navigationHelper._mobileSpacingState = {
             lastHeader: 72,
-            lastFooter: 80,
+            lastFooter: 0,
             headerObserver: null,
             footerObserver: null,
             viewportHandler: null
@@ -203,8 +203,8 @@ window.navigationHelper = {
             const headerRect = header ? header.getBoundingClientRect() : null;
             const footerRect = footer ? footer.getBoundingClientRect() : null;
 
-            const headerHeight = Math.max(1, Math.ceil((headerRect && headerRect.height) || state.lastHeader || 72));
-            const footerHeight = Math.max(1, Math.ceil((footerRect && footerRect.height) || state.lastFooter || 80));
+            const headerHeight = Math.max(1, Math.ceil(headerRect?.height ?? state.lastHeader ?? 72));
+            const footerHeight = footerRect ? Math.max(0, Math.ceil(footerRect.height)) : 0;
 
             state.lastHeader = headerHeight;
             state.lastFooter = footerHeight;


### PR DESCRIPTION
## Summary
- add reusable mobile body spacing variables so the main content area consistently clears the fixed header and footer on small screens
- give the mobile content wrapper its own padding and dynamic viewport-aware minimum height so page sections remain fully visible
- update the spacing synchronisation helper to tolerate pages without a footer while still pushing header height into CSS variables

## Testing
- dotnet build --configuration Release *(fails: `dotnet` is not available in the container)*
- dotnet test ./tests/BlazorWebApp.Tests --configuration Release *(fails: `dotnet` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68c8d1903d04832ca1897d19771c85b2