### PR TITLE
feat: apply dashboard and pipeline ux refinements

### DIFF
--- a/src/Web/NexaCRM.WebClient/Models/Deal.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Deal.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace NexaCRM.WebClient.Models
 {
     public class Deal
@@ -8,5 +10,7 @@ namespace NexaCRM.WebClient.Models
         public decimal Amount { get; set; }
         public string? Company { get; set; }
         public string? ContactPerson { get; set; }
+        public string? Owner { get; set; }
+        public DateTime CreatedDate { get; set; } = DateTime.Today;
     }
 }

--- a/src/Web/NexaCRM.WebClient/Pages/DbAdvancedManagementPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/DbAdvancedManagementPage.razor
@@ -15,14 +15,19 @@
     <header class="advanced-db__header">
         <h1>고급 DB 관리</h1>
         <div class="toolbar">
-            <button class="btn btn-light" @onclick="SaveCurrentView"><i class="bi bi-bookmark"></i> 보기 저장</button>
+            <button class="btn btn-light preview-action" @onclick="SaveCurrentView" title="곧 제공 예정 기능입니다."><i class="bi bi-bookmark"></i> 보기 저장</button>
             <button class="btn btn-light" disabled><i class="bi bi-layout-three-columns"></i> 컬럼</button>
             <button class="btn btn-light" disabled><i class="bi bi-list-check"></i> 일괄 작업</button>
-            <button class="btn btn-light" @onclick="ExportCsv"><i class="bi bi-download"></i> 내보내기</button>
-            <label class="btn btn-success" for="importFile"><i class="bi bi-person-plus"></i> 고객 DB 추가하기</label>
+            <button class="btn btn-light preview-action" @onclick="ExportCsv" title="곧 제공 예정 기능입니다."><i class="bi bi-download"></i> 내보내기</button>
+            <label class="btn btn-success preview-action" for="importFile" title="곧 제공 예정 기능입니다."><i class="bi bi-person-plus"></i> 고객 DB 추가하기</label>
             <input id="importFile" type="file" accept=".xlsx,.xls,.csv" style="display:none" @onchange="OnImportFileSelected" />
         </div>
     </header>
+
+    <div class="preview-banner" role="status" aria-live="polite">
+        <i class="bi bi-info-circle-fill" aria-hidden="true"></i>
+        <span>저장/내보내기 기능은 현재 데모 모드로 안내되며 곧 정식 제공될 예정입니다.</span>
+    </div>
 
     <nav class="tabs" role="tablist">
     <button class="tab @(activeTab==Tab.Explore?"active":null)" @onclick="(()=>SetTab(Tab.Explore))">목록</button>
@@ -330,7 +335,7 @@
                 </table>
             </div>
             <div class="mt-3 text-end">
-                <button class="btn btn-success" @onclick="SaveGradeRows"><i class="bi bi-save"></i> 등급구분값 저장</button>
+                <button class="btn btn-success preview-action" @onclick="SaveGradeRows" title="곧 제공 예정 기능입니다."><i class="bi bi-save"></i> 등급구분값 저장</button>
             </div>
         </section>
     }
@@ -399,7 +404,7 @@
                 </table>
             </div>
             <div class="mt-3 text-end">
-                <button class="btn btn-success" @onclick="SaveConsultRows"><i class="bi bi-save"></i> 상담구분값 저장</button>
+                <button class="btn btn-success preview-action" @onclick="SaveConsultRows" title="곧 제공 예정 기능입니다."><i class="bi bi-save"></i> 상담구분값 저장</button>
             </div>
         </section>
     }
@@ -482,7 +487,7 @@
                 }
             </div>
             <div class="mt-4 text-end">
-                <button class="btn btn-dark" @onclick="SaveDistributionSettings"><i class="bi bi-save"></i> 저장하기</button>
+                <button class="btn btn-dark preview-action" @onclick="SaveDistributionSettings" title="곧 제공 예정 기능입니다."><i class="bi bi-save"></i> 저장하기</button>
             </div>
         </section>
     }
@@ -565,9 +570,10 @@
     private bool autoDistVendor = false;
     private string selectedTeam = "TM0001";
 
-    private void SaveDistributionSettings()
+    private async Task SaveDistributionSettings()
     {
         // TODO: 실제 저장 로직(예: DB/API 연동) 필요
+        await NotifyPreviewFeatureAsync("분배 설정 저장");
     }
 
     // 상담구분값 관리용 모델
@@ -607,7 +613,7 @@
             consultRows.Remove(row);
     }
 
-    private void SaveConsultRows()
+    private async Task SaveConsultRows()
     {
         foreach (var row in consultRows)
         {
@@ -615,6 +621,7 @@
         }
         // TODO: 실제 저장 로직(예: DB/API 연동) 필요
         // 현재는 단순히 UpdatedAt만 갱신
+        await NotifyPreviewFeatureAsync("상담 구분값 저장");
     }
 
     // 등급관리용 모델
@@ -650,7 +657,7 @@
             gradeRows.Remove(row);
     }
 
-    private void SaveGradeRows()
+    private async Task SaveGradeRows()
     {
         foreach (var row in gradeRows)
         {
@@ -658,6 +665,7 @@
         }
         // TODO: 실제 저장 로직(예: DB/API 연동) 필요
         // 현재는 단순히 UpdatedAt만 갱신
+        await NotifyPreviewFeatureAsync("등급 구분값 저장");
     }
     private Tab activeTab = Tab.Explore;
 
@@ -1021,22 +1029,15 @@
         public List<int> ContactIds { get; set; } = new();
     }
 
-    private Task SaveCurrentView()
-    {
-        // TODO: Persist filters/columns as a saved view
-        return Task.CompletedTask;
-    }
+    private Task SaveCurrentView() => NotifyPreviewFeatureAsync("보기 저장");
 
-    private Task ExportCsv()
-    {
-        // TODO: Wire to CSV export util
-        return Task.CompletedTask;
-    }
+    private Task ExportCsv() => NotifyPreviewFeatureAsync("CSV 내보내기");
 
-    private Task OnImportFileSelected(ChangeEventArgs e)
+    private Task OnImportFileSelected(ChangeEventArgs e) => NotifyPreviewFeatureAsync("고객 DB 추가하기");
+
+    private Task NotifyPreviewFeatureAsync(string featureName)
     {
-        // TODO: Hook into import workflow (mapping/validation)
-        return Task.CompletedTask;
+        return JS.InvokeVoidAsync("alert", $"{featureName} 기능은 준비 중입니다. 곧 제공될 예정입니다.").AsTask();
     }
 
     private static string GetStatusClass(DbStatus status) => status switch

--- a/src/Web/NexaCRM.WebClient/Pages/DbAdvancedManagementPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/DbAdvancedManagementPage.razor.css
@@ -13,6 +13,32 @@
     gap: 0.75rem;
 }
 
+.preview-banner {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    border: 1px solid #d0d9e7;
+    border-radius: 10px;
+    background: linear-gradient(135deg, #eef2ff 0%, #f8fafc 100%);
+    color: #1f2937;
+    font-size: 0.95rem;
+}
+
+.preview-banner .bi {
+    color: #2153C8;
+    font-size: 1rem;
+}
+
+.preview-action {
+    opacity: 0.88;
+    transition: opacity 0.2s ease;
+}
+
+.preview-action:hover {
+    opacity: 1;
+}
+
 .advanced-db__header .toolbar {
     display: flex;
     gap: 0.5rem;

--- a/src/Web/NexaCRM.WebClient/Pages/LoginPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/LoginPage.razor
@@ -92,7 +92,7 @@
     </div>
 
     <div class="social-login-grid">
-      <button class="social-login-btn naver-btn" type="button">
+      <button class="social-login-btn naver-btn" type="button" disabled aria-disabled="true" title="@Localizer["SocialLoginComingSoon"]">
         <span class="social-icon">
           <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
             <rect width="32" height="32" rx="16" fill="#03C75A" />
@@ -103,7 +103,7 @@
         <span class="social-text">@Localizer["Naver"]</span>
       </button>
 
-      <button class="social-login-btn google-btn" type="button">
+      <button class="social-login-btn google-btn" type="button" disabled aria-disabled="true" title="@Localizer["SocialLoginComingSoon"]">
         <span class="social-icon">
           <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
             <path fill="#4285F4" d="M28.16 16.26c0-.94-.08-1.8-.24-2.6H16v4.92h6.84c-.3 1.62-1.2 2.98-2.56 3.88v3.3h4.14c2.4-2.2 3.74-5.44 3.74-9.5z"/>
@@ -115,7 +115,7 @@
         <span class="social-text">@Localizer["Google"]</span>
       </button>
 
-      <button class="social-login-btn kakao-btn" type="button">
+      <button class="social-login-btn kakao-btn" type="button" disabled aria-disabled="true" title="@Localizer["SocialLoginComingSoon"]">
         <span class="social-icon">
           <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
             <rect width="32" height="32" rx="16" fill="#FEE500" />
@@ -125,6 +125,7 @@
         <span class="social-text">@Localizer["Kakao"]</span>
       </button>
     </div>
+    <p class="social-login-notice">@Localizer["SocialLoginComingSoon"]</p>
   </div>
 </div>
 

--- a/src/Web/NexaCRM.WebClient/Pages/LoginPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/LoginPage.razor.css
@@ -279,6 +279,17 @@
     transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+.social-login-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+    box-shadow: none;
+    transform: none;
+}
+
+.social-login-btn:disabled .social-text {
+    color: var(--muted-color);
+}
+
 .social-login-btn:hover {
     transform: translateY(-2px);
     box-shadow: 0 18px 32px rgba(124, 58, 237, 0.22);
@@ -304,6 +315,13 @@
 
 .social-text {
     line-height: 1.2;
+}
+
+.social-login-notice {
+    margin-top: 1rem;
+    text-align: center;
+    font-size: 0.8rem;
+    color: var(--muted-color);
 }
 
 .naver-btn {

--- a/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor
@@ -1,36 +1,44 @@
 @page "/main-dashboard"
 @using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.Extensions.Localization
+@using NexaCRM.WebClient.Services.Interfaces
 @inject IStringLocalizer<MainDashboard> Localizer
 @inject NavigationManager NavigationManager
 @inject IJSRuntime JSRuntime
+@inject INotificationFeedService NotificationFeed
 @attribute [Authorize(Roles = "Sales,Manager")]
+@implements IDisposable
 
 <div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;' data-page="main-dashboard">
     <!-- Mobile Header Bar -->
-    <div class="mobile-header" style="display: flex !important; visibility: visible !important; opacity: 1 !important; position: fixed !important; top: 0 !important; left: 0 !important; right: 0 !important; z-index: 999999 !important; background-color: #ffffff !important; border-bottom: 1px solid #e5e7eb !important; height: 60px !important; width: 100vw !important; box-shadow: 0 2px 8px rgba(0,0,0,0.15) !important;">
-        <div class="mobile-header-content" style="display: flex !important; align-items: center !important; justify-content: space-between !important; width: 100% !important; padding: 0 1rem !important;">
-            <button class="mobile-menu-toggle" @onclick="ToggleMobileMenu" title="@Localizer["OpenMenu"]" style="display: flex !important; align-items: center !important; justify-content: center !important; padding: 0.5rem !important; background: none !important; border: none !important; color: #374151 !important;">
+    <div class="mobile-header mobile-header--active">
+        <div class="mobile-header-content">
+            <button class="mobile-menu-toggle" @onclick="ToggleMobileMenu" title="@Localizer["OpenMenu"]">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 256 256">
                     <path d="M224,128a8,8,0,0,1-8,8H40a8,8,0,0,1,0-16H216A8,8,0,0,1,224,128ZM40,72H216a8,8,0,0,0,0-16H40a8,8,0,0,0,0,16ZM216,184H40a8,8,0,0,0,0,16H216a8,8,0,0,0,0-16Z"></path>
                 </svg>
             </button>
             
-            <div class="mobile-header-title" style="display: flex !important; flex: 1 !important; justify-content: center !important;">
-                <h1 class="mobile-title" style="display: block !important; font-size: 1.25rem !important; font-weight: 700 !important; color: #374151 !important; margin: 0 !important;">@Localizer["CRM"]</h1>
+            <div class="mobile-header-title">
+                <h1 class="mobile-title">@Localizer["CRM"]</h1>
             </div>
-            
-            <div class="mobile-header-actions" style="display: flex !important; gap: 0.5rem !important; align-items: center !important;">
-                <button class="mobile-action-btn" @onclick="ToggleMobileSearch" title="@Localizer["Search"]" style="display: flex !important; align-items: center !important; justify-content: center !important; padding: 0.5rem !important; background: none !important; border: none !important; color: #374151 !important;">
+
+            <div class="mobile-header-actions">
+                <button class="mobile-action-btn" @onclick="ToggleMobileSearch" title="@Localizer["Search"]">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 256 256">
                         <path d="M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z"></path>
                     </svg>
                 </button>
-                <button class="mobile-action-btn mobile-notifications-btn" @onclick="ToggleMobileNotifications" title="@Localizer["Notifications"]" style="display: flex !important; align-items: center !important; justify-content: center !important; padding: 0.5rem !important; background: none !important; border: none !important; color: #374151 !important; position: relative !important;">
+                <button class="mobile-action-btn mobile-notifications-btn" @onclick="ToggleMobileNotifications" title="@Localizer["Notifications"]">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 256 256">
                         <path d="M221.8,175.94C216.25,166.38,208,139.33,208,104a80,80,0,1,0-160,0c0,35.34-8.26,62.38-13.81,71.94A16,16,0,0,0,48,200H88.81a40,40,0,0,0,78.38,0H208a16,16,0,0,0,13.8-24.06ZM128,216a24,24,0,0,1-22.62-16h45.24A24,24,0,0,1,128,216ZM48,184c7.7-13.24,16-43.92,16-80a64,64,0,1,1,128,0c0,36.05,8.28,66.73,16,80Z"></path>
                     </svg>
-                    <span class="notification-badge" style="display: block !important; position: absolute !important; top: -2px !important; right: -2px !important; background-color: #ef4444 !important; color: white !important; font-size: 0.75rem !important; padding: 0.125rem 0.375rem !important; border-radius: 0.5rem !important; min-width: 1rem !important; text-align: center !important;">3</span>
+                    @if (UnreadMobileNotificationsCount > 0)
+                    {
+                        <span class="notification-badge" aria-label="@Localizer["Notifications"]">
+                            @UnreadMobileNotificationsCount
+                        </span>
+                    }
                 </button>
             </div>
         </div>
@@ -104,39 +112,44 @@
             </button>
         </div>
         <div class="mobile-notifications-content">
-            <div class="notification-item">
-                <div class="notification-icon">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256">
-                        <path d="M256,136a8,8,0,0,1-8,8H232v16a8,8,0,0,1-16,0V144H200a8,8,0,0,1,0-16h16V112a8,8,0,0,1,16,0v16h16A8,8,0,0,1,256,136Z"></path>
-                    </svg>
+            @foreach (var notification in mobileNotifications)
+            {
+                <div class="notification-item">
+                    <div class="notification-icon">
+                        @switch (notification.Icon)
+                        {
+                            case NotificationIconType.Lead:
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256">
+                                    <path d="M256,136a8,8,0,0,1-8,8H232v16a8,8,0,0,1-16,0V144H200a8,8,0,0,1,0-16h16V112a8,8,0,0,1,16,0v16h16A8,8,0,0,1,256,136Z"></path>
+                                </svg>
+                                break;
+                            case NotificationIconType.Deal:
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256">
+                                    <path d="M173.66,98.34a8,8,0,0,1,0,11.32l-56,56a8,8,0,0,1-11.32,0l-24-24a8,8,0,0,1,11.32-11.32L112,148.69l50.34-50.35A8,8,0,0,1,173.66,98.34Z"></path>
+                                </svg>
+                                break;
+                            case NotificationIconType.Task:
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256">
+                                    <path d="M128,80a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Z"></path>
+                                </svg>
+                                break;
+                        }
+                    </div>
+                    <div class="notification-content">
+                        <div class="notification-title">@Localizer[notification.TitleKey]</div>
+                        <div class="notification-time">
+                            @if (!string.IsNullOrWhiteSpace(notification.TimeValue))
+                            {
+                                <span>@notification.TimeValue @Localizer[notification.TimeKey]</span>
+                            }
+                            else
+                            {
+                                <span>@Localizer[notification.TimeKey]</span>
+                            }
+                        </div>
+                    </div>
                 </div>
-                <div class="notification-content">
-                    <div class="notification-title">@Localizer["NewLead"]</div>
-                    <div class="notification-time">2 @Localizer["MinutesAgo"]</div>
-                </div>
-            </div>
-            <div class="notification-item">
-                <div class="notification-icon">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256">
-                        <path d="M173.66,98.34a8,8,0,0,1,0,11.32l-56,56a8,8,0,0,1-11.32,0l-24-24a8,8,0,0,1,11.32-11.32L112,148.69l50.34-50.35A8,8,0,0,1,173.66,98.34Z"></path>
-                    </svg>
-                </div>
-                <div class="notification-content">
-                    <div class="notification-title">@Localizer["DealClosed"]</div>
-                    <div class="notification-time">15 @Localizer["MinutesAgo"]</div>
-                </div>
-            </div>
-            <div class="notification-item">
-                <div class="notification-icon">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256">
-                        <path d="M128,80a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Z"></path>
-                    </svg>
-                </div>
-                <div class="notification-content">
-                    <div class="notification-title">@Localizer["TaskReminder"]</div>
-                    <div class="notification-time">1 @Localizer["HourAgo"]</div>
-                </div>
-            </div>
+            }
         </div>
     </div>
 
@@ -169,73 +182,73 @@
                                 salesLink = "/sales-manager-dashboard";
                             }
                         }
-                        <a href="@salesLink" class="flex items-center gap-3 px-3 py-2 nav-link" style="color: #0e131b !important;">
-                            <div class="text-[#0e131b]" data-icon="CurrencyDollar" data-size="24px" data-weight="regular" style="color: #0e131b !important;">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256" style="color: #0e131b !important; fill: #0e131b !important;">
+                        <a href="@salesLink" class="flex items-center gap-3 px-3 py-2 nav-link">
+                            <div class="text-[#0e131b] nav-link-icon" data-icon="CurrencyDollar" data-size="24px" data-weight="regular">
+                                <svg class="nav-link-icon-graphic" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                                 <path
                                     d="M152,120H136V56h8a32,32,0,0,1,32,32,8,8,0,0,0,16,0,48.05,48.05,0,0,0-48-48h-8V24a8,8,0,0,0-16,0V40h-8a48,48,0,0,0,0,96h8v64H104a32,32,0,0,1-32-32,8,8,0,0,0-16,0,48.05,48.05,0,0,0,48,48h16v16a8,8,0,0,0,16,0V216h16a48,48,0,0,0,0-96Zm-40,0a32,32,0,0,1,0-64h8v64Zm40,80H136V136h16a32,32,0,0,1,0,64Z"
                                 ></path>
                                 </svg>
                             </div>
-                            <p class="text-[#0e131b] text-sm font-medium leading-normal" style="color: #0e131b !important;">@Localizer["Sales"]</p>
+                            <p class="text-[#0e131b] text-sm font-medium leading-normal nav-link-text">@Localizer["Sales"]</p>
                         </a>
-                        <a href="/contacts" class="flex items-center gap-3 px-3 py-2 nav-link" style="color: #0e131b !important;">
-                            <div class="text-[#0e131b]" data-icon="Users" data-size="24px" data-weight="regular" style="color: #0e131b !important;">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256" style="color: #0e131b !important; fill: #0e131b !important;">
+                        <a href="/contacts" class="flex items-center gap-3 px-3 py-2 nav-link">
+                            <div class="text-[#0e131b] nav-link-icon" data-icon="Users" data-size="24px" data-weight="regular">
+                                <svg class="nav-link-icon-graphic" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                                 <path
                                     d="M117.25,157.92a60,60,0,1,0-66.5,0A95.83,95.83,0,0,0,3.53,195.63a8,8,0,1,0,13.4,8.74,80,80,0,0,1,134.14,0,8,8,0,0,0,13.4-8.74A95.83,95.83,0,0,0,117.25,157.92ZM40,108a44,44,0,1,1,44,44A44.05,44.05,0,0,1,40,108Zm210.14,98.7a8,8,0,0,1-11.07-2.33A79.83,79.83,0,0,0,172,168a8,8,0,0,1,0-16,44,44,0,1,0-16.34-84.87,8,8,0,1,1-5.94-14.85,60,60,0,0,1,55.53,105.64,95.83,95.83,0,0,1,47.22,37.71A8,8,0,0,1,250.14,206.7Z"
                                 ></path>
                                 </svg>
                             </div>
-                            <p class="text-[#0e131b] text-sm font-medium leading-normal" style="color: #0e131b !important;">@Localizer["Contacts"]</p>
+                            <p class="text-[#0e131b] text-sm font-medium leading-normal nav-link-text">@Localizer["Contacts"]</p>
                         </a>
                     </Authorized>
                 </AuthorizeView>
-                <a href="/marketing-campaign-management-interface" class="flex items-center gap-3 px-3 py-2 nav-link" style="color: #0e131b !important;">
-                    <div class="text-[#0e131b]" data-icon="Megaphone" data-size="24px" data-weight="regular" style="color: #0e131b !important;">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256" style="color: #0e131b !important; fill: #0e131b !important;">
+                <a href="/marketing-campaign-management-interface" class="flex items-center gap-3 px-3 py-2 nav-link">
+                    <div class="text-[#0e131b] nav-link-icon" data-icon="Megaphone" data-size="24px" data-weight="regular">
+                        <svg class="nav-link-icon-graphic" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                         <path
                             d="M240,120a48.05,48.05,0,0,0-48-48H152.2c-2.91-.17-53.62-3.74-101.91-44.24A16,16,0,0,0,24,40V200a16,16,0,0,0,26.29,12.25c37.77-31.68,77-40.76,93.71-43.3v31.72A16,16,0,0,0,151.12,214l11,7.33A16,16,0,0,0,186.5,212l11.77-44.36A48.07,48.07,0,0,0,240,120ZM40,199.93V40h0c42.81,35.91,86.63,45,104,47.24v65.48C126.65,155,82.84,164.07,40,199.93Zm131,8,0,.11-11-7.33V168h21.6ZM192,152H160V88h32a32,32,0,1,1,0,64Z"
                         ></path>
                         </svg>
                     </div>
-                    <p class="text-[#0e131b] text-sm font-medium leading-normal" style="color: #0e131b !important;">@Localizer["Marketing"]</p>
+                    <p class="text-[#0e131b] text-sm font-medium leading-normal nav-link-text">@Localizer["Marketing"]</p>
                 </a>
-                <a href="/customer-support-dashboard" class="flex items-center gap-3 px-3 py-2 nav-link" style="color: #0e131b !important;">
-                    <div class="text-[#0e131b]" data-icon="Headset" data-size="24px" data-weight="regular" style="color: #0e131b !important;">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256" style="color: #0e131b !important; fill: #0e131b !important;">
+                <a href="/customer-support-dashboard" class="flex items-center gap-3 px-3 py-2 nav-link">
+                    <div class="text-[#0e131b] nav-link-icon" data-icon="Headset" data-size="24px" data-weight="regular">
+                        <svg class="nav-link-icon-graphic" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                         <path
                             d="M201.89,54.66A103.43,103.43,0,0,0,128.79,24H128A104,104,0,0,0,24,128v56a24,24,0,0,0,24,24H64a24,24,0,0,0,24-24V144a24,24,0,0,0-24-24H40.36A88.12,88.12,0,0,1,190.54,65.93,87.39,87.39,0,0,1,215.65,120H192a24,24,0,0,0-24,24v40a24,24,0,0,0,24,24h24a24,24,0,0,1-24,24H136a8,8,0,0,0,0,16h56a40,40,0,0,0,40-40V128A103.41,103.41,0,0,0,201.89,54.66ZM64,136a8,8,0,0,1,8,8v40a8,8,0,0,1-8,8H48a8,8,0,0,1-8-8V136Zm128,56a8,8,0,0,1-8-8V144a8,8,0,0,1,8-8h24v56Z"
                         ></path>
                         </svg>
                     </div>
-                    <p class="text-[#0e131b] text-sm font-medium leading-normal" style="color: #0e131b !important;">@Localizer["Service"]</p>
+                    <p class="text-[#0e131b] text-sm font-medium leading-normal nav-link-text">@Localizer["Service"]</p>
                 </a>
-                <a href="/reports-page" class="flex items-center gap-3 px-3 py-2 nav-link" style="color: #0e131b !important;">
-                    <div class="text-[#0e131b]" data-icon="PresentationChart" data-size="24px" data-weight="regular" style="color: #0e131b !important;">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256" style="color: #0e131b !important; fill: #0e131b !important;">
+                <a href="/reports-page" class="flex items-center gap-3 px-3 py-2 nav-link">
+                    <div class="text-[#0e131b] nav-link-icon" data-icon="PresentationChart" data-size="24px" data-weight="regular">
+                        <svg class="nav-link-icon-graphic" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                         <path
                             d="M216,40H136V24a8,8,0,0,0-16,0V40H40A16,16,0,0,0,24,56V176a16,16,0,0,0,16,16H79.36L57.75,219a8,8,0,0,0,12.5,10l29.59-37h56.32l29.59,37a8,8,0,1,0,12.5-10l-21.61-27H216a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40Zm0,136H40V56H216V176ZM104,120v24a8,8,0,0,1-16,0V120a8,8,0,0,1,16,0Zm32-16v40a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Zm32-16v56a8,8,0,0,1-16,0V88a8,8,0,0,1,16,0Z"
                         ></path>
                         </svg>
                     </div>
-                    <p class="text-[#0e131b] text-sm font-medium leading-normal" style="color: #0e131b !important;">@Localizer["Reports"]</p>
+                    <p class="text-[#0e131b] text-sm font-medium leading-normal nav-link-text">@Localizer["Reports"]</p>
                 </a>
-                <a href="/settings-page" class="flex items-center gap-3 px-3 py-2" style="color: #0e131b !important;">
-                    <div class="text-[#0e131b]" data-icon="Gear" data-size="24px" data-weight="regular" style="color: #0e131b !important;">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                <a href="/settings-page" class="flex items-center gap-3 px-3 py-2 nav-link">
+                    <div class="text-[#0e131b] nav-link-icon" data-icon="Gear" data-size="24px" data-weight="regular">
+                        <svg class="nav-link-icon-graphic" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                         <path
                             d="M128,80a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Zm88-29.84q.06-2.16,0-4.32l14.92-18.64a8,8,0,0,0,1.48-7.06,107.21,107.21,0,0,0-10.88-26.25,8,8,0,0,0-6-3.93l-23.72-2.64q-1.48-1.56-3-3L186,40.54a8,8,0,0,0-3.94-6,107.71,107.71,0,0,0-26.25-10.87,8,8,0,0,0-7.06,1.49L130.16,40Q128,40,125.84,40L107.2,25.11a8,8,0,0,0-7.06-1.48A107.6,107.6,0,0,0,73.89,34.51a8,8,0,0,0-3.93,6L67.32,64.27q-1.56,1.49-3,3L40.54,70a8,8,0,0,0-6,3.94,107.71,107.71,0,0,0-10.87,26.25,8,8,0,0,0,1.49,7.06L40,125.84Q40,128,40,130.16L25.11,148.8a8,8,0,0,0-1.48,7.06,107.21,107.21,0,0,0,10.88,26.25,8,8,0,0,0,6,3.93l23.72,2.64q1.49,1.56,3,3L70,215.46a8,8,0,0,0,3.94,6,107.71,107.71,0,0,0,26.25,10.87,8,8,0,0,0,7.06-1.49L125.84,216q2.16.06,4.32,0l18.64,14.92a8,8,0,0,0,7.06,1.48,107.21,107.21,0,0,0,26.25-10.88,8,8,0,0,0,3.93-6l2.64-23.72q1.56-1.48,3-3L215.46,186a8,8,0,0,0,6-3.94,107.71,107.71,0,0,0,10.87-26.25,8,8,0,0,0-1.49-7.06Zm-16.1-6.5a73.93,73.93,0,0,1,0,8.68,8,8,0,0,0,1.74,5.48l14.19,17.73a91.57,91.57,0,0,1-6.23,15L187,173.11a8,8,0,0,0-5.1,2.64,74.11,74.11,0,0,1-6.14,6.14,8,8,0,0,0-2.64,5.1l-2.51,22.58a91.32,91.32,0,0,1-15,6.23l-17.74-14.19a8,8,0,0,0-5-1.75h-.48a73.93,73.93,0,0,1-8.68,0,8,8,0,0,0-5.48,1.74L100.45,215.8a91.57,91.57,0,0,1-15-6.23L82.89,187a8,8,0,0,0-2.64-5.1,74.11,74.11,0,0,1-6.14-6.14,8,8,0,0,0-5.1-2.64L46.43,170.6a91.32,91.32,0,0,1-6.23-15l14.19-17.74a8,8,0,0,0,1.74-5.48,73.93,73.93,0,0,1,0-8.68,8,8,0,0,0-1.74-5.48L40.2,100.45a91.57,91.57,0,0,1,6.23-15L69,82.89a8,8,0,0,0,5.1-2.64,74.11,74.11,0,0,1,6.14-6.14A8,8,0,0,0,82.89,69L85.4,46.43a91.32,91.32,0,0,1,15-6.23l17.74,14.19a8,8,0,0,0,5.48,1.74,73.93,73.93,0,0,1,8.68,0,8,8,0,0,0,5.48-1.74L155.55,40.2a91.57,91.57,0,0,1,15,6.23L173.11,69a8,8,0,0,0,2.64,5.1,74.11,74.11,0,0,1,6.14,6.14,8,8,0,0,0,5.1,2.64l22.58,2.51a91.32,91.32,0,0,1,6.23,15l-14.19,17.74A8,8,0,0,0,199.87,123.66Z"
                         ></path>
                         </svg>
                     </div>
-                    <p class="text-[#0e131b] text-sm font-medium leading-normal" style="color: #0e131b !important;">@Localizer["Settings"]</p>
+                    <p class="text-[#0e131b] text-sm font-medium leading-normal nav-link-text">@Localizer["Settings"]</p>
                 </a>
             </div>
             </div>
         </div>
         </div>
-        <div class="layout-content-container flex flex-col max-w-[960px] flex-1 dashboard-main-content" style="padding-top: 70px;">
+        <div class="layout-content-container flex flex-col max-w-[960px] flex-1 dashboard-main-content">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-10 py-3 dashboard-header dashboard-top-nav">
             <div class="flex items-center gap-4 text-[#0e131b]">
             <div class="size-4">
@@ -272,7 +285,10 @@
             </label>
             <div class="flex gap-2">
                 <button
-                class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 bg-[#e7ecf3] text-[#0e131b] gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5 dashboard-button"
+                type="button"
+                class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 bg-[#e7ecf3] text-[#0e131b] gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5 dashboard-button dashboard-button--notifications"
+                @onclick="NavigateToNotifications"
+                aria-label="@Localizer["Notifications"]"
                 >
                 <div class="text-[#0e131b]" data-icon="Bell" data-size="20px" data-weight="regular">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
@@ -281,8 +297,14 @@
                     ></path>
                     </svg>
                 </div>
+                @if (unreadNotificationsCount > 0)
+                {
+                    <span class="notification-badge" aria-hidden="true">@unreadNotificationsCount</span>
+                    <span class="sr-only">@string.Format(Localizer["UnreadNotificationsLabel"], unreadNotificationsCount)</span>
+                }
                 </button>
                 <button
+                type="button"
                 class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 bg-[#e7ecf3] text-[#0e131b] gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5 dashboard-button"
                 >
                 <div class="text-[#0e131b]" data-icon="Question" data-size="20px" data-weight="regular">
@@ -330,9 +352,9 @@
             </div>
             </label>
         </div>
-        <h2 class="text-[#0e131b] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5" style="display: block !important; visibility: visible !important;">@Localizer["DashboardOverview"]</h2>
-        <div class="grid grid-cols-[repeat(auto-fit,minmax(158px,1fr))] gap-3 p-4 dashboard-grid" style="display: grid !important; visibility: visible !important;">
-            <button class="flex flex-1 gap-3 rounded-lg border border-[#d0d9e7] bg-slate-50 p-4 items-center dashboard-card" data-route="/sales-pipeline" style="display: flex !important; visibility: visible !important;">
+        <h2 class="text-[#0e131b] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5 dashboard-section-title">@Localizer["DashboardOverview"]</h2>
+        <div class="grid grid-cols-[repeat(auto-fit,minmax(158px,1fr))] gap-3 p-4 dashboard-grid">
+            <button class="flex flex-1 gap-3 rounded-lg border border-[#d0d9e7] bg-slate-50 p-4 items-center dashboard-card" data-route="/sales-pipeline">
             <div class="text-[#0e131b]" data-icon="Funnel" data-size="24px" data-weight="regular">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                 <path
@@ -342,7 +364,7 @@
             </div>
             <h2 class="text-[#0e131b] text-base font-bold leading-tight">@Localizer["SalesPipeline"]</h2>
             </button>
-            <button class="flex flex-1 gap-3 rounded-lg border border-[#d0d9e7] bg-slate-50 p-4 items-center dashboard-card" data-route="/reports" style="display: flex !important; visibility: visible !important;">
+            <button class="flex flex-1 gap-3 rounded-lg border border-[#d0d9e7] bg-slate-50 p-4 items-center dashboard-card" data-route="/reports">
             <div class="text-[#0e131b]" data-icon="Target" data-size="24px" data-weight="regular">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                 <path
@@ -352,7 +374,7 @@
             </div>
             <h2 class="text-[#0e131b] text-base font-bold leading-tight">@Localizer["QuarterlyPerformance"]</h2>
             </button>
-            <button class="flex flex-1 gap-3 rounded-lg border border-[#d0d9e7] bg-slate-50 p-4 items-center dashboard-card" data-route="/tasks-page" style="display: flex !important; visibility: visible !important;">
+            <button class="flex flex-1 gap-3 rounded-lg border border-[#d0d9e7] bg-slate-50 p-4 items-center dashboard-card" data-route="/tasks-page">
             <div class="text-[#0e131b]" data-icon="ListBullets" data-size="24px" data-weight="regular">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                 <path
@@ -362,7 +384,7 @@
             </div>
             <h2 class="text-[#0e131b] text-base font-bold leading-tight">@Localizer["Tasks"]</h2>
             </button>
-            <button class="flex flex-1 gap-3 rounded-lg border border-[#d0d9e7] bg-slate-50 p-4 items-center dashboard-card" data-route="#recent-activity" style="display: flex !important; visibility: visible !important;">
+            <button class="flex flex-1 gap-3 rounded-lg border border-[#d0d9e7] bg-slate-50 p-4 items-center dashboard-card" data-route="#recent-activity">
             <div class="text-[#0e131b]" data-icon="Users" data-size="24px" data-weight="regular">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                 <path
@@ -373,11 +395,11 @@
             <h2 class="text-[#0e131b] text-base font-bold leading-tight">@Localizer["RecentActivity"]</h2>
             </button>
         </div>
-        <h2 class="text-[#0e131b] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5" style="display: block !important; visibility: visible !important;">@Localizer["SalesPipelineSummary"]</h2>
-        <div class="flex flex-wrap gap-4 px-4 py-6" style="display: flex !important; visibility: visible !important;">
-            <div class="flex min-w-72 flex-1 flex-col gap-2 rounded-lg border border-[#d0d9e7] p-6" style="display: flex !important; visibility: visible !important; width: 100%; min-width: auto;">
-            <p class="text-[#0e131b] text-base font-medium leading-normal" style="display: block !important; visibility: visible !important;">@Localizer["DealsByStage"]</p>
-            <div class="grid min-h-[180px] gap-x-4 gap-y-6 grid-cols-[auto_1fr] items-center py-3" style="display: grid !important; visibility: visible !important; min-height: 120px;">
+        <h2 class="text-[#0e131b] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5 dashboard-section-title">@Localizer["SalesPipelineSummary"]</h2>
+        <div class="flex flex-wrap gap-4 px-4 py-6 dashboard-section-content">
+            <div class="flex min-w-72 flex-1 flex-col gap-2 rounded-lg border border-[#d0d9e7] p-6 dashboard-stat-card">
+            <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["DealsByStage"]</p>
+            <div class="grid min-h-[180px] gap-x-4 gap-y-6 grid-cols-[auto_1fr] items-center py-3 dashboard-chart-grid">
                 <p class="text-[#4d6a99] text-[13px] font-bold leading-normal tracking-[0.015em]">@Localizer["Prospecting"]</p>
                 <div class="h-full flex-1"><div class="border-[#4d6a99] bg-[#e7ecf3] border-r-2 h-full" style="width: 60%;"></div></div>
                 <p class="text-[#4d6a99] text-[13px] font-bold leading-normal tracking-[0.015em]">@Localizer["Qualification"]</p>
@@ -393,11 +415,11 @@
             </div>
             </div>
         </div>
-        <h2 class="text-[#0e131b] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5" style="display: block !important; visibility: visible !important;">@Localizer["QuarterlyPerformance"]</h2>
-        <div class="flex flex-wrap gap-4 px-4 py-6" style="display: flex !important; visibility: visible !important;">
-            <div class="flex min-w-72 flex-1 flex-col gap-2 rounded-lg border border-[#d0d9e7] p-6" style="display: flex !important; visibility: visible !important; width: 100%; min-width: auto;">
-            <p class="text-[#0e131b] text-base font-medium leading-normal" style="display: block !important; visibility: visible !important;">@Localizer["RevenueByQuarter"]</p>
-            <div class="grid min-h-[180px] grid-flow-col gap-6 grid-rows-[1fr_auto] items-end justify-items-center px-3" style="display: grid !important; visibility: visible !important; min-height: 120px;">
+        <h2 class="text-[#0e131b] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5 dashboard-section-title">@Localizer["QuarterlyPerformance"]</h2>
+        <div class="flex flex-wrap gap-4 px-4 py-6 dashboard-section-content">
+            <div class="flex min-w-72 flex-1 flex-col gap-2 rounded-lg border border-[#d0d9e7] p-6 dashboard-stat-card">
+            <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["RevenueByQuarter"]</p>
+            <div class="grid min-h-[180px] grid-flow-col gap-6 grid-rows-[1fr_auto] items-end justify-items-center px-3 dashboard-chart-grid">
                 <div class="border-[#4d6a99] bg-[#e7ecf3] border-t-2 w-full" style="height: 70%;"></div>
                 <p class="text-[#4d6a99] text-[13px] font-bold leading-normal tracking-[0.015em]">@Localizer["Q1"]</p>
                 <div class="border-[#4d6a99] bg-[#e7ecf3] border-t-2 w-full" style="height: 90%;"></div>
@@ -411,7 +433,7 @@
         </div>
         <h2 class="text-[#0e131b] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">@Localizer["Tasks"]</h2>
         <div class="px-4 py-3 container">
-            <div class="flex overflow-hidden rounded-lg border border-[#d0d9e7] bg-slate-50 dashboard-table-container" style="visibility: visible !important;">
+            <div class="flex overflow-hidden rounded-lg border border-[#d0d9e7] bg-slate-50 dashboard-table-container">
             <table class="flex-1">
                 <thead>
                 <tr class="bg-slate-50">
@@ -433,9 +455,8 @@
                     <td class="table-b8380c11-022e-424e-acc3-69900c40b013-column-360 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
                     <button
                         class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-8 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-medium leading-normal w-full priority-button"
-                        style="background-color: #e7ecf3 !important; color: #0e131b !important;"
                     >
-                        <span class="truncate" style="color: #0e131b !important;">@Localizer["High"]</span>
+                        <span class="truncate priority-label">@Localizer["High"]</span>
                     </button>
                     </td>
                 </tr>
@@ -449,9 +470,8 @@
                     <td class="table-b8380c11-022e-424e-acc3-69900c40b013-column-360 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
                     <button
                         class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-8 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-medium leading-normal w-full priority-button"
-                        style="background-color: #e7ecf3 !important; color: #0e131b !important;"
                     >
-                        <span class="truncate" style="color: #0e131b !important;">@Localizer["Medium"]</span>
+                        <span class="truncate priority-label">@Localizer["Medium"]</span>
                     </button>
                     </td>
                 </tr>
@@ -465,9 +485,8 @@
                     <td class="table-b8380c11-022e-424e-acc3-69900c40b013-column-360 h-[72px] px-4 py-2 w-60 text-sm font-normal leading-normal">
                     <button
                         class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-8 px-4 bg-[#e7ecf3] text-[#0e131b] text-sm font-medium leading-normal w-full priority-button"
-                        style="background-color: #e7ecf3 !important; color: #0e131b !important;"
                     >
-                        <span class="truncate" style="color: #0e131b !important;">@Localizer["Low"]</span>
+                        <span class="truncate priority-label">@Localizer["Low"]</span>
                     </button>
                     </td>
                 </tr>
@@ -551,18 +570,48 @@
 </div>
 
 @code {
+    private int unreadNotificationsCount;
+
+    protected override async Task OnInitializedAsync()
+    {
+        NotificationFeed.UnreadCountChanged += HandleUnreadCountChanged;
+        unreadNotificationsCount = Math.Max(0, await NotificationFeed.GetUnreadCountAsync());
+    }
+
+    private static readonly MobileNotification[] mobileNotifications =
+    [
+        new(NotificationIconType.Lead, "NewLead", "2", "MinutesAgo"),
+        new(NotificationIconType.Deal, "DealClosed", "15", "MinutesAgo"),
+        new(NotificationIconType.Task, "TaskReminder", "1", "HourAgo")
+    ];
+
     private bool showMobileSearch = false;
     private bool showMobileNotifications = false;
     private string mobileSearchQuery = "";
+    private int UnreadMobileNotificationsCount => mobileNotifications.Length;
+
+    private sealed record MobileNotification(NotificationIconType Icon, string TitleKey, string TimeValue, string TimeKey);
+
+    private enum NotificationIconType
+    {
+        Lead,
+        Deal,
+        Task
+    }
 
     private async Task NavigateToPage(string url)
     {
         // Close any open mobile panels first
         await CloseMobilePanels();
-        
+
         // Add visual feedback before navigation
         await Task.Delay(150);
         NavigationManager.NavigateTo(url);
+    }
+
+    private void NavigateToNotifications()
+    {
+        NavigationManager.NavigateTo("/notifications");
     }
 
     private async Task ScrollToSection(string sectionId)
@@ -641,15 +690,21 @@
     private async Task ToggleMobileNotifications()
     {
         showMobileNotifications = !showMobileNotifications;
-        
+
         // Close search if notifications is opening
         if (showMobileNotifications)
         {
             showMobileSearch = false;
         }
-        
+
         StateHasChanged();
         await Task.Delay(50); // Small delay for smooth animation
+    }
+
+    private void HandleUnreadCountChanged(int count)
+    {
+        unreadNotificationsCount = Math.Max(0, count);
+        _ = InvokeAsync(StateHasChanged);
     }
 
     private async Task CloseMobilePanels()
@@ -716,179 +771,56 @@
             {
                 await JSRuntime.InvokeVoidAsync("eval", @"
                     try {
-                        // Force mobile header to be visible
                         const mobileHeader = document.querySelector('.mobile-header');
-                        if (mobileHeader && window.innerWidth < 768) {
-                            mobileHeader.style.display = 'flex';
-                            mobileHeader.style.visibility = 'visible';
-                            mobileHeader.style.opacity = '1';
-                            mobileHeader.style.position = 'fixed';
-                            mobileHeader.style.top = '0';
-                            mobileHeader.style.left = '0';
-                            mobileHeader.style.right = '0';
-                            mobileHeader.style.zIndex = '999999';
-                            mobileHeader.style.backgroundColor = '#ffffff';
-                            mobileHeader.style.height = '60px';
-                            mobileHeader.style.width = '100vw';
-                            mobileHeader.style.borderBottom = '1px solid #e5e7eb';
-                            mobileHeader.style.boxShadow = '0 2px 8px rgba(0,0,0,0.15)';
-                            
-                            // Ensure all child elements are visible
-                            const headerContent = mobileHeader.querySelector('.mobile-header-content');
-                            if (headerContent) {
-                                headerContent.style.display = 'flex';
-                                headerContent.style.width = '100%';
-                                headerContent.style.alignItems = 'center';
-                                headerContent.style.justifyContent = 'space-between';
-                                headerContent.style.padding = '0 16px';
-                            }
-                            
-                            const mobileTitle = mobileHeader.querySelector('.mobile-title');
-                            if (mobileTitle) {
-                                mobileTitle.style.display = 'block';
-                                mobileTitle.style.color = '#000000';
-                                mobileTitle.style.fontSize = '20px';
-                                mobileTitle.style.fontWeight = '700';
-                            }
-                            
-                            // Check for dark mode and adjust colors
-                            const isDarkMode = document.documentElement.getAttribute('data-theme') === 'dark';
-                            if (isDarkMode) {
-                                mobileHeader.style.backgroundColor = '#1f2937';
-                                mobileHeader.style.borderBottomColor = '#374151';
-                                if (mobileTitle) {
-                                    mobileTitle.style.color = '#ffffff';
-                                }
-                                const buttons = mobileHeader.querySelectorAll('button');
-                                buttons.forEach(btn => {
-                                    btn.style.color = '#ffffff';
-                                });
-                            }
+                        if (mobileHeader) {
+                            mobileHeader.classList.add('mobile-header--active');
                         }
-                        
-                        // Fix dark mode button text colors
-                        const isDarkMode = document.documentElement.getAttribute('data-theme') === 'dark';
-                        if (isDarkMode) {
-                            if (window.innerWidth < 768) {
-                                const dashboardCards = document.querySelectorAll('.dashboard-card');
-                                dashboardCards.forEach(card => {
-                                    card.style.backgroundColor = '#374151';
-                                    card.style.borderColor = '#4b5563';
-                                    card.style.color = '#ffffff';
-                                    
-                                    const textElements = card.querySelectorAll('h2, span, .text-\\[#0e131b\\]');
-                                    textElements.forEach(el => {
-                                        el.style.color = '#ffffff';
-                                    });
-                                });
+
+                        const handleBackdropClick = (event) => {
+                            if (!event.target || !event.target.classList) {
+                                return;
                             }
-                            
-                            // Fix priority button text colors in dark mode
-                            const priorityButtons = document.querySelectorAll('.priority-button');
-                            priorityButtons.forEach(button => {
-                                button.style.backgroundColor = '#374151';
-                                button.style.color = '#ffffff';
-                                button.style.borderColor = '#4b5563';
-                                
-                                const span = button.querySelector('span');
-                                if (span) {
-                                    span.style.color = '#ffffff';
+
+                            if (event.target.classList.contains('mobile-search-bar') && event.target.classList.contains('expanded')) {
+                                const closeSearch = document.querySelector('.mobile-search-close');
+                                if (closeSearch) {
+                                    closeSearch.click();
                                 }
-                            });
-                            
-                            // Fix sidebar navigation links in dark mode
-                            const sidebarLinks = document.querySelectorAll('.dashboard-sidebar a');
-                            sidebarLinks.forEach(link => {
-                                link.style.color = '#ffffff !important';
-                                link.style.setProperty('color', '#ffffff', 'important');
-                                
-                                const allElements = link.querySelectorAll('*');
-                                allElements.forEach(el => {
-                                    el.style.color = '#ffffff !important';
-                                    el.style.setProperty('color', '#ffffff', 'important');
-                                });
-                                
-                                const textElements = link.querySelectorAll('p, div[data-icon], svg');
-                                textElements.forEach(el => {
-                                    el.style.color = '#ffffff !important';
-                                    el.style.setProperty('color', '#ffffff', 'important');
-                                    if (el.tagName === 'SVG') {
-                                        el.style.fill = '#ffffff !important';
-                                        el.style.setProperty('fill', '#ffffff', 'important');
-                                    }
-                                });
-                            });
-                            
-                            // Fix sidebar background in dark mode
-                            const sidebar = document.querySelector('.dashboard-sidebar');
-                            if (sidebar) {
-                                sidebar.style.backgroundColor = '#1f2937';
-                                
-                                // Apply to all nested elements
-                                const allSidebarElements = sidebar.querySelectorAll('*');
-                                allSidebarElements.forEach(el => {
-                                    if (el.tagName === 'A' || el.tagName === 'P' || el.tagName === 'DIV') {
-                                        el.style.color = '#ffffff !important';
-                                        el.style.setProperty('color', '#ffffff', 'important');
-                                    }
-                                    if (el.tagName === 'SVG') {
-                                        el.style.fill = '#ffffff !important';
-                                        el.style.setProperty('fill', '#ffffff', 'important');
-                                    }
-                                });
                             }
-                        }
-                        // Handle mobile panel backdrop clicks
-                        document.addEventListener('click', (e) => {
-                            try {
-                                if (e.target && e.target.classList) {
-                                    if (e.target.classList.contains('mobile-search-bar') && e.target.classList.contains('expanded')) {
-                                        // Click on backdrop should close search
-                                        const closeBtn = document.querySelector('.mobile-search-close');
-                                        if (closeBtn) closeBtn.click();
-                                    }
-                                    if (e.target.classList.contains('mobile-notifications-panel') && e.target.classList.contains('expanded')) {
-                                        // Click on backdrop should close notifications
-                                        const closeBtn = document.querySelector('.mobile-notifications-close');
-                                        if (closeBtn) closeBtn.click();
-                                    }
+
+                            if (event.target.classList.contains('mobile-notifications-panel') && event.target.classList.contains('expanded')) {
+                                const closeNotifications = document.querySelector('.mobile-notifications-close');
+                                if (closeNotifications) {
+                                    closeNotifications.click();
                                 }
-                            } catch (clickError) {
-                                console.warn('Click handler error:', clickError);
                             }
-                        });
-                        
-                        // Setup swipe gestures for mobile panels
+                        };
+
+                        document.addEventListener('click', handleBackdropClick);
+
                         let touchStartY = 0;
-                        document.addEventListener('touchstart', (e) => {
-                            try {
-                                if (e.touches && e.touches[0]) {
-                                    touchStartY = e.touches[0].clientY;
-                                }
-                            } catch (touchError) {
-                                console.warn('Touch start error:', touchError);
+                        document.addEventListener('touchstart', (event) => {
+                            if (event.touches && event.touches[0]) {
+                                touchStartY = event.touches[0].clientY;
                             }
                         }, { passive: true });
-                        
-                        document.addEventListener('touchend', (e) => {
-                            try {
-                                if (e.changedTouches && e.changedTouches[0]) {
-                                    const touchEndY = e.changedTouches[0].clientY;
-                                    const diff = touchStartY - touchEndY;
-                                    
-                                    // Swipe up to close panels
-                                    if (diff > 50) {
-                                        const expandedPanels = document.querySelectorAll('.mobile-search-bar.expanded, .mobile-notifications-panel.expanded');
-                                        if (expandedPanels) {
-                                            expandedPanels.forEach(panel => {
-                                                const closeBtn = panel.querySelector('.mobile-search-close, .mobile-notifications-close');
-                                                if (closeBtn) closeBtn.click();
-                                            });
-                                        }
+
+                        document.addEventListener('touchend', (event) => {
+                            if (!event.changedTouches || !event.changedTouches[0]) {
+                                return;
+                            }
+
+                            const touchEndY = event.changedTouches[0].clientY;
+                            const diff = touchStartY - touchEndY;
+
+                            if (diff > 50) {
+                                const expandedPanels = document.querySelectorAll('.mobile-search-bar.expanded, .mobile-notifications-panel.expanded');
+                                expandedPanels.forEach((panel) => {
+                                    const closeBtn = panel.querySelector('.mobile-search-close, .mobile-notifications-close');
+                                    if (closeBtn) {
+                                        closeBtn.click();
                                     }
-                                }
-                            } catch (touchError) {
-                                console.warn('Touch end error:', touchError);
+                                });
                             }
                         }, { passive: true });
                     } catch (setupError) {
@@ -927,5 +859,13 @@
         
         // Add a small delay to ensure navigation is processed
         await Task.Delay(10);
+    }
+
+    public void Dispose()
+    {
+        if (NotificationFeed is not null)
+        {
+            NotificationFeed.UnreadCountChanged -= HandleUnreadCountChanged;
+        }
     }
 }

--- a/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor.css
@@ -1,3 +1,83 @@
+/* Dashboard base styling */
+.nav-link {
+    color: #0e131b;
+    border-radius: 0.75rem;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus-visible {
+    background-color: #e7ecf3;
+    color: #0e131b;
+}
+
+.nav-link-icon,
+.nav-link-icon-graphic,
+.nav-link-text {
+    color: #0e131b;
+    fill: #0e131b;
+}
+
+.nav-link-text {
+    margin: 0;
+}
+
+.dashboard-main-content {
+    padding-top: 70px;
+}
+
+.dashboard-button {
+    position: relative;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.dashboard-button:hover,
+.dashboard-button:focus-visible {
+    background-color: #dce4f2;
+}
+
+.dashboard-button--notifications .notification-badge {
+    top: -0.35rem;
+    right: -0.25rem;
+}
+
+.dashboard-section-title {
+    display: block;
+    visibility: visible;
+}
+
+.dashboard-section-content {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    padding: 1.5rem 1rem;
+}
+
+.dashboard-stat-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.dashboard-chart-grid {
+    display: grid;
+    min-height: 180px;
+}
+
+.dashboard-grid {
+    display: grid;
+}
+
+.priority-button {
+    background-color: #e7ecf3;
+    color: #0e131b;
+    border: none;
+}
+
+.priority-button .priority-label {
+    color: #0e131b;
+}
+
 /* 다크 모드에서 텍스트 색상 수정 */
 [data-theme="dark"] .text-\[#0e131b\] {
     color: #ffffff !important;
@@ -189,144 +269,118 @@
 
 /* 모바일 헤더 기본 스타일 */
 .mobile-header {
-    display: none !important;
+    display: none;
+    visibility: hidden;
+    opacity: 0;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+}
+
+.mobile-notifications-btn {
+    position: relative;
+}
+
+.notification-badge {
+    position: absolute;
+    top: -0.25rem;
+    right: -0.25rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #ef4444;
+    color: #ffffff;
+    font-size: 0.75rem;
+    font-weight: 600;
+    line-height: 1;
+    padding: 0.125rem 0.375rem;
+    border-radius: 999px;
+    min-width: 1.25rem;
+    text-align: center;
+    pointer-events: none;
 }
 
 @media (max-width: 768px) {
     .mobile-header {
-        display: flex !important;
-        position: fixed !important;
-        top: 0 !important;
-        left: 0 !important;
-        right: 0 !important;
-        z-index: 9999 !important;
-        background-color: #ffffff !important;
-        border-bottom: 1px solid #e5e7eb !important;
-        height: 60px !important;
-        width: 100vw !important;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.1) !important;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 9999;
+        background-color: #ffffff;
+        border-bottom: 1px solid #e5e7eb;
+        height: 60px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
     }
-    
-    .mobile-header-content {
-        display: flex !important;
-        align-items: center !important;
-        justify-content: space-between !important;
-        width: 100% !important;
-        padding: 0 1rem !important;
-    }
-    
-    .mobile-menu-toggle,
-    .mobile-action-btn {
-        display: flex !important;
-        align-items: center !important;
-        justify-content: center !important;
-        padding: 0.5rem !important;
-        background: none !important;
-        border: none !important;
-        color: #374151 !important;
-        cursor: pointer !important;
-    }
-    
-    .mobile-header-title {
-        display: flex !important;
-        flex: 1 !important;
-        justify-content: center !important;
-    }
-    
-    .mobile-title {
-        display: block !important;
-        font-size: 1.25rem !important;
-        font-weight: 700 !important;
-        color: #374151 !important;
-        margin: 0 !important;
-    }
-    
-    .mobile-header-actions {
-        display: flex !important;
-        gap: 0.5rem !important;
-        align-items: center !important;
-    }
-    
-    /* 모바일에서 사이드바 숨기기 */
-    .dashboard-sidebar {
-        display: none !important;
-    }
-    
-    /* 모바일에서 메인 컨텐츠 전체 너비 사용 */
-    .dashboard-main-content {
-        width: 100% !important;
-        max-width: 100% !important;
-        padding-top: 70px !important;
-    }
-}
 
-/* 모바일에서 확실히 보이도록 추가 스타일 */
-@media screen and (max-width: 768px) {
-    .mobile-header {
-        display: flex !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        position: fixed !important;
-        top: 0 !important;
-        left: 0 !important;
-        right: 0 !important;
-        z-index: 999999 !important;
-        background: white !important;
-        width: 100% !important;
-        height: 60px !important;
-        border-bottom: 1px solid #e5e7eb !important;
-        box-shadow: 0 2px 8px rgba(0,0,0,0.15) !important;
+    .mobile-header--active {
+        visibility: visible;
+        opacity: 1;
     }
-    
-    .mobile-header * {
-        display: flex !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-    }
-    
+
     .mobile-header-content {
-        width: 100% !important;
-        height: 100% !important;
-        display: flex !important;
-        align-items: center !important;
-        justify-content: space-between !important;
-        padding: 0 16px !important;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+        height: 100%;
+        padding: 0 1rem;
     }
-    
+
+    .mobile-header-title {
+        display: flex;
+        flex: 1;
+        justify-content: center;
+    }
+
     .mobile-title {
-        color: #000000 !important;
-        font-size: 20px !important;
-        font-weight: 700 !important;
-        margin: 0 !important;
-        display: block !important;
+        margin: 0;
+        font-size: 1.25rem;
+        font-weight: 700;
+        color: #374151;
     }
-    
+
     .mobile-menu-toggle,
     .mobile-action-btn {
-        background: none !important;
-        border: none !important;
-        color: #000000 !important;
-        cursor: pointer !important;
-        padding: 8px !important;
-        display: flex !important;
-        align-items: center !important;
-        justify-content: center !important;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.5rem;
+        background: none;
+        border: none;
+        color: #374151;
+        cursor: pointer;
+        transition: color 0.2s ease;
+    }
+
+    .mobile-header-actions {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+    }
+
+    .dashboard-sidebar {
+        display: none;
+    }
+
+    .dashboard-main-content {
+        width: 100%;
+        max-width: 100%;
+        padding-top: 70px;
     }
 }
 
 /* 반응형 다크 모드 지원 */
 @media (max-width: 768px) {
     [data-theme="dark"] .mobile-header {
-        background-color: #1f2937 !important;
-        border-bottom-color: #374151 !important;
+        background-color: #1f2937;
+        border-bottom-color: #374151;
     }
-    
-    [data-theme="dark"] .mobile-header .mobile-title {
-        color: #ffffff !important;
-    }
-    
+
+    [data-theme="dark"] .mobile-header .mobile-title,
     [data-theme="dark"] .mobile-header button {
-        color: #ffffff !important;
+        color: #ffffff;
     }
     
     /* 다크 모드에서 대시보드 카드 버튼 텍스트 */
@@ -452,47 +506,31 @@
     
     /* 모바일에서 대시보드 섹션 표시 */
     .dashboard-grid {
-        display: grid !important;
-        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)) !important;
-        gap: 0.75rem !important;
-        padding: 1rem !important;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 0.75rem;
+        padding: 1rem;
     }
-    
+
     .dashboard-card {
-        display: flex !important;
-        flex-direction: column !important;
-        gap: 0.5rem !important;
-        padding: 0.75rem !important;
-        min-height: auto !important;
+        flex-direction: column;
+        gap: 0.5rem;
+        padding: 0.75rem;
+        min-height: auto;
     }
-    
-    /* 모바일에서 SalesPipelineSummary 섹션 표시 */
-    h2.text-\[#0e131b\] {
-        display: block !important;
-        visibility: visible !important;
-        opacity: 1 !important;
+
+    .dashboard-section-content {
+        gap: 1rem;
+        padding: 1rem;
     }
-    
-    /* 모바일에서 차트와 콘텐츠 영역 표시 */
-    .flex.flex-wrap.gap-4.px-4.py-6 {
-        display: flex !important;
-        flex-wrap: wrap !important;
-        gap: 1rem !important;
-        padding: 1rem !important;
+
+    .dashboard-stat-card {
+        min-width: auto;
+        width: 100%;
+        gap: 0.5rem;
+        padding: 1rem;
     }
-    
-    .flex.min-w-72.flex-1.flex-col.gap-2.rounded-lg.border {
-        display: flex !important;
-        flex-direction: column !important;
-        min-width: auto !important;
-        width: 100% !important;
-        gap: 0.5rem !important;
-        padding: 1rem !important;
-    }
-    
-    /* 모바일에서 그리드 차트 표시 */
-    .grid.min-h-\[180px\] {
-        display: grid !important;
-        min-height: 120px !important;
+
+    .dashboard-chart-grid {
+        min-height: 120px;
     }
 }

--- a/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor
@@ -56,7 +56,8 @@
             <input
                 placeholder='@Localizer["Search"]'
                 class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border-none bg-[#e7ecf3] focus:border-none h-full placeholder:text-[#4d6a99] px-4 rounded-l-none border-l-0 pl-2 text-base font-normal leading-normal"
-                value=""
+                @bind="DealSearchTerm"
+                @bind:event="oninput"
             />
             </div>
         </label>
@@ -102,37 +103,78 @@
                 <input
                 placeholder='@Localizer["SearchDeals"]'
                 class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#0e131b] focus:outline-0 focus:ring-0 border-none bg-[#e7ecf3] focus:border-none h-full placeholder:text-[#4d6a99] px-4 rounded-l-none border-l-0 pl-2 text-base font-normal leading-normal"
-                value=""
+                @bind="DealSearchTerm"
+                @bind:event="oninput"
                 />
             </div>
             </label>
         </div>
-        <div class="flex gap-3 p-3 flex-wrap pr-4">
-            <button class="flex h-8 shrink-0 items-center justify-center gap-x-2 rounded-lg bg-[#e7ecf3] pl-4 pr-2">
-            <p class="text-[#0e131b] text-sm font-medium leading-normal">@Localizer["Owner"]</p>
-            <div class="text-[#0e131b]" data-icon="CaretDown" data-size="20px" data-weight="regular">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
-                <path d="M213.66,101.66l-80,80a8,8,0,0,1-11.32,0l-80-80A8,8,0,0,1,53.66,90.34L128,164.69l74.34-74.35a8,8,0,0,1,11.32,11.32Z"></path>
-                </svg>
+        <div class="flex gap-3 p-3 flex-wrap pr-4 pipeline-filter-row">
+            <div class="pipeline-filter-control">
+                <span class="pipeline-filter-label">@Localizer["Owner"]</span>
+                <div class="pipeline-filter-select-wrapper">
+                    <select id="owner-filter" class="pipeline-filter-select" @bind="SelectedOwner">
+                        <option value="@FilterOwnerAll">@Localizer["FilterOwnerAny"]</option>
+                        @foreach (var owner in ownerOptions)
+                        {
+                            <option value="@owner">@owner</option>
+                        }
+                    </select>
+                </div>
             </div>
-            </button>
-            <button class="flex h-8 shrink-0 items-center justify-center gap-x-2 rounded-lg bg-[#e7ecf3] pl-4 pr-2">
-            <p class="text-[#0e131b] text-sm font-medium leading-normal">@Localizer["TimePeriod"]</p>
-            <div class="text-[#0e131b]" data-icon="CaretDown" data-size="20px" data-weight="regular">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
-                <path d="M213.66,101.66l-80,80a8,8,0,0,1-11.32,0l-80-80A8,8,0,0,1,53.66,90.34L128,164.69l74.34-74.35a8,8,0,0,1,11.32,11.32Z"></path>
-                </svg>
+            <div class="pipeline-filter-control">
+                <span class="pipeline-filter-label">@Localizer["TimePeriod"]</span>
+                <div class="pipeline-filter-select-wrapper">
+                    <select id="time-filter" class="pipeline-filter-select" @bind="SelectedTimePeriod">
+                        <option value="@FilterPeriodAll">@Localizer["FilterTimeAny"]</option>
+                        <option value="@FilterPeriodLast7Days">@Localizer["FilterTimeLast7Days"]</option>
+                        <option value="@FilterPeriodLast30Days">@Localizer["FilterTimeLast30Days"]</option>
+                        <option value="@FilterPeriodQuarterToDate">@Localizer["FilterTimeQuarterToDate"]</option>
+                    </select>
+                </div>
             </div>
-            </button>
-            <button class="flex h-8 shrink-0 items-center justify-center gap-x-2 rounded-lg bg-[#e7ecf3] pl-4 pr-2">
-            <p class="text-[#0e131b] text-sm font-medium leading-normal">@Localizer["Amount"]</p>
-            <div class="text-[#0e131b]" data-icon="CaretDown" data-size="20px" data-weight="regular">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
-                <path d="M213.66,101.66l-80,80a8,8,0,0,1-11.32,0l-80-80A8,8,0,0,1,53.66,90.34L128,164.69l74.34-74.35a8,8,0,0,1,11.32,11.32Z"></path>
-                </svg>
+            <div class="pipeline-filter-control">
+                <span class="pipeline-filter-label">@Localizer["Amount"]</span>
+                <div class="pipeline-filter-select-wrapper">
+                    <select id="amount-filter" class="pipeline-filter-select" @bind="SelectedAmountRange">
+                        <option value="@FilterAmountAll">@Localizer["FilterAmountAny"]</option>
+                        <option value="@FilterAmountUnder25K">@Localizer["FilterAmountUnder25K"]</option>
+                        <option value="@FilterAmount25KTo50K">@Localizer["FilterAmount25KTo50K"]</option>
+                        <option value="@FilterAmountAbove50K">@Localizer["FilterAmountAbove50K"]</option>
+                    </select>
+                </div>
             </div>
-            </button>
         </div>
+
+        @if (isLoading)
+        {
+            <div class="filter-summary filter-summary--muted" aria-live="polite">
+                <span>@Localizer["Loading..."]</span>
+            </div>
+        }
+        else
+        {
+            <div class="filter-summary @(HasActiveFilters ? "filter-summary--active" : string.Empty)" aria-live="polite">
+                <div class="filter-summary__meta">
+                    <span class="filter-summary__count">@string.Format(Localizer["DealsFound"], FilteredDealCount)</span>
+                    @if (HasActiveFilters)
+                    {
+                        <button type="button" class="clear-filters-button" @onclick="ClearFilters">
+                            @Localizer["ClearFilters"]
+                        </button>
+                    }
+                </div>
+                @if (HasActiveFilters)
+                {
+                    <div class="filter-summary__badges">
+                        @foreach (var description in BuildActiveFilterDescriptions())
+                        {
+                            <span class="active-filter-badge">@description</span>
+                        }
+                    </div>
+                }
+            </div>
+        }
         <h2 class="text-[#0e131b] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">@Localizer["PipelineStages"]</h2>
         <div class="px-4 py-3 container">
             <div class="flex overflow-hidden rounded-lg border border-[#d0d9e7] bg-slate-50">
@@ -145,15 +187,21 @@
                 </tr>
                 </thead>
                 <tbody>
-                    @if (dealsByStage == null)
+                    @if (isLoading)
                     {
                         <tr>
                             <td colspan="3"><em>@Localizer["Loading..."]</em></td>
                         </tr>
                     }
+                    else if (groupedDeals.Length == 0)
+                    {
+                        <tr>
+                            <td colspan="3" class="text-center text-[#4d6a99] text-sm font-normal leading-normal">@Localizer["NoDealsMatch"]</td>
+                        </tr>
+                    }
                     else
                     {
-                        @foreach (var stage in dealsByStage)
+                        @foreach (var stage in groupedDeals)
                         {
                             <tr class="border-t border-t-[#d0d9e7]">
                                 <td class="table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-120 h-[72px] px-4 py-2 w-[400px] text-[#0e131b] text-sm font-normal leading-normal">
@@ -182,12 +230,199 @@
 </div>
 
 @code {
-    private IGrouping<string, Deal>[]? dealsByStage;
+    private const string FilterOwnerAll = "all";
+    private const string FilterPeriodAll = "all";
+    private const string FilterPeriodLast7Days = "last7";
+    private const string FilterPeriodLast30Days = "last30";
+    private const string FilterPeriodQuarterToDate = "quarter";
+    private const string FilterAmountAll = "all";
+    private const string FilterAmountUnder25K = "under25";
+    private const string FilterAmount25KTo50K = "25to50";
+    private const string FilterAmountAbove50K = "above50";
 
-    protected override async System.Threading.Tasks.Task OnInitializedAsync()
+    private readonly List<Deal> allDeals = new();
+    private IGrouping<string, Deal>[] groupedDeals = Array.Empty<IGrouping<string, Deal>>();
+    private IReadOnlyList<string> ownerOptions = Array.Empty<string>();
+    private string dealSearchTerm = string.Empty;
+    private string selectedOwner = FilterOwnerAll;
+    private string selectedTimePeriod = FilterPeriodAll;
+    private string selectedAmountRange = FilterAmountAll;
+    private bool isLoading = true;
+
+    private string DealSearchTerm
+    {
+        get => dealSearchTerm;
+        set
+        {
+            if (dealSearchTerm != value)
+            {
+                dealSearchTerm = value;
+                ApplyFilters();
+            }
+        }
+    }
+
+    private string SelectedOwner
+    {
+        get => selectedOwner;
+        set
+        {
+            if (selectedOwner != value)
+            {
+                selectedOwner = value;
+                ApplyFilters();
+            }
+        }
+    }
+
+    private string SelectedTimePeriod
+    {
+        get => selectedTimePeriod;
+        set
+        {
+            if (selectedTimePeriod != value)
+            {
+                selectedTimePeriod = value;
+                ApplyFilters();
+            }
+        }
+    }
+
+    private string SelectedAmountRange
+    {
+        get => selectedAmountRange;
+        set
+        {
+            if (selectedAmountRange != value)
+            {
+                selectedAmountRange = value;
+                ApplyFilters();
+            }
+        }
+    }
+
+    private int FilteredDealCount => groupedDeals.Sum(group => group.Count());
+    private bool HasActiveFilters =>
+        !string.IsNullOrWhiteSpace(DealSearchTerm) ||
+        SelectedOwner != FilterOwnerAll ||
+        SelectedTimePeriod != FilterPeriodAll ||
+        SelectedAmountRange != FilterAmountAll;
+
+    protected override async Task OnInitializedAsync()
     {
         var deals = await DealService.GetDealsAsync();
-        dealsByStage = deals.Where(d => !string.IsNullOrEmpty(d.Stage)).GroupBy(d => d.Stage!).ToArray();
+        allDeals.AddRange(deals.Where(d => !string.IsNullOrWhiteSpace(d.Stage)));
+
+        ownerOptions = allDeals
+            .Select(d => d.Owner)
+            .Where(owner => !string.IsNullOrWhiteSpace(owner))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(owner => owner, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        ApplyFilters();
+        isLoading = false;
+    }
+
+    private void ApplyFilters()
+    {
+        if (allDeals.Count == 0)
+        {
+            groupedDeals = Array.Empty<IGrouping<string, Deal>>();
+            return;
+        }
+
+        IEnumerable<Deal> query = allDeals;
+
+        if (!string.IsNullOrWhiteSpace(DealSearchTerm))
+        {
+            var term = DealSearchTerm.Trim();
+            query = query.Where(deal =>
+                (deal.Name?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (deal.Company?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (deal.ContactPerson?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false));
+        }
+
+        if (SelectedOwner != FilterOwnerAll)
+        {
+            query = query.Where(deal => string.Equals(deal.Owner, SelectedOwner, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (SelectedTimePeriod != FilterPeriodAll)
+        {
+            var today = DateTime.Today;
+            query = SelectedTimePeriod switch
+            {
+                FilterPeriodLast7Days => query.Where(deal => deal.CreatedDate.Date >= today.AddDays(-7)),
+                FilterPeriodLast30Days => query.Where(deal => deal.CreatedDate.Date >= today.AddDays(-30)),
+                FilterPeriodQuarterToDate => query.Where(deal => deal.CreatedDate.Date >= new DateTime(today.Year, ((today.Month - 1) / 3) * 3 + 1, 1)),
+                _ => query
+            };
+        }
+
+        if (SelectedAmountRange != FilterAmountAll)
+        {
+            query = SelectedAmountRange switch
+            {
+                FilterAmountUnder25K => query.Where(deal => deal.Amount < 25000m),
+                FilterAmount25KTo50K => query.Where(deal => deal.Amount >= 25000m && deal.Amount <= 50000m),
+                FilterAmountAbove50K => query.Where(deal => deal.Amount > 50000m),
+                _ => query
+            };
+        }
+
+        groupedDeals = query
+            .Where(deal => !string.IsNullOrWhiteSpace(deal.Stage))
+            .GroupBy(deal => deal.Stage!)
+            .OrderBy(group => group.Key)
+            .ToArray();
+    }
+
+    private IEnumerable<string> BuildActiveFilterDescriptions()
+    {
+        if (!string.IsNullOrWhiteSpace(DealSearchTerm))
+        {
+            yield return $"{Localizer["Search"]}: \"{DealSearchTerm}\"";
+        }
+
+        if (SelectedOwner != FilterOwnerAll)
+        {
+            yield return $"{Localizer["Owner"]}: {SelectedOwner}";
+        }
+
+        if (SelectedTimePeriod != FilterPeriodAll)
+        {
+            var label = SelectedTimePeriod switch
+            {
+                FilterPeriodLast7Days => Localizer["FilterTimeLast7Days"],
+                FilterPeriodLast30Days => Localizer["FilterTimeLast30Days"],
+                FilterPeriodQuarterToDate => Localizer["FilterTimeQuarterToDate"],
+                _ => Localizer["FilterTimeAny"]
+            };
+
+            yield return $"{Localizer["TimePeriod"]}: {label}";
+        }
+
+        if (SelectedAmountRange != FilterAmountAll)
+        {
+            var label = SelectedAmountRange switch
+            {
+                FilterAmountUnder25K => Localizer["FilterAmountUnder25K"],
+                FilterAmount25KTo50K => Localizer["FilterAmount25KTo50K"],
+                FilterAmountAbove50K => Localizer["FilterAmountAbove50K"],
+                _ => Localizer["FilterAmountAny"]
+            };
+
+            yield return $"{Localizer["Amount"]}: {label}";
+        }
+    }
+
+    private void ClearFilters()
+    {
+        DealSearchTerm = string.Empty;
+        SelectedOwner = FilterOwnerAll;
+        SelectedTimePeriod = FilterPeriodAll;
+        SelectedAmountRange = FilterAmountAll;
     }
 
     private async System.Threading.Tasks.Task HandleFloatingAction(string action)

--- a/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor.css
@@ -1,3 +1,138 @@
 @container(max-width:120px){.table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-120{display: none;}}
 @container(max-width:240px){.table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-240{display: none;}}
 @container(max-width:360px){.table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-360{display: none;}}
+
+.pipeline-filter-row {
+    align-items: flex-end;
+}
+
+.pipeline-filter-control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    min-width: 180px;
+}
+
+.pipeline-filter-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #4d6a99;
+}
+
+.pipeline-filter-select-wrapper {
+    position: relative;
+}
+
+.pipeline-filter-select-wrapper::after {
+    content: "";
+    position: absolute;
+    pointer-events: none;
+    top: 50%;
+    right: 1rem;
+    width: 0.5rem;
+    height: 0.5rem;
+    border-right: 2px solid #0e131b;
+    border-bottom: 2px solid #0e131b;
+    transform: translateY(-25%) rotate(45deg);
+}
+
+.pipeline-filter-select {
+    width: 100%;
+    appearance: none;
+    border: 1px solid #d0d9e7;
+    border-radius: 0.75rem;
+    background-color: #e7ecf3;
+    color: #0e131b;
+    font-size: 0.875rem;
+    font-weight: 500;
+    padding: 0.5rem 2.75rem 0.5rem 0.75rem;
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pipeline-filter-select:focus {
+    outline: none;
+    border-color: #6366f1;
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}
+
+.filter-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin: 0 1.5rem 1rem 1.5rem;
+    padding: 0.75rem 1rem;
+    border: 1px solid #d0d9e7;
+    border-radius: 0.75rem;
+    background-color: #f8fafc;
+}
+
+.filter-summary--active {
+    border-color: #6366f1;
+    background-color: #eef2ff;
+}
+
+.filter-summary--muted {
+    color: #4d6a99;
+    font-size: 0.875rem;
+}
+
+.filter-summary__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.filter-summary__count {
+    font-weight: 600;
+    color: #0e131b;
+}
+
+.clear-filters-button {
+    border: none;
+    background: #ffffff;
+    color: #4d6a99;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.clear-filters-button:hover {
+    background: #4d6a99;
+    color: #ffffff;
+}
+
+.filter-summary__badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.active-filter-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.35rem 0.6rem;
+    border-radius: 999px;
+    background: #e7ecf3;
+    color: #0e131b;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+@media (max-width: 768px) {
+    .pipeline-filter-control {
+        min-width: 100%;
+    }
+
+    .filter-summary {
+        margin-inline: 1rem;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/LoginPage.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/LoginPage.en-US.resx
@@ -45,6 +45,9 @@
   <data name="Kakao" xml:space="preserve">
     <value>Continue with Kakao</value>
   </data>
+  <data name="SocialLoginComingSoon" xml:space="preserve">
+    <value>Social logins are coming soon.</value>
+  </data>
   <data name="ShowPassword" xml:space="preserve">
     <value>SHOW</value>
   </data>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/LoginPage.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/LoginPage.ko-KR.resx
@@ -45,6 +45,9 @@
   <data name="Kakao" xml:space="preserve">
     <value>카카오로 시작하기</value>
   </data>
+  <data name="SocialLoginComingSoon" xml:space="preserve">
+    <value>소셜 로그인 연동은 준비 중입니다.</value>
+  </data>
   <data name="ShowPassword" xml:space="preserve">
     <value>보기</value>
   </data>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/MainDashboard.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/MainDashboard.en-US.resx
@@ -145,6 +145,9 @@
   <data name="Notifications" xml:space="preserve">
     <value>Notifications</value>
   </data>
+  <data name="UnreadNotificationsLabel" xml:space="preserve">
+    <value>You have {0} unread notifications.</value>
+  </data>
   <data name="Contacts" xml:space="preserve">
     <value>Contacts</value>
   </data>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/MainDashboard.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/MainDashboard.ko-KR.resx
@@ -145,6 +145,9 @@
   <data name="Notifications" xml:space="preserve">
     <value>알림</value>
   </data>
+  <data name="UnreadNotificationsLabel" xml:space="preserve">
+    <value>읽지 않은 알림이 {0}건 있습니다.</value>
+  </data>
   <data name="Contacts" xml:space="preserve">
     <value>연락처</value>
   </data>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/SalesPipelinePage.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/SalesPipelinePage.en-US.resx
@@ -84,6 +84,42 @@
   <data name="Amount" xml:space="preserve">
     <value>Amount</value>
   </data>
+  <data name="FilterOwnerAny" xml:space="preserve">
+    <value>All owners</value>
+  </data>
+  <data name="FilterTimeAny" xml:space="preserve">
+    <value>Any time</value>
+  </data>
+  <data name="FilterTimeLast7Days" xml:space="preserve">
+    <value>Last 7 days</value>
+  </data>
+  <data name="FilterTimeLast30Days" xml:space="preserve">
+    <value>Last 30 days</value>
+  </data>
+  <data name="FilterTimeQuarterToDate" xml:space="preserve">
+    <value>Quarter to date</value>
+  </data>
+  <data name="FilterAmountAny" xml:space="preserve">
+    <value>Any amount</value>
+  </data>
+  <data name="FilterAmountUnder25K" xml:space="preserve">
+    <value>Under $25K</value>
+  </data>
+  <data name="FilterAmount25KTo50K" xml:space="preserve">
+    <value>$25K - $50K</value>
+  </data>
+  <data name="FilterAmountAbove50K" xml:space="preserve">
+    <value>Above $50K</value>
+  </data>
+  <data name="DealsFound" xml:space="preserve">
+    <value>{0} deals found</value>
+  </data>
+  <data name="ClearFilters" xml:space="preserve">
+    <value>Clear filters</value>
+  </data>
+  <data name="NoDealsMatch" xml:space="preserve">
+    <value>No deals match the current filters.</value>
+  </data>
   <data name="PipelineStages" xml:space="preserve">
     <value>Pipeline Stages</value>
   </data>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/SalesPipelinePage.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/SalesPipelinePage.ko-KR.resx
@@ -84,6 +84,42 @@
   <data name="Amount" xml:space="preserve">
     <value>금액</value>
   </data>
+  <data name="FilterOwnerAny" xml:space="preserve">
+    <value>전체 소유자</value>
+  </data>
+  <data name="FilterTimeAny" xml:space="preserve">
+    <value>전체 기간</value>
+  </data>
+  <data name="FilterTimeLast7Days" xml:space="preserve">
+    <value>최근 7일</value>
+  </data>
+  <data name="FilterTimeLast30Days" xml:space="preserve">
+    <value>최근 30일</value>
+  </data>
+  <data name="FilterTimeQuarterToDate" xml:space="preserve">
+    <value>이번 분기 누계</value>
+  </data>
+  <data name="FilterAmountAny" xml:space="preserve">
+    <value>전체 금액</value>
+  </data>
+  <data name="FilterAmountUnder25K" xml:space="preserve">
+    <value>2만5천 달러 미만</value>
+  </data>
+  <data name="FilterAmount25KTo50K" xml:space="preserve">
+    <value>2만5천~5만 달러</value>
+  </data>
+  <data name="FilterAmountAbove50K" xml:space="preserve">
+    <value>5만 달러 초과</value>
+  </data>
+  <data name="DealsFound" xml:space="preserve">
+    <value>{0}건의 거래가 검색되었습니다.</value>
+  </data>
+  <data name="ClearFilters" xml:space="preserve">
+    <value>필터 초기화</value>
+  </data>
+  <data name="NoDealsMatch" xml:space="preserve">
+    <value>현재 필터와 일치하는 거래가 없습니다.</value>
+  </data>
   <data name="PipelineStages" xml:space="preserve">
     <value>파이프라인 단계</value>
   </data>

--- a/src/Web/NexaCRM.WebClient/Services/Mock/MockDealService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Mock/MockDealService.cs
@@ -1,6 +1,7 @@
+using System;
+using System.Collections.Generic;
 using NexaCRM.WebClient.Models;
 using NexaCRM.WebClient.Services.Interfaces;
-using System.Collections.Generic;
 
 namespace NexaCRM.WebClient.Services.Mock
 {
@@ -10,11 +11,11 @@ namespace NexaCRM.WebClient.Services.Mock
         {
             var deals = new List<Deal>
             {
-                new Deal { Id = 1, Name = "Deal 1", Stage = "Prospecting", Amount = 50000, Company = "Company A", ContactPerson = "John Doe" },
-                new Deal { Id = 2, Name = "Deal 2", Stage = "Qualification", Amount = 30000, Company = "Company B", ContactPerson = "Jane Smith" },
-                new Deal { Id = 3, Name = "Deal 3", Stage = "Proposal", Amount = 20000, Company = "Company C", ContactPerson = "Peter Jones" },
-                new Deal { Id = 4, Name = "Deal 4", Stage = "Negotiation", Amount = 15000, Company = "Company D", ContactPerson = "Mary Johnson" },
-                new Deal { Id = 5, Name = "Deal 5", Stage = "Closed (Won)", Amount = 10000, Company = "Company E", ContactPerson = "David Williams" }
+                new Deal { Id = 1, Name = "Deal 1", Stage = "Prospecting", Amount = 50000, Company = "Company A", ContactPerson = "John Doe", Owner = "Alex Kim", CreatedDate = DateTime.Today.AddDays(-3) },
+                new Deal { Id = 2, Name = "Deal 2", Stage = "Qualification", Amount = 30000, Company = "Company B", ContactPerson = "Jane Smith", Owner = "Alex Kim", CreatedDate = DateTime.Today.AddDays(-18) },
+                new Deal { Id = 3, Name = "Deal 3", Stage = "Proposal", Amount = 20000, Company = "Company C", ContactPerson = "Peter Jones", Owner = "Morgan Lee", CreatedDate = DateTime.Today.AddDays(-33) },
+                new Deal { Id = 4, Name = "Deal 4", Stage = "Negotiation", Amount = 15000, Company = "Company D", ContactPerson = "Mary Johnson", Owner = "Jordan Park", CreatedDate = DateTime.Today.AddDays(-8) },
+                new Deal { Id = 5, Name = "Deal 5", Stage = "Closed (Won)", Amount = 100000, Company = "Company E", ContactPerson = "David Williams", Owner = "Morgan Lee", CreatedDate = DateTime.Today.AddDays(-65) }
             };
             return System.Threading.Tasks.Task.FromResult<IEnumerable<Deal>>(deals);
         }


### PR DESCRIPTION
## Summary
- refactor the mobile dashboard header styles and notifications into reusable CSS-driven components
- connect the sales pipeline search and filter controls to real data and add filter summaries
- disable unavailable social logins and add preview messaging for advanced DB management actions

## Testing
- dotnet build --configuration Release *(fails: command not found)*
- dotnet test ./tests/BlazorWebApp.Tests --configuration Release *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ce003fb688832ca56f6be36dcb8a24