### PR TITLE
feat: refresh tablet navigation styling

### DIFF
--- a/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.en-US.resx
@@ -21,6 +21,9 @@
   <data name="MenuBrandTitle" xml:space="preserve">
     <value>Company Logo</value>
   </data>
+  <data name="MenuBrandSubtitle" xml:space="preserve">
+    <value>Customer Relationship Hub</value>
+  </data>
   <data name="CloseMenu" xml:space="preserve">
     <value>Close menu</value>
   </data>

--- a/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.ko-KR.resx
@@ -21,6 +21,9 @@
   <data name="MenuBrandTitle" xml:space="preserve">
     <value>회사 로고</value>
   </data>
+  <data name="MenuBrandSubtitle" xml:space="preserve">
+    <value>고객 관계 허브</value>
+  </data>
   <data name="CloseMenu" xml:space="preserve">
     <value>메뉴 닫기</value>
   </data>

--- a/src/Web/NexaCRM.WebClient/Shared/MainLayout.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/MainLayout.razor
@@ -63,12 +63,6 @@
             </div>
         </header>
     }
-    else
-    {
-        <button title="Navigation menu" class="floating-menu-toggle" @onclick="ToggleNavMenu">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-    }
 
     <div class="sidebar">
         <NavMenu />
@@ -223,10 +217,10 @@
         if (firstRender)
         {
             await JSRuntime.InvokeVoidAsync("window.navigationHelper.setupOverlayHandler");
-            await JSRuntime.InvokeVoidAsync("window.navigationHelper.toggleMenu", true);
-            await JSRuntime.InvokeVoidAsync("updateMainThemeToggleIcon");
             isMobile = await DeviceService.IsMobileAsync();
             UpdateLayoutState();
+            await JSRuntime.InvokeVoidAsync("window.navigationHelper.toggleMenu", isMobile);
+            await JSRuntime.InvokeVoidAsync("updateMainThemeToggleIcon");
             if (isMobile)
             {
                 await JSRuntime.InvokeVoidAsync("window.navigationHelper.syncMobileLayoutSpacing");

--- a/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor
@@ -21,6 +21,7 @@
                     <i class="bi bi-cube"></i>
                 </span>
                 <div class="nav-drawer__title">@Localizer["MenuBrandTitle"]</div>
+                <div class="nav-drawer__subtitle">@Localizer["MenuBrandSubtitle"]</div>
             </div>
             <button type="button" class="nav-drawer__close" @onclick="CloseNavMenu" @onclick:stopPropagation="true">
                 <span class="visually-hidden">@Localizer["CloseMenu"]</span>

--- a/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor.css
+++ b/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor.css
@@ -35,6 +35,13 @@
     letter-spacing: -0.01em;
 }
 
+.nav-drawer__subtitle {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    line-height: 1.35;
+    letter-spacing: -0.01em;
+}
+
 .nav-drawer__close {
     display: grid;
     place-items: center;
@@ -150,5 +157,79 @@
 @media (max-width: 767px) {
     .nav-item--home {
         display: none;
+    }
+}
+
+@media (min-width: 769px) {
+    .nav-drawer__header {
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: flex-start;
+        gap: clamp(1rem, 2vw, 1.5rem);
+        padding: clamp(1.75rem, 3vw, 2.25rem);
+        margin-bottom: clamp(1.5rem, 3vw, 2.25rem);
+        border-radius: 1.65rem;
+        border: 1px solid color-mix(in srgb, var(--primary-color) 22%, transparent);
+        background:
+            radial-gradient(120% 120% at 110% -20%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 65%),
+            linear-gradient(135deg, color-mix(in srgb, var(--primary-color) 48%, transparent) 0%, color-mix(in srgb, #5b5af7 68%, transparent) 100%);
+        box-shadow: 0 24px 48px rgba(33, 83, 200, 0.24);
+        border-bottom: none;
+        position: relative;
+        overflow: hidden;
+        backdrop-filter: blur(18px);
+        -webkit-backdrop-filter: blur(18px);
+    }
+
+    .nav-drawer__header::after {
+        content: "";
+        position: absolute;
+        inset: 0.6rem;
+        border-radius: 1.35rem;
+        border: 1px solid rgba(255, 255, 255, 0.22);
+        pointer-events: none;
+    }
+
+    .nav-drawer__brand {
+        align-items: flex-start;
+        gap: clamp(0.85rem, 1.8vw, 1.25rem);
+        position: relative;
+        z-index: 1;
+    }
+
+    .nav-drawer__logo {
+        width: clamp(3.25rem, 4vw, 3.75rem);
+        height: clamp(3.25rem, 4vw, 3.75rem);
+        border-radius: 1.25rem;
+        display: grid;
+        place-items: center;
+        background: rgba(255, 255, 255, 0.22);
+        border: 1px solid rgba(255, 255, 255, 0.4);
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.25);
+        color: #ffffff;
+        font-size: clamp(1.2rem, 2vw, 1.35rem);
+    }
+
+    .nav-drawer__title {
+        color: #ffffff;
+        font-size: clamp(1.35rem, 2.4vw, 1.6rem);
+        font-weight: 700;
+        letter-spacing: -0.025em;
+    }
+
+    .nav-drawer__subtitle {
+        color: rgba(255, 255, 255, 0.85);
+        font-size: clamp(0.9rem, 1.6vw, 1rem);
+        font-weight: 500;
+        max-width: 24ch;
+        line-height: 1.4;
+    }
+
+    .nav-drawer__close {
+        display: none;
+    }
+
+    .nav-drawer__content {
+        gap: clamp(1.25rem, 2.5vw, 1.75rem);
     }
 }

--- a/src/Web/NexaCRM.WebClient/wwwroot/css/app.css
+++ b/src/Web/NexaCRM.WebClient/wwwroot/css/app.css
@@ -191,7 +191,7 @@ a:hover, .btn-link:hover {
 
 /* Navigation styles - 반응형 디자인 */
 .page {
-    --sidebar-width: min(90vw, 320px); /* Ensure sidebar has consistent roomy width across devices */
+    --sidebar-width: min(90vw, 320px);
     min-height: 100vh;
     transition: margin-left 0.3s ease-in-out;
     /* 기본적으로 전체 화면 사용 */
@@ -582,10 +582,6 @@ a:hover, .btn-link:hover {
 
 /* 태블릿 환경 (768px - 1024px) */
 @media (min-width: 768px) and (max-width: 1024px) {
-    .sidebar {
-        width: var(--sidebar-width); /* 태블릿에서도 동일한 공유 폭 유지 */
-    }
-    
     .sidebar .nav-link {
         padding: 0.85rem 1rem;
         font-size: 0.95rem;
@@ -604,15 +600,7 @@ a:hover, .btn-link:hover {
 }
 
 /* 모바일 환경 (768px 이하) */
-@media (max-width: 767px) {
-    .page {
-        --sidebar-width: min(80vw, 280px); /* Mobile sidebar width */
-    }
-
-    .sidebar {
-        width: var(--sidebar-width); /* 공유된 폭(min(90vw, 320px))을 사용하여 반응형 유지 */
-    }
-    
+@media (max-width: 768px) {
     .sidebar .nav-link {
         padding: 0.95rem 1.1rem;
         font-size: 1rem;
@@ -673,6 +661,108 @@ a:hover, .btn-link:hover {
     /* Hide dashboard sidebar on mobile (in case it's present) */
     .dashboard-sidebar {
         display: none !important;
+    }
+}
+
+/* Desktop & tablet navigation layout */
+@media (min-width: 769px) {
+    .page {
+        --sidebar-width: clamp(260px, 24vw, 320px);
+    }
+
+    .page.desktop-layout {
+        --desktop-shell-gap: clamp(1.5rem, 3.2vw, 2.5rem);
+        --desktop-shell-padding: clamp(1.75rem, 4vw, 2.75rem);
+        display: grid;
+        grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+        gap: var(--desktop-shell-gap);
+        width: min(1480px, 100%);
+        margin: 0 auto;
+        padding: var(--desktop-shell-padding);
+        padding-bottom: clamp(2rem, 5vw, 3.25rem);
+        min-height: 100vh;
+        box-sizing: border-box;
+        align-items: start;
+    }
+
+    .desktop-layout .sidebar {
+        position: sticky;
+        top: var(--desktop-shell-padding);
+        transform: none !important;
+        width: var(--sidebar-width);
+        max-width: var(--sidebar-width);
+        height: calc(100vh - (var(--desktop-shell-padding) * 2));
+        max-height: calc(100vh - (var(--desktop-shell-padding) * 2));
+        border-radius: 1.75rem;
+        border: 1px solid color-mix(in srgb, var(--nav-accent-color, var(--primary-color)) 18%, transparent);
+        background:
+            radial-gradient(140% 120% at 100% 0%, color-mix(in srgb, var(--nav-accent-color, var(--primary-color)) 18%, transparent) 0%, transparent 55%),
+            var(--surface-gradient, var(--surface-color));
+        box-shadow: 0 32px 64px rgba(15, 23, 42, 0.14);
+        backdrop-filter: blur(20px);
+        -webkit-backdrop-filter: blur(20px);
+        padding: 0;
+        overflow: hidden;
+    }
+
+    .desktop-layout .sidebar.collapse {
+        transform: none !important;
+    }
+
+    .desktop-layout .nav-drawer {
+        height: 100%;
+        padding: clamp(1.75rem, 4vw, 2.5rem) clamp(1.5rem, 3vw, 2.5rem);
+        gap: clamp(1.5rem, 3vw, 2rem);
+    }
+
+    .desktop-layout .nav-scroll-container {
+        margin-right: -0.5rem;
+        padding-right: 0.75rem;
+    }
+
+    .desktop-layout .nav-drawer__footer {
+        padding-top: clamp(1.25rem, 3vw, 2rem);
+    }
+
+    .desktop-layout .mobile-overlay {
+        display: none !important;
+    }
+
+    .desktop-layout main {
+        width: 100%;
+        min-height: calc(100vh - (var(--desktop-shell-padding) * 2));
+        display: flex;
+    }
+
+    .desktop-layout .content {
+        margin: 0;
+        max-width: 100%;
+        width: 100%;
+        min-height: 100%;
+        border-radius: 2rem;
+        padding: clamp(2.25rem, 5vw, 3rem);
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.97), rgba(244, 247, 255, 0.92));
+        border: 1px solid color-mix(in srgb, var(--divider-color) 55%, transparent);
+        box-shadow: 0 32px 64px rgba(15, 23, 42, 0.12);
+        display: flex;
+        flex-direction: column;
+        gap: clamp(1.5rem, 3vw, 2.25rem);
+        flex: 1;
+    }
+
+    .desktop-layout .floating-menu-toggle {
+        display: none !important;
+    }
+
+    @supports (height: 100dvh) {
+        .desktop-layout .sidebar {
+            height: calc(100dvh - (var(--desktop-shell-padding) * 2));
+            max-height: calc(100dvh - (var(--desktop-shell-padding) * 2));
+        }
+
+        .desktop-layout main {
+            min-height: calc(100dvh - (var(--desktop-shell-padding) * 2));
+        }
     }
 }
 

--- a/src/Web/NexaCRM.WebClient/wwwroot/js/navigation.js
+++ b/src/Web/NexaCRM.WebClient/wwwroot/js/navigation.js
@@ -158,26 +158,54 @@ window.navigationHelper = {
             }, { passive: false });
         }
         
-        // 초기 상태에서 메뉴를 확실히 숨김
-        if (sidebar && !sidebar.classList.contains('collapse')) {
-            sidebar.classList.add('collapse');
+        const applyResponsiveState = () => {
+            const sidebarElement = document.querySelector('.sidebar');
+            const toggleBtn = document.querySelector('.floating-menu-toggle');
+            const pageElement = document.querySelector('.page');
+            const bodyElement = document.body;
+            const isMobileViewport = window.deviceInfo && typeof window.deviceInfo.isMobile === 'function'
+                ? window.deviceInfo.isMobile()
+                : window.matchMedia('(max-width: 768px)').matches;
+
+            if (!sidebarElement) {
+                return;
+            }
+
+            if (isMobileViewport) {
+                if (!sidebarElement.classList.contains('collapse')) {
+                    sidebarElement.classList.add('collapse');
+                }
+                if (toggleBtn) {
+                    toggleBtn.style.display = 'flex';
+                }
+            } else {
+                sidebarElement.classList.remove('collapse');
+                if (toggleBtn) {
+                    toggleBtn.style.display = 'none';
+                }
+            }
+
+            if (overlay) {
+                overlay.classList.remove('show');
+            }
+
+            if (bodyElement) {
+                bodyElement.classList.remove('nav-open');
+            }
+
+            if (pageElement) {
+                pageElement.classList.remove('nav-open');
+            }
+        };
+
+        applyResponsiveState();
+
+        if (window.navigationHelper._viewportResizeHandler) {
+            window.removeEventListener('resize', window.navigationHelper._viewportResizeHandler);
         }
 
-        // Ensure overlay is hidden initially
-        if (overlay) {
-            overlay.classList.remove('show');
-        }
-
-        const body = document.body;
-        const page = document.querySelector('.page');
-
-        if (body) {
-            body.classList.remove('nav-open');
-        }
-
-        if (page) {
-            page.classList.remove('nav-open');
-        }
+        window.navigationHelper._viewportResizeHandler = applyResponsiveState;
+        window.addEventListener('resize', applyResponsiveState);
 
         // Setup navigation scrolling functionality
         window.navigationHelper.setupNavigationScrolling();
@@ -557,7 +585,30 @@ window.navigationHelper = {
         const body = document.body;
         const page = document.querySelector('.page');
 
-        if (!sidebar) return;
+        if (!sidebar) {
+            return false;
+        }
+
+        const isMobileViewport = window.deviceInfo && typeof window.deviceInfo.isMobile === 'function'
+            ? window.deviceInfo.isMobile()
+            : window.matchMedia('(max-width: 768px)').matches;
+
+        if (!isMobileViewport) {
+            sidebar.classList.remove('collapse');
+            if (overlay) {
+                overlay.classList.remove('show');
+            }
+            if (toggleBtn) {
+                toggleBtn.style.display = 'none';
+            }
+            if (body) {
+                body.classList.remove('nav-open');
+            }
+            if (page) {
+                page.classList.remove('nav-open');
+            }
+            return false;
+        }
 
         if (typeof isCollapsed === 'undefined') {
             isCollapsed = !sidebar.classList.contains('collapse');
@@ -574,6 +625,9 @@ window.navigationHelper = {
             if (page) {
                 page.classList.remove('nav-open');
             }
+            if (toggleBtn) {
+                toggleBtn.style.display = 'flex';
+            }
         } else {
             sidebar.classList.remove('collapse');
             if (overlay) {
@@ -585,10 +639,9 @@ window.navigationHelper = {
             if (page) {
                 page.classList.add('nav-open');
             }
-        }
-
-        if (toggleBtn) {
-            toggleBtn.style.display = isCollapsed ? 'flex' : 'none';
+            if (toggleBtn) {
+                toggleBtn.style.display = 'none';
+            }
         }
 
         return isCollapsed;
@@ -613,26 +666,11 @@ window.navigationHelper = {
         
         // 즉시 실행하여 초기 상태 보장
         setTimeout(() => {
-            const sidebar = document.querySelector('.sidebar');
-            const overlay = document.querySelector('.mobile-overlay');
-            
-            if (sidebar && !sidebar.classList.contains('collapse')) {
-                sidebar.classList.add('collapse');
-            }
-            
-            // Ensure overlay is hidden on page load
-            if (overlay && overlay.classList.contains('show')) {
-                overlay.classList.remove('show');
-            }
+            const isMobileViewport = window.deviceInfo && typeof window.deviceInfo.isMobile === 'function'
+                ? window.deviceInfo.isMobile()
+                : window.matchMedia('(max-width: 768px)').matches;
 
-            if (document.body) {
-                document.body.classList.remove('nav-open');
-            }
-
-            const page = document.querySelector('.page');
-            if (page) {
-                page.classList.remove('nav-open');
-            }
+            window.navigationHelper.toggleMenu(isMobileViewport);
         }, 100);
 
         // Re-setup dashboard navigation when page content changes (for SPA routing)


### PR DESCRIPTION
## Summary
- align the shared sidebar width tokens so mobile and desktop layouts use a single responsive value
- rebuild the tablet/desktop shell grid with a sticky gradient navigation panel and expanded content canvas
- restyle the navigation header for larger screens to match the updated tablet design language

## Testing
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release` *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68c911cf835c832cb8b37f5933abe649