### PR TITLE
fix: register email template service

### DIFF
--- a/src/Web/NexaCRM.WebClient/Program.cs
+++ b/src/Web/NexaCRM.WebClient/Program.cs
@@ -49,6 +49,7 @@ builder.Services.AddScoped<ISmsService, SmsService>();
 builder.Services.AddScoped<ISystemInfoService, SystemInfoService>();
 builder.Services.AddScoped<IFaqService, FaqService>();
 builder.Services.AddScoped<IUserFavoritesService, UserFavoritesService>();
+builder.Services.AddScoped<IEmailTemplateService, MockEmailTemplateService>();
 
 var culture = new CultureInfo("ko-KR");
 CultureInfo.DefaultThreadCurrentCulture = culture;


### PR DESCRIPTION
## Summary
- register the email template service in the WebAssembly host so EmailTemplateBuilder can be constructed

## Testing
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c8e8bfeba4832c9b5d23fdff1f2ee4