### PR TITLE
Fix Task type ambiguity on SalesPipelinePage

### DIFF
--- a/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor
@@ -326,7 +326,7 @@
         SelectedTimePeriod != FilterPeriodAll ||
         SelectedAmountRange != FilterAmountAll;
 
-    protected override async Task OnInitializedAsync()
+    protected override async System.Threading.Tasks.Task OnInitializedAsync()
     {
         var deals = await DealService.GetDealsAsync();
         allDeals.AddRange(deals.Where(d => !string.IsNullOrWhiteSpace(d.Stage)));


### PR DESCRIPTION
## Summary
- qualify SalesPipelinePage.OnInitializedAsync to use System.Threading.Tasks.Task and avoid ambiguity with the Task model type

## Testing
- ~/.dotnet/dotnet build --configuration Release
- ~/.dotnet/dotnet test ./tests/BlazorWebApp.Tests --configuration Release

------
https://chatgpt.com/codex/tasks/task_b_68ce0d38d8c4832cb8e7e7e189f5ea8c