### PR TITLE
feat: refresh desktop navigation styling

### DIFF
--- a/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor.css
+++ b/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor.css
@@ -160,69 +160,88 @@
     }
 }
 
-@media (min-width: 769px) {
+@media (min-width: 768px) {
+    .nav-drawer {
+        gap: clamp(1.75rem, 3vw, 2.5rem);
+    }
+
+    .nav-drawer__container {
+        --tablet-nav-accent: color-mix(in srgb, var(--nav-accent-color, var(--primary-color)) 86%, #5b48f7 14%);
+        --tablet-nav-accent-soft: color-mix(in srgb, var(--nav-accent-color, var(--primary-color)) 32%, #a9b0ff 68%);
+        --tablet-nav-surface: color-mix(in srgb, #ffffff 90%, var(--nav-accent-color, var(--primary-color)) 10%);
+        --tablet-nav-surface-strong: color-mix(in srgb, #f2f4ff 80%, var(--nav-accent-color, var(--primary-color)) 20%);
+        --tablet-nav-shadow: rgba(82, 96, 155, 0.18);
+        --tablet-nav-soft-shadow: rgba(82, 96, 155, 0.12);
+    }
+
     .nav-drawer__header {
         flex-direction: column;
         align-items: flex-start;
         justify-content: flex-start;
-        gap: clamp(1rem, 2vw, 1.5rem);
-        padding: clamp(1.75rem, 3vw, 2.25rem);
-        margin-bottom: clamp(1.5rem, 3vw, 2.25rem);
-        border-radius: 1.65rem;
-        border: 1px solid color-mix(in srgb, var(--primary-color) 22%, transparent);
+        gap: clamp(1rem, 2.2vw, 1.6rem);
+        padding: clamp(1.9rem, 3.4vw, 2.45rem);
+        margin-bottom: clamp(1.6rem, 3.2vw, 2.35rem);
+        border-radius: 1.75rem;
+        border: 1px solid color-mix(in srgb, var(--tablet-nav-accent) 32%, transparent);
         background:
-            radial-gradient(120% 120% at 110% -20%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 65%),
-            linear-gradient(135deg, color-mix(in srgb, var(--primary-color) 48%, transparent) 0%, color-mix(in srgb, #5b5af7 68%, transparent) 100%);
-        box-shadow: 0 24px 48px rgba(33, 83, 200, 0.24);
+            radial-gradient(120% 120% at 110% -20%, rgba(255, 255, 255, 0.32) 0%, rgba(255, 255, 255, 0) 62%),
+            linear-gradient(
+                135deg,
+                color-mix(in srgb, var(--tablet-nav-accent) 68%, #f4f1ff 32%) 0%,
+                color-mix(in srgb, var(--tablet-nav-accent) 48%, #dcd6ff 52%) 100%
+            );
+        box-shadow: 0 28px 54px color-mix(in srgb, var(--tablet-nav-accent) 26%, transparent);
         border-bottom: none;
         position: relative;
         overflow: hidden;
-        backdrop-filter: blur(18px);
-        -webkit-backdrop-filter: blur(18px);
+        backdrop-filter: blur(22px);
+        -webkit-backdrop-filter: blur(22px);
     }
 
     .nav-drawer__header::after {
         content: "";
         position: absolute;
-        inset: 0.6rem;
+        inset: 0.65rem;
         border-radius: 1.35rem;
-        border: 1px solid rgba(255, 255, 255, 0.22);
+        border: 1px solid rgba(255, 255, 255, 0.32);
         pointer-events: none;
     }
 
     .nav-drawer__brand {
         align-items: flex-start;
-        gap: clamp(0.85rem, 1.8vw, 1.25rem);
+        gap: clamp(0.9rem, 1.9vw, 1.3rem);
         position: relative;
         z-index: 1;
     }
 
     .nav-drawer__logo {
-        width: clamp(3.25rem, 4vw, 3.75rem);
-        height: clamp(3.25rem, 4vw, 3.75rem);
-        border-radius: 1.25rem;
+        width: clamp(3.25rem, 4vw, 3.85rem);
+        height: clamp(3.25rem, 4vw, 3.85rem);
+        border-radius: 1.3rem;
         display: grid;
         place-items: center;
-        background: rgba(255, 255, 255, 0.22);
-        border: 1px solid rgba(255, 255, 255, 0.4);
-        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.25);
+        background:
+            linear-gradient(150deg, rgba(255, 255, 255, 0.28), rgba(255, 255, 255, 0.1)),
+            linear-gradient(180deg, color-mix(in srgb, var(--tablet-nav-accent) 88%, #ffffff 12%), color-mix(in srgb, var(--tablet-nav-accent) 58%, #352bd4 42%));
+        border: 1px solid rgba(255, 255, 255, 0.42);
+        box-shadow: 0 20px 44px color-mix(in srgb, var(--tablet-nav-accent) 28%, transparent);
         color: #ffffff;
-        font-size: clamp(1.2rem, 2vw, 1.35rem);
+        font-size: clamp(1.2rem, 2vw, 1.4rem);
     }
 
     .nav-drawer__title {
         color: #ffffff;
-        font-size: clamp(1.35rem, 2.4vw, 1.6rem);
+        font-size: clamp(1.4rem, 2.45vw, 1.65rem);
         font-weight: 700;
-        letter-spacing: -0.025em;
+        letter-spacing: -0.03em;
     }
 
     .nav-drawer__subtitle {
-        color: rgba(255, 255, 255, 0.85);
-        font-size: clamp(0.9rem, 1.6vw, 1rem);
+        color: rgba(255, 255, 255, 0.88);
+        font-size: clamp(0.9rem, 1.6vw, 1.05rem);
         font-weight: 500;
-        max-width: 24ch;
-        line-height: 1.4;
+        max-width: 26ch;
+        line-height: 1.45;
     }
 
     .nav-drawer__close {
@@ -230,6 +249,226 @@
     }
 
     .nav-drawer__content {
-        gap: clamp(1.25rem, 2.5vw, 1.75rem);
+        gap: clamp(1.35rem, 2.6vw, 1.9rem);
+        padding: clamp(1.35rem, 2.8vw, 1.85rem);
+        border-radius: 1.75rem;
+        border: 1px solid color-mix(in srgb, var(--tablet-nav-accent-soft) 35%, transparent);
+        background: linear-gradient(
+            180deg,
+            color-mix(in srgb, var(--tablet-nav-surface) 86%, #ffffff 14%) 0%,
+            color-mix(in srgb, var(--tablet-nav-surface-strong) 70%, #ffffff 30%) 100%
+        );
+        box-shadow: 0 26px 58px var(--tablet-nav-shadow);
+    }
+
+    .nav-scroll-container {
+        gap: clamp(0.55rem, 1.4vw, 0.85rem);
+        padding-right: clamp(0.4rem, 1vw, 0.6rem);
+        margin-right: calc(-1 * clamp(0.4rem, 1vw, 0.6rem));
+    }
+
+    .nav-item {
+        margin: 0;
+    }
+
+    .nav-link {
+        display: flex;
+        align-items: center;
+        gap: clamp(0.8rem, 1.6vw, 1.1rem);
+        padding: clamp(0.75rem, 1.8vw, 0.95rem) clamp(0.85rem, 2vw, 1.1rem) !important;
+        border-radius: 1.15rem !important;
+        border: 1px solid transparent !important;
+        background: transparent !important;
+        color: #58607d !important;
+        box-shadow: none !important;
+        letter-spacing: -0.01em;
+        font-weight: 600;
+        transition: background var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast), transform var(--transition-fast), border-color var(--transition-fast);
+    }
+
+    .nav-link i {
+        width: clamp(2.1rem, 2.8vw, 2.4rem);
+        height: clamp(2.1rem, 2.8vw, 2.4rem);
+        border-radius: 0.95rem;
+        display: grid;
+        place-items: center;
+        font-size: 1.05rem;
+        background: linear-gradient(145deg, rgba(96, 106, 162, 0.12), rgba(96, 106, 162, 0.03)) !important;
+        color: inherit !important;
+        box-shadow: none !important;
+        transition: background var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast);
+    }
+
+    .nav-link:hover {
+        background: linear-gradient(135deg, color-mix(in srgb, var(--tablet-nav-accent) 22%, rgba(255, 255, 255, 0.98) 78%), color-mix(in srgb, var(--tablet-nav-accent) 12%, rgba(255, 255, 255, 0.98) 88%)) !important;
+        border-color: color-mix(in srgb, var(--tablet-nav-accent) 28%, transparent) !important;
+        color: color-mix(in srgb, var(--tablet-nav-accent) 85%, #352bd4 15%) !important;
+        box-shadow: 0 20px 40px var(--tablet-nav-soft-shadow) !important;
+        transform: translateX(4px);
+    }
+
+    .nav-link:hover i {
+        background: #ffffff !important;
+        color: color-mix(in srgb, var(--tablet-nav-accent) 85%, #352bd4 15%) !important;
+        box-shadow: 0 14px 28px color-mix(in srgb, var(--tablet-nav-accent) 24%, transparent) !important;
+    }
+
+    .nav-link.active {
+        background: linear-gradient(135deg, color-mix(in srgb, var(--tablet-nav-accent) 18%, #ede9ff 82%), color-mix(in srgb, var(--tablet-nav-accent) 26%, #e2dcff 74%)) !important;
+        border-color: color-mix(in srgb, var(--tablet-nav-accent) 38%, transparent) !important;
+        color: color-mix(in srgb, var(--tablet-nav-accent) 82%, #352bd4 18%) !important;
+        box-shadow: 0 24px 48px color-mix(in srgb, var(--tablet-nav-accent) 22%, transparent) !important;
+    }
+
+    .nav-link.active i {
+        background: #ffffff !important;
+        color: color-mix(in srgb, var(--tablet-nav-accent) 82%, #352bd4 18%) !important;
+        box-shadow: 0 16px 32px color-mix(in srgb, var(--tablet-nav-accent) 28%, transparent) !important;
+    }
+
+    .nav-section-header {
+        padding: clamp(0.8rem, 2vw, 0.95rem) clamp(0.85rem, 2vw, 1.1rem);
+        margin: 0.35rem 0;
+        border-radius: 1.2rem;
+        border: 1px solid transparent;
+        background: transparent;
+        font-weight: 600;
+        color: #596083;
+        transition: background var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
+    }
+
+    .nav-section-header i {
+        width: clamp(2rem, 2.6vw, 2.35rem);
+        height: clamp(2rem, 2.6vw, 2.35rem);
+        border-radius: 0.9rem;
+        display: grid;
+        place-items: center;
+        font-size: 1.05rem;
+        background: linear-gradient(145deg, rgba(96, 106, 162, 0.12), rgba(96, 106, 162, 0.04)) !important;
+        color: inherit;
+        box-shadow: none;
+    }
+
+    .nav-section-header .submenu-toggle {
+        margin-left: auto;
+        font-size: 0.75rem;
+        color: currentColor;
+        transition: transform var(--transition-fast), color var(--transition-fast);
+    }
+
+    .nav-section-header:hover {
+        background: linear-gradient(135deg, color-mix(in srgb, var(--tablet-nav-accent) 20%, rgba(255, 255, 255, 0.98) 80%), color-mix(in srgb, var(--tablet-nav-accent) 12%, rgba(255, 255, 255, 0.98) 88%));
+        border-color: color-mix(in srgb, var(--tablet-nav-accent) 28%, transparent);
+        color: color-mix(in srgb, var(--tablet-nav-accent) 80%, #352bd4 20%);
+        box-shadow: 0 18px 36px var(--tablet-nav-soft-shadow);
+        transform: translateX(4px);
+    }
+
+    .nav-section-header:hover i {
+        background: #ffffff !important;
+        color: color-mix(in srgb, var(--tablet-nav-accent) 80%, #352bd4 20%);
+        box-shadow: 0 12px 26px color-mix(in srgb, var(--tablet-nav-accent) 22%, transparent);
+    }
+
+    .nav-submenu {
+        padding-left: clamp(2.5rem, 4vw, 3rem);
+        gap: 0.4rem;
+    }
+
+    .nav-submenu .submenu-link {
+        padding: 0.65rem 0.85rem;
+        border-radius: 0.95rem;
+        border: 1px solid transparent !important;
+        background: transparent !important;
+        color: #656e91 !important;
+        font-weight: 500;
+        letter-spacing: -0.005em;
+        box-shadow: none !important;
+        transition: background var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast), transform var(--transition-fast), border-color var(--transition-fast);
+    }
+
+    .nav-submenu .submenu-link i {
+        width: 1.8rem;
+        height: 1.8rem;
+        border-radius: 0.75rem;
+        display: grid;
+        place-items: center;
+        font-size: 0.9rem;
+        background: rgba(96, 106, 162, 0.12) !important;
+        color: inherit !important;
+        box-shadow: none !important;
+    }
+
+    .nav-submenu .submenu-link:hover {
+        background: color-mix(in srgb, var(--tablet-nav-accent) 16%, rgba(255, 255, 255, 0.98) 84%) !important;
+        border-color: color-mix(in srgb, var(--tablet-nav-accent) 26%, transparent) !important;
+        color: color-mix(in srgb, var(--tablet-nav-accent) 80%, #352bd4 20%) !important;
+        box-shadow: 0 16px 28px var(--tablet-nav-soft-shadow) !important;
+        transform: translateX(6px);
+    }
+
+    .nav-submenu .submenu-link:hover i {
+        background: #ffffff !important;
+        color: color-mix(in srgb, var(--tablet-nav-accent) 80%, #352bd4 20%) !important;
+        box-shadow: 0 10px 20px color-mix(in srgb, var(--tablet-nav-accent) 20%, transparent) !important;
+    }
+
+    .nav-submenu .submenu-link.active {
+        background: color-mix(in srgb, var(--tablet-nav-accent) 22%, rgba(237, 233, 255, 0.95) 78%) !important;
+        border-color: color-mix(in srgb, var(--tablet-nav-accent) 32%, transparent) !important;
+        color: color-mix(in srgb, var(--tablet-nav-accent) 82%, #352bd4 18%) !important;
+        box-shadow: 0 18px 32px color-mix(in srgb, var(--tablet-nav-accent) 22%, transparent) !important;
+    }
+
+    .nav-submenu .submenu-link.active i {
+        background: #ffffff !important;
+        color: color-mix(in srgb, var(--tablet-nav-accent) 82%, #352bd4 18%) !important;
+        box-shadow: 0 12px 26px color-mix(in srgb, var(--tablet-nav-accent) 24%, transparent) !important;
+    }
+
+    .nav-drawer__divider {
+        background: color-mix(in srgb, var(--tablet-nav-accent-soft) 45%, transparent);
+        height: 2px;
+        border-radius: 999px;
+    }
+
+    .nav-drawer__footer {
+        padding-top: clamp(1.5rem, 3vw, 2.1rem);
+    }
+
+    .nav-drawer__logout {
+        padding: clamp(0.75rem, 1.8vw, 0.95rem) clamp(0.85rem, 2vw, 1.1rem);
+        border-radius: 1.1rem;
+        border: 1px solid transparent;
+        background: transparent;
+        color: #646d92;
+        font-weight: 600;
+        gap: clamp(0.75rem, 1.8vw, 1rem);
+        transition: background var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast), border-color var(--transition-fast);
+    }
+
+    .nav-drawer__logout i {
+        width: clamp(2.1rem, 2.8vw, 2.3rem);
+        height: clamp(2.1rem, 2.8vw, 2.3rem);
+        border-radius: 0.95rem;
+        display: grid;
+        place-items: center;
+        font-size: 1.05rem;
+        background: rgba(96, 106, 162, 0.12) !important;
+        color: inherit !important;
+        box-shadow: none !important;
+    }
+
+    .nav-drawer__logout:hover {
+        background: color-mix(in srgb, var(--tablet-nav-accent) 18%, rgba(255, 255, 255, 0.98) 82%);
+        border-color: color-mix(in srgb, var(--tablet-nav-accent) 30%, transparent);
+        color: color-mix(in srgb, var(--tablet-nav-accent) 82%, #352bd4 18%);
+        box-shadow: 0 18px 36px var(--tablet-nav-soft-shadow);
+    }
+
+    .nav-drawer__logout:hover i {
+        background: #ffffff !important;
+        color: color-mix(in srgb, var(--tablet-nav-accent) 82%, #352bd4 18%) !important;
+        box-shadow: 0 12px 24px color-mix(in srgb, var(--tablet-nav-accent) 24%, transparent) !important;
     }
 }

--- a/src/Web/NexaCRM.WebClient/wwwroot/css/app.css
+++ b/src/Web/NexaCRM.WebClient/wwwroot/css/app.css
@@ -665,7 +665,7 @@ a:hover, .btn-link:hover {
 }
 
 /* Desktop & tablet navigation layout */
-@media (min-width: 769px) {
+@media (min-width: 768px) {
     .page {
         --sidebar-width: clamp(260px, 24vw, 320px);
     }
@@ -693,14 +693,18 @@ a:hover, .btn-link:hover {
         max-width: var(--sidebar-width);
         height: calc(100vh - (var(--desktop-shell-padding) * 2));
         max-height: calc(100vh - (var(--desktop-shell-padding) * 2));
-        border-radius: 1.75rem;
-        border: 1px solid color-mix(in srgb, var(--nav-accent-color, var(--primary-color)) 18%, transparent);
+        border-radius: 1.9rem;
+        border: 1px solid color-mix(in srgb, var(--nav-accent-color, var(--primary-color)) 22%, transparent);
         background:
-            radial-gradient(140% 120% at 100% 0%, color-mix(in srgb, var(--nav-accent-color, var(--primary-color)) 18%, transparent) 0%, transparent 55%),
-            var(--surface-gradient, var(--surface-color));
-        box-shadow: 0 32px 64px rgba(15, 23, 42, 0.14);
-        backdrop-filter: blur(20px);
-        -webkit-backdrop-filter: blur(20px);
+            radial-gradient(150% 140% at 100% 0%, color-mix(in srgb, var(--nav-accent-color, var(--primary-color)) 16%, transparent) 0%, transparent 60%),
+            linear-gradient(
+                180deg,
+                color-mix(in srgb, #fafbff 88%, var(--nav-accent-color, var(--primary-color)) 12%) 0%,
+                color-mix(in srgb, #eef1ff 74%, var(--nav-accent-color, var(--primary-color)) 26%) 100%
+            );
+        box-shadow: 0 36px 72px rgba(82, 96, 155, 0.18);
+        backdrop-filter: blur(26px);
+        -webkit-backdrop-filter: blur(26px);
         padding: 0;
         overflow: hidden;
     }
@@ -711,8 +715,8 @@ a:hover, .btn-link:hover {
 
     .desktop-layout .nav-drawer {
         height: 100%;
-        padding: clamp(1.75rem, 4vw, 2.5rem) clamp(1.5rem, 3vw, 2.5rem);
-        gap: clamp(1.5rem, 3vw, 2rem);
+        padding: clamp(2rem, 4.5vw, 2.85rem) clamp(1.75rem, 3.5vw, 2.65rem);
+        gap: clamp(1.75rem, 3.2vw, 2.25rem);
     }
 
     .desktop-layout .nav-scroll-container {


### PR DESCRIPTION
## Summary
- restyle the navigation menu for tablet and larger viewports with new gradients, spacing, and hover states
- refresh the desktop sidebar container layout to match the updated visual language

## Testing
- `dotnet build --configuration Release` *(fails: dotnet not available in container)*
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68caaba418f0832cb59f7e80a36cc44b