### PR TITLE
fix: unify sidebar width variable

### DIFF
--- a/src/Web/NexaCRM.WebClient/wwwroot/css/app.css
+++ b/src/Web/NexaCRM.WebClient/wwwroot/css/app.css
@@ -191,7 +191,7 @@ a:hover, .btn-link:hover {
 
 /* Navigation styles - 반응형 디자인 */
 .page {
-    --sidebar-width: min(80vw, 250px);
+    --sidebar-width: min(90vw, 320px); /* Ensure sidebar has consistent roomy width across devices */
     min-height: 100vh;
     transition: margin-left 0.3s ease-in-out;
     /* 기본적으로 전체 화면 사용 */
@@ -582,12 +582,8 @@ a:hover, .btn-link:hover {
 
 /* 태블릿 환경 (768px - 1024px) */
 @media (min-width: 768px) and (max-width: 1024px) {
-    .page {
-        --sidebar-width: 250px; /* 태블릿에서도 동일한 크기 */
-    }
-
     .sidebar {
-        width: var(--sidebar-width); /* 태블릿에서도 동일한 크기 */
+        width: var(--sidebar-width); /* 태블릿에서도 동일한 공유 폭 유지 */
     }
     
     .sidebar .nav-link {
@@ -609,12 +605,8 @@ a:hover, .btn-link:hover {
 
 /* 모바일 환경 (768px 이하) */
 @media (max-width: 768px) {
-    .page {
-        --sidebar-width: min(80vw, 280px); /* Mobile sidebar width */
-    }
-
     .sidebar {
-        width: var(--sidebar-width); /* Responsive width, max 80% of viewport */
+        width: var(--sidebar-width); /* 공유된 폭(min(90vw, 320px))을 사용하여 반응형 유지 */
     }
     
     .sidebar .nav-link {
@@ -839,12 +831,8 @@ input, select, textarea {
     }
 }
 @media (max-width: 480px) {
-    .page {
-        --sidebar-width: min(100vw, 320px); /* Full width on very small screens, but capped */
-    }
-
     .sidebar {
-        width: var(--sidebar-width); /* Full width on very small screens, but capped */
+        width: var(--sidebar-width); /* 매우 작은 화면에서도 공유 폭으로 일관성 유지 */
     }
     
     .sidebar .nav-link {

--- a/src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css
+++ b/src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css
@@ -1,7 +1,6 @@
 /* Enhanced responsive layout for handheld devices */
 @media (max-width: 768px) {
     .mobile-layout {
-        --sidebar-width: min(90vw, 320px);
         --mobile-header-clearance: clamp(1.25rem, 5vw, 1.75rem);
         --mobile-footer-clearance: clamp(0.875rem, 4vw, 1.5rem);
         --mobile-safe-area-top: calc(var(--mobile-header-height, 4.5rem) + env(safe-area-inset-top));


### PR DESCRIPTION
## Summary
- set the shared `--sidebar-width` to `min(90vw, 320px)` for consistent navigation spacing
- remove duplicate sidebar width overrides in responsive rules and adjust comments to reflect the shared value
- rely on the shared width from `app.css` in the mobile layout styles

## Testing
- `dotnet build --configuration Release` *(fails: command not found: dotnet)*
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_68c91c4b9ae8832ca940b6008189f0e9