### PR TITLE
fix: prevent null edit context in profile settings page

### DIFF
--- a/src/Web/NexaCRM.WebClient/Pages/ProfileSettingsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/ProfileSettingsPage.razor
@@ -147,12 +147,18 @@
 
 @code {
     private UserProfile userProfile = new();
-    private EditContext editContext = default!;
+    private EditContext editContext;
     private bool isMobileMenuOpen = false;
+
+    public ProfileSettingsPage()
+    {
+        editContext = new EditContext(userProfile);
+    }
 
     protected override async Task OnInitializedAsync()
     {
-        userProfile = await SettingsService.GetUserProfileAsync();
+        var loadedProfile = await SettingsService.GetUserProfileAsync();
+        userProfile = loadedProfile ?? new UserProfile();
         editContext = new EditContext(userProfile);
     }
 


### PR DESCRIPTION
## Summary
- initialize the profile settings page edit context in the constructor so it is never null during the first render
- recreate the edit context after loading the user profile and fall back to a default profile when the service returns null

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68c90d89c428832c995e36a026031166