### PR TITLE
feat: add animated loading states to sales pipeline table

### DIFF
--- a/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor
@@ -1,5 +1,6 @@
 @page "/sales-pipeline-page"
 @using Microsoft.Extensions.Localization
+@using System.Linq
 @inject IStringLocalizer<SalesPipelinePage> Localizer
 @using NexaCRM.WebClient.Models
 @using NexaCRM.WebClient.Services.Interfaces
@@ -148,8 +149,10 @@
 
         @if (isLoading)
         {
-            <div class="filter-summary filter-summary--muted" aria-live="polite">
-                <span>@Localizer["Loading..."]</span>
+            <div class="filter-summary filter-summary--loading" aria-live="polite">
+                <span class="visually-hidden">@Localizer["Loading..."]</span>
+                <div class="skeleton skeleton--text skeleton--short"></div>
+                <div class="skeleton skeleton--text skeleton--wide"></div>
             </div>
         }
         else
@@ -178,20 +181,35 @@
         <h2 class="text-[#0e131b] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">@Localizer["PipelineStages"]</h2>
         <div class="px-4 py-3 container">
             <div class="flex overflow-hidden rounded-lg border border-[#d0d9e7] bg-slate-50">
-            <table class="flex-1">
+            <table class="flex-1 pipeline-table">
                 <thead>
                 <tr class="bg-slate-50">
-                    <th class="table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-120 px-4 py-3 text-left text-[#0e131b] w-[400px] text-sm font-medium leading-normal">@Localizer["Stage"]</th>
-                    <th class="table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-240 px-4 py-3 text-left text-[#0e131b] w-[400px] text-sm font-medium leading-normal">@Localizer["Deals"]</th>
-                    <th class="table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-360 px-4 py-3 text-left text-[#0e131b] w-[400px] text-sm font-medium leading-normal">@Localizer["Amount"]</th>
+                    <th class="pipeline-table__header table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-120 px-4 py-3 text-left text-[#0e131b] w-[400px] text-sm font-medium leading-normal">@Localizer["Stage"]</th>
+                    <th class="pipeline-table__header table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-240 px-4 py-3 text-left text-[#0e131b] w-[400px] text-sm font-medium leading-normal">@Localizer["Deals"]</th>
+                    <th class="pipeline-table__header table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-360 px-4 py-3 text-left text-[#0e131b] w-[400px] text-sm font-medium leading-normal">@Localizer["Amount"]</th>
                 </tr>
                 </thead>
-                <tbody>
+                <tbody class="pipeline-table__body">
                     @if (isLoading)
                     {
-                        <tr>
-                            <td colspan="3"><em>@Localizer["Loading..."]</em></td>
-                        </tr>
+                        @foreach (var placeholderIndex in Enumerable.Range(0, 4))
+                        {
+                            <tr class="pipeline-row pipeline-row--skeleton border-t border-t-[#d0d9e7]">
+                                <td class="pipeline-table__cell pipeline-table__cell--stage table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-120 h-[72px] px-4 py-2 w-[400px] text-[#0e131b] text-sm font-normal leading-normal">
+                                    @if (placeholderIndex == 0)
+                                    {
+                                        <span class="visually-hidden">@Localizer["Loading..."]</span>
+                                    }
+                                    <span class="skeleton skeleton--text skeleton--stage"></span>
+                                </td>
+                                <td class="pipeline-table__cell pipeline-table__cell--deals table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-240 h-[72px] px-4 py-2 w-[400px] text-[#4d6a99] text-sm font-normal leading-normal">
+                                    <span class="skeleton skeleton--text skeleton--count"></span>
+                                </td>
+                                <td class="pipeline-table__cell pipeline-table__cell--amount table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-360 h-[72px] px-4 py-2 w-[400px] text-[#4d6a99] text-sm font-normal leading-normal">
+                                    <span class="skeleton skeleton--text skeleton--amount"></span>
+                                </td>
+                            </tr>
+                        }
                     }
                     else if (groupedDeals.Length == 0)
                     {
@@ -203,12 +221,12 @@
                     {
                         @foreach (var stage in groupedDeals)
                         {
-                            <tr class="border-t border-t-[#d0d9e7]">
-                                <td class="table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-120 h-[72px] px-4 py-2 w-[400px] text-[#0e131b] text-sm font-normal leading-normal">
+                            <tr class="pipeline-row pipeline-row--data border-t border-t-[#d0d9e7]">
+                                <td class="pipeline-table__cell pipeline-table__cell--stage table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-120 h-[72px] px-4 py-2 w-[400px] text-[#0e131b] text-sm font-normal leading-normal">
                                 @stage.Key
                                 </td>
-                                <td class="table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-240 h-[72px] px-4 py-2 w-[400px] text-[#4d6a99] text-sm font-normal leading-normal">@stage.Count()</td>
-                                <td class="table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-360 h-[72px] px-4 py-2 w-[400px] text-[#4d6a99] text-sm font-normal leading-normal">@stage.Sum(d => d.Amount).ToString("C")</td>
+                                <td class="pipeline-table__cell pipeline-table__cell--deals table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-240 h-[72px] px-4 py-2 w-[400px] text-[#4d6a99] text-sm font-normal leading-normal">@stage.Count()</td>
+                                <td class="pipeline-table__cell pipeline-table__cell--amount table-95fef262-a922-4bfe-a4c4-b7dc2d92c3ad-column-360 h-[72px] px-4 py-2 w-[400px] text-[#4d6a99] text-sm font-normal leading-normal">@stage.Sum(d => d.Amount).ToString("C")</td>
                             </tr>
                         }
                     }

--- a/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor.css
@@ -127,6 +127,130 @@
     font-weight: 600;
 }
 
+.filter-summary--loading {
+    gap: 0.75rem;
+    color: transparent;
+}
+
+.filter-summary--loading .skeleton {
+    display: block;
+    height: 0.875rem;
+    max-width: 220px;
+}
+
+.filter-summary--loading .skeleton--short {
+    max-width: 140px;
+}
+
+.filter-summary--loading .skeleton--wide {
+    max-width: 260px;
+}
+
+.pipeline-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.pipeline-table__body {
+    background-color: #ffffff;
+}
+
+.pipeline-table__header {
+    position: relative;
+    transition: color 0.2s ease;
+}
+
+.pipeline-table__header:hover {
+    color: #111827;
+}
+
+.pipeline-row {
+    transition: background-color 0.24s ease, box-shadow 0.24s ease, transform 0.24s ease;
+}
+
+.pipeline-row--data {
+    background-color: #ffffff;
+    animation: pipeline-row-enter 0.32s ease both;
+}
+
+.pipeline-row--data:hover,
+.pipeline-row--data:focus-within {
+    background-color: rgba(99, 102, 241, 0.08);
+    transform: translateY(-2px);
+    box-shadow: 0 18px 30px -22px rgba(15, 23, 42, 0.55);
+}
+
+.pipeline-table__cell {
+    position: relative;
+    vertical-align: middle;
+}
+
+.pipeline-row--skeleton .pipeline-table__cell {
+    padding-block: 1.35rem;
+}
+
+.pipeline-row--skeleton .skeleton {
+    display: block;
+}
+
+.pipeline-row--skeleton .skeleton + .skeleton {
+    margin-top: 0.25rem;
+}
+
+.skeleton--text {
+    height: 0.875rem;
+    border-radius: 999px;
+}
+
+.skeleton--short,
+.skeleton--wide,
+.skeleton--stage,
+.skeleton--count,
+.skeleton--amount {
+    display: block;
+}
+
+.skeleton--short {
+    width: 36%;
+}
+
+.skeleton--wide {
+    width: 72%;
+}
+
+.skeleton--stage {
+    width: 68%;
+}
+
+.skeleton--count {
+    width: 48%;
+}
+
+.skeleton--amount {
+    width: 58%;
+}
+
+@keyframes pipeline-row-enter {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .pipeline-row,
+    .pipeline-row--data {
+        animation: none !important;
+        transition: none !important;
+        transform: none !important;
+    }
+}
+
 @media (max-width: 768px) {
     .pipeline-filter-control {
         min-width: 100%;


### PR DESCRIPTION
## Summary
- add localized skeleton loading feedback to the sales pipeline filters and table rows
- animate deal rows on entry and hover to surface data changes more smoothly
- extend page styles with skeleton sizing helpers, row transitions, and reduced-motion safeguards

## Testing
- dotnet build --configuration Release *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68ce0413240c832caeedd5efa6ada256