### PR TITLE
chore: add build verification script

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ dotnet run --project src/Services/Deal.API/Services.Deal.API.csproj
 dotnet run --project src/Web/NexaCRM.WebClient/NexaCRM.WebClient.csproj
 ```
 
+### 빌드/테스트 검증 스크립트
+코드를 변경한 후에는 저장소 루트에서 다음 스크립트를 실행해 의존성 복원, 빌드, 테스트를 한 번에 검증할 수 있습니다.
+
+```bash
+./scripts/verify-build.sh
+```
+
+> `dotnet` SDK가 설치되어 있어야 하며, 스크립트는 자동으로 `dotnet restore`, `dotnet build --configuration Release`, `dotnet test --configuration Release`를 순서대로 수행합니다.
+
 ### 접속 정보
 -   **Web UI**: `https://localhost:7001`
 -   **Contact API Swagger**: `https://localhost:7011/swagger`

--- a/scripts/verify-build.sh
+++ b/scripts/verify-build.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+if ! command -v dotnet >/dev/null 2>&1; then
+  echo "[error] dotnet CLI not found. Install .NET 8 SDK before running this script." >&2
+  exit 1
+fi
+
+SOLUTION="${REPO_ROOT}/NexaCrmSolution.sln"
+TEST_PROJECT="${REPO_ROOT}/tests/BlazorWebApp.Tests/BlazorWebApp.Tests.csproj"
+
+if [[ ! -f "${SOLUTION}" ]]; then
+  echo "[error] Solution file not found at ${SOLUTION}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${TEST_PROJECT}" ]]; then
+  echo "[warning] Test project file ${TEST_PROJECT} not found. Skipping tests." >&2
+  RUN_TESTS=false
+else
+  RUN_TESTS=true
+fi
+
+echo "[1/3] Restoring NuGet packages..."
+dotnet restore "${SOLUTION}"
+if [[ "${RUN_TESTS}" == true ]]; then
+  dotnet restore "${TEST_PROJECT}"
+fi
+
+echo "[2/3] Building solution in Release configuration..."
+dotnet build "${SOLUTION}" --configuration Release --no-restore
+if [[ "${RUN_TESTS}" == true ]]; then
+  dotnet build "${TEST_PROJECT}" --configuration Release --no-restore
+fi
+
+if [[ "${RUN_TESTS}" == true ]]; then
+  echo "[3/3] Running unit tests..."
+  dotnet test "${TEST_PROJECT}" --configuration Release --no-build --no-restore
+else
+  echo "[3/3] Tests skipped."
+fi
+
+echo "Build verification completed successfully."


### PR DESCRIPTION
## Summary
- add a reusable build verification script that restores, builds, and tests the solution
- document how to run the new script in the README so changes can be verified consistently

## Testing
- ./scripts/verify-build.sh

------
https://chatgpt.com/codex/tasks/task_b_68ccd3081624832ca90ffe155b4c8d25