### PR TITLE
fix: surface organization team pages in rail

### DIFF
--- a/src/Web/NexaCRM.WebClient/Models/TeamModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/TeamModels.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace NexaCRM.WebClient.Models.Teams;
+
+public class TeamInfo
+{
+    public int Id { get; set; }
+    public string TeamCode { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string ManagerName { get; set; } = string.Empty;
+    public int MemberCount { get; set; }
+    public bool IsActive { get; set; }
+    public DateTime RegisteredAt { get; set; }
+}
+
+public class TeamMemberInfo
+{
+    public int Id { get; set; }
+    public int TeamId { get; set; }
+    public string TeamName { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty;
+    public string EmployeeCode { get; set; } = string.Empty;
+    public string Username { get; set; } = string.Empty;
+    public string FullName { get; set; } = string.Empty;
+    public bool AllowExcelUpload { get; set; }
+    public bool IsActive { get; set; }
+    public DateTime RegisteredAt { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/TeamManagementPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/TeamManagementPage.razor
@@ -1,0 +1,299 @@
+@page "/organization/team-management"
+@attribute [Authorize(Roles = "Manager,Admin")]
+
+@using System
+@using System.ComponentModel.DataAnnotations
+@using System.Linq
+@using NexaCRM.WebClient.Models.Teams
+@using NexaCRM.WebClient.Services.Interfaces
+
+@inject ITeamService TeamService
+
+<ResponsivePage>
+    <div class="team-management-page">
+        <div class="card shadow-sm page-header">
+            <div>
+                <h2 class="mb-1">팀 관리</h2>
+                <p class="text-muted mb-0">조직의 팀 구성과 운영 현황을 한눈에 확인하고 관리할 수 있습니다.</p>
+            </div>
+            <div class="summary-box">
+                <span class="summary-label">TOTAL</span>
+                <span class="summary-value">@_filteredTeams.Count</span>
+            </div>
+        </div>
+
+        <div class="card shadow-sm filter-card">
+            <EditForm Model="_teamFilter" OnValidSubmit="ApplyFilter">
+                <div class="row g-3 align-items-end">
+                    <div class="col-md-4 col-sm-6">
+                        <label class="form-label">사용 여부</label>
+                        <InputSelect class="form-select" @bind-Value="_teamFilter.Usage">
+                            <option value="All">전체</option>
+                            <option value="Active">사용</option>
+                            <option value="Inactive">미사용</option>
+                        </InputSelect>
+                    </div>
+                    <div class="col-md-4 col-sm-6">
+                        <label class="form-label">등록 기간</label>
+                        <InputSelect class="form-select" @bind-Value="_teamFilter.Period">
+                            <option value="All">전체</option>
+                            <option value="1M">1개월 이내</option>
+                            <option value="3M">3개월 이내</option>
+                            <option value="6M">6개월 이내</option>
+                        </InputSelect>
+                    </div>
+                    <div class="col-md-4 col-sm-12 d-flex justify-content-end gap-2">
+                        <button type="submit" class="btn btn-primary">조회</button>
+                        <button type="button" class="btn btn-outline-secondary" @onclick="ResetFilter">초기화</button>
+                    </div>
+                </div>
+            </EditForm>
+        </div>
+
+        <div class="action-bar">
+            <button class="btn btn-success" @onclick="ToggleTeamForm">
+                <i class="bi bi-plus-lg me-1"></i> 팀 등록
+            </button>
+        </div>
+
+        @if (_showTeamForm)
+        {
+            <div class="card shadow-sm new-team-card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <strong>새 팀 등록</strong>
+                    <button class="btn btn-link text-decoration-none" @onclick="ToggleTeamForm">
+                        <i class="bi bi-x-lg"></i>
+                    </button>
+                </div>
+                <div class="card-body">
+                    <EditForm Model="_newTeam" OnValidSubmit="CreateTeamAsync">
+                        <DataAnnotationsValidator />
+                        <ValidationSummary />
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                <label class="form-label">팀명</label>
+                                <InputText class="form-control" @bind-Value="_newTeam.Name" />
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label">팀장</label>
+                                <InputText class="form-control" @bind-Value="_newTeam.ManagerName" />
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label">팀 코드</label>
+                                <InputText class="form-control" @bind-Value="_newTeam.TeamCode" placeholder="자동 생성" />
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label">팀 인원 수</label>
+                                <InputNumber class="form-control" @bind-Value="_newTeam.MemberCount" />
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label">등록일</label>
+                                <InputDate class="form-control" @bind-Value="_newTeam.RegisteredAt" />
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label">사용 여부</label>
+                                <div class="form-check form-switch">
+                                    <input class="form-check-input" type="checkbox" role="switch" id="teamActiveSwitch" @bind="_newTeam.IsActive" />
+                                    <label class="form-check-label" for="teamActiveSwitch">@(_newTeam.IsActive ? "사용" : "미사용")</label>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="text-end mt-4">
+                            <button type="submit" class="btn btn-primary px-4">등록</button>
+                        </div>
+                    </EditForm>
+                </div>
+            </div>
+        }
+
+        <div class="card shadow-sm table-card">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle">
+                    <thead class="table-light">
+                        <tr>
+                            <th scope="col">NO</th>
+                            <th scope="col">팀코드</th>
+                            <th scope="col">팀명</th>
+                            <th scope="col">담당자</th>
+                            <th scope="col">연락 수</th>
+                            <th scope="col" class="text-center">사용 여부</th>
+                            <th scope="col">등록일자</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @if (_filteredTeams.Count == 0)
+                        {
+                            <tr>
+                                <td colspan="7" class="text-center text-muted py-4">표시할 팀이 없습니다.</td>
+                            </tr>
+                        }
+                        else
+                        {
+                            @foreach (var (team, index) in _filteredTeams.Select((t, i) => (t, i + 1)))
+                            {
+                                <tr>
+                                    <td>@index</td>
+                                    <td>@team.TeamCode</td>
+                                    <td class="fw-semibold">@team.Name</td>
+                                    <td>@team.ManagerName</td>
+                                    <td>@team.MemberCount</td>
+                                    <td class="text-center">
+                                        <div class="form-check form-switch justify-content-center d-inline-flex">
+                                            <input class="form-check-input" id="@($"team-active-{team.Id}")" type="checkbox" role="switch" checked="@team.IsActive" @onchange="args => ToggleTeamUsageAsync(team, args)" />
+                                        </div>
+                                    </td>
+                                    <td>@team.RegisteredAt.ToString("yyyy-MM-dd")</td>
+                                </tr>
+                            }
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</ResponsivePage>
+
+@code {
+    private readonly List<TeamInfo> _filteredTeams = new();
+    private List<TeamInfo> _teams = new();
+    private bool _showTeamForm;
+    private TeamFilterModel _teamFilter = new();
+    private TeamCreateModel _newTeam = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadTeamsAsync();
+        _newTeam = new TeamCreateModel();
+        ApplyFilter();
+    }
+
+    private async Task LoadTeamsAsync()
+    {
+        var teams = await TeamService.GetTeamsAsync();
+        _teams = teams
+            .OrderByDescending(t => t.RegisteredAt)
+            .ToList();
+    }
+
+    private void ApplyFilter()
+    {
+        var query = _teams.AsEnumerable();
+
+        if (_teamFilter.Usage == "Active")
+        {
+            query = query.Where(t => t.IsActive);
+        }
+        else if (_teamFilter.Usage == "Inactive")
+        {
+            query = query.Where(t => !t.IsActive);
+        }
+
+        if (TryGetPeriodStart(_teamFilter.Period, out var startDate))
+        {
+            query = query.Where(t => t.RegisteredAt >= startDate);
+        }
+
+        _filteredTeams.Clear();
+        _filteredTeams.AddRange(query.OrderByDescending(t => t.RegisteredAt));
+    }
+
+    private static bool TryGetPeriodStart(string period, out DateTime startDate)
+    {
+        startDate = default;
+        var today = DateTime.Today;
+
+        return period switch
+        {
+            "1M" => Assign(today.AddMonths(-1), out startDate),
+            "3M" => Assign(today.AddMonths(-3), out startDate),
+            "6M" => Assign(today.AddMonths(-6), out startDate),
+            _ => false
+        };
+    }
+
+    private static bool Assign(DateTime value, out DateTime result)
+    {
+        result = value;
+        return true;
+    }
+
+    private void ResetFilter()
+    {
+        _teamFilter = new TeamFilterModel();
+        ApplyFilter();
+    }
+
+    private void ToggleTeamForm()
+    {
+        _showTeamForm = !_showTeamForm;
+        if (_showTeamForm)
+        {
+            _newTeam = new TeamCreateModel();
+        }
+    }
+
+    private async Task CreateTeamAsync()
+    {
+        var team = new TeamInfo
+        {
+            Name = _newTeam.Name,
+            ManagerName = _newTeam.ManagerName,
+            TeamCode = _newTeam.TeamCode,
+            MemberCount = _newTeam.MemberCount,
+            IsActive = _newTeam.IsActive,
+            RegisteredAt = _newTeam.RegisteredAt
+        };
+
+        var created = await TeamService.CreateTeamAsync(team);
+        _teams.Add(created);
+        ApplyFilter();
+        _showTeamForm = false;
+        _newTeam = new TeamCreateModel();
+    }
+
+    private async Task ToggleTeamUsageAsync(TeamInfo team, ChangeEventArgs args)
+    {
+        if (team is null)
+        {
+            return;
+        }
+
+        var value = args.Value is bool boolean
+            ? boolean
+            : bool.TryParse(args.Value?.ToString(), out var parsed) && parsed;
+
+        await TeamService.UpdateTeamStatusAsync(team.Id, value);
+
+        var target = _teams.FirstOrDefault(t => t.Id == team.Id);
+        if (target is not null)
+        {
+            target.IsActive = value;
+        }
+
+        ApplyFilter();
+    }
+
+    private class TeamFilterModel
+    {
+        public string Usage { get; set; } = "All";
+        public string Period { get; set; } = "All";
+    }
+
+    private class TeamCreateModel
+    {
+        [Required(ErrorMessage = "팀명을 입력해 주세요.")]
+        public string Name { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "팀장을 입력해 주세요.")]
+        public string ManagerName { get; set; } = string.Empty;
+
+        [Range(0, 999, ErrorMessage = "팀 인원 수는 0명 이상이어야 합니다.")]
+        public int MemberCount { get; set; }
+
+        public string TeamCode { get; set; } = string.Empty;
+
+        public bool IsActive { get; set; } = true;
+
+        public DateTime RegisteredAt { get; set; } = DateTime.Today;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/TeamManagementPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/TeamManagementPage.razor.css
@@ -1,0 +1,108 @@
+.team-management-page {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.page-header,
+.filter-card,
+.table-card,
+.new-team-card {
+    border: none;
+    border-radius: 1rem;
+}
+
+.page-header {
+    padding: 1.5rem 2rem;
+    background: linear-gradient(135deg, #f9fbff 0%, #f0f4ff 100%);
+    align-items: center;
+}
+
+.page-header h2 {
+    font-weight: 700;
+}
+
+.summary-box {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.25rem;
+    color: #1f3c88;
+}
+
+.summary-label {
+    font-size: 0.85rem;
+    letter-spacing: 0.1em;
+}
+
+.summary-value {
+    font-size: 2rem;
+    font-weight: 700;
+}
+
+.filter-card,
+.new-team-card,
+.table-card {
+    padding: 1.5rem;
+    background-color: #ffffff;
+}
+
+.filter-card label,
+.new-team-card label {
+    font-weight: 600;
+    color: #4a5568;
+}
+
+.filter-card .btn,
+.action-bar .btn {
+    min-width: 6.5rem;
+}
+
+.action-bar {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.new-team-card .card-header {
+    border-bottom: none;
+    background: transparent;
+}
+
+.new-team-card .card-body {
+    padding-top: 0;
+}
+
+.table-card table {
+    margin-bottom: 0;
+}
+
+.table-card thead th {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #4a5568;
+    background-color: #f7f9fc;
+}
+
+.table-card tbody td {
+    vertical-align: middle;
+}
+
+.table-card tbody tr:hover {
+    background-color: #f5f7fb;
+}
+
+@media (max-width: 767.98px) {
+    .page-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1rem;
+    }
+
+    .summary-box {
+        align-items: flex-start;
+    }
+
+    .filter-card .row > div:last-child {
+        justify-content: flex-start !important;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/TeamMemberManagementPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/TeamMemberManagementPage.razor
@@ -1,0 +1,398 @@
+@page "/organization/team-members"
+@attribute [Authorize(Roles = "Manager,Admin")]
+
+@using System
+@using System.ComponentModel.DataAnnotations
+@using System.Linq
+@using NexaCRM.WebClient.Models.Teams
+@using NexaCRM.WebClient.Services.Interfaces
+
+@inject ITeamService TeamService
+
+<ResponsivePage>
+    <div class="team-member-page">
+        <div class="card shadow-sm page-header">
+            <div>
+                <h2 class="mb-1">팀원 관리</h2>
+                <p class="text-muted mb-0">팀원 계정과 권한을 손쉽게 조회하고 설정할 수 있습니다.</p>
+            </div>
+            <div class="summary-box">
+                <span class="summary-label">TOTAL</span>
+                <span class="summary-value">@_filteredMembers.Count</span>
+            </div>
+        </div>
+
+        <div class="card shadow-sm filter-card">
+            <EditForm Model="_memberFilter" OnValidSubmit="ApplyMemberFilter">
+                <div class="row g-3 align-items-end">
+                    <div class="col-lg-3 col-md-4">
+                        <label class="form-label">팀 선택</label>
+                        <InputSelect class="form-select" @bind-Value="_memberFilter.TeamId">
+                            <option value="0">전체</option>
+                            @foreach (var team in _teams)
+                            {
+                                <option value="@team.Id">@team.Name</option>
+                            }
+                        </InputSelect>
+                    </div>
+                    <div class="col-lg-4 col-md-5">
+                        <label class="form-label">상세 검색</label>
+                        <InputText class="form-control" @bind-Value="_memberFilter.Keyword" placeholder="이름, 아이디, 코드 검색" />
+                    </div>
+                    <div class="col-lg-5 col-md-12">
+                        <label class="form-label">조회 기간</label>
+                        <div class="d-flex gap-2 flex-wrap">
+                            @foreach (var preset in _periodPresets)
+                            {
+                                <button type="button" class="btn btn-outline-secondary btn-sm @(IsPeriodSelected(preset.Value) ? "active" : null)" @onclick="() => SetPeriod(preset.Value)">
+                                    @preset.Label
+                                </button>
+                            }
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex justify-content-end gap-2 mt-3">
+                    <button type="submit" class="btn btn-primary">조회</button>
+                    <button type="button" class="btn btn-outline-secondary" @onclick="ResetMemberFilter">초기화</button>
+                </div>
+            </EditForm>
+        </div>
+
+        <div class="action-bar">
+            <button class="btn btn-success" @onclick="ToggleMemberForm">
+                <i class="bi bi-plus-lg me-1"></i> 팀원 등록
+            </button>
+        </div>
+
+        @if (_showMemberForm)
+        {
+            <div class="card shadow-sm new-member-card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <strong>새 팀원 등록</strong>
+                    <button class="btn btn-link text-decoration-none" @onclick="ToggleMemberForm">
+                        <i class="bi bi-x-lg"></i>
+                    </button>
+                </div>
+                <div class="card-body">
+                    <EditForm Model="_newMember" OnValidSubmit="CreateMemberAsync">
+                        <DataAnnotationsValidator />
+                        <ValidationSummary />
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                <label class="form-label">팀</label>
+                                <InputSelect class="form-select" @bind-Value="_newMember.TeamId">
+                                    <option value="">팀을 선택해 주세요</option>
+                                    @foreach (var team in _teams)
+                                    {
+                                        <option value="@team.Id">@team.Name</option>
+                                    }
+                                </InputSelect>
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label">직책</label>
+                                <InputText class="form-control" @bind-Value="_newMember.Role" />
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label">사번/코드</label>
+                                <InputText class="form-control" @bind-Value="_newMember.EmployeeCode" placeholder="자동 생성" />
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label">아이디</label>
+                                <InputText class="form-control" @bind-Value="_newMember.Username" />
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label">이름</label>
+                                <InputText class="form-control" @bind-Value="_newMember.FullName" />
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label">엑셀 업로드 권한</label>
+                                <div class="form-check form-switch">
+                                    <input class="form-check-input" type="checkbox" role="switch" id="memberUploadSwitch" @bind="_newMember.AllowExcelUpload" />
+                                    <label class="form-check-label" for="memberUploadSwitch">@(_newMember.AllowExcelUpload ? "사용" : "미사용")</label>
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label">사용 여부</label>
+                                <div class="form-check form-switch">
+                                    <input class="form-check-input" type="checkbox" role="switch" id="memberActiveSwitch" @bind="_newMember.IsActive" />
+                                    <label class="form-check-label" for="memberActiveSwitch">@(_newMember.IsActive ? "사용" : "미사용")</label>
+                                </div>
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label">등록일</label>
+                                <InputDate class="form-control" @bind-Value="_newMember.RegisteredAt" />
+                            </div>
+                        </div>
+                        <div class="text-end mt-4">
+                            <button type="submit" class="btn btn-primary px-4">등록</button>
+                        </div>
+                    </EditForm>
+                </div>
+            </div>
+        }
+
+        <div class="card shadow-sm table-card">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle">
+                    <thead class="table-light">
+                        <tr>
+                            <th scope="col">NO</th>
+                            <th scope="col">직책</th>
+                            <th scope="col">팀명</th>
+                            <th scope="col">코드</th>
+                            <th scope="col">아이디</th>
+                            <th scope="col">이름</th>
+                            <th scope="col" class="text-center">엑셀 업로드</th>
+                            <th scope="col" class="text-center">사용 여부</th>
+                            <th scope="col">등록일자</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @if (_filteredMembers.Count == 0)
+                        {
+                            <tr>
+                                <td colspan="9" class="text-center text-muted py-4">조건에 맞는 팀원이 없습니다.</td>
+                            </tr>
+                        }
+                        else
+                        {
+                            @foreach (var (member, index) in _filteredMembers.Select((m, i) => (m, i + 1)))
+                            {
+                                <tr>
+                                    <td>@index</td>
+                                    <td>@member.Role</td>
+                                    <td class="fw-semibold">@member.TeamName</td>
+                                    <td>@member.EmployeeCode</td>
+                                    <td>@member.Username</td>
+                                    <td>@member.FullName</td>
+                                    <td class="text-center">
+                                        <div class="form-check form-switch justify-content-center d-inline-flex">
+                                            <input class="form-check-input" id="@($"member-upload-{member.Id}")" type="checkbox" role="switch" checked="@member.AllowExcelUpload" @onchange="args => ToggleUploadAsync(member, args)" />
+                                        </div>
+                                    </td>
+                                    <td class="text-center">
+                                        <div class="form-check form-switch justify-content-center d-inline-flex">
+                                            <input class="form-check-input" id="@($"member-active-{member.Id}")" type="checkbox" role="switch" checked="@member.IsActive" @onchange="args => ToggleMemberUsageAsync(member, args)" />
+                                        </div>
+                                    </td>
+                                    <td>@member.RegisteredAt.ToString("yyyy-MM-dd")</td>
+                                </tr>
+                            }
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</ResponsivePage>
+
+@code {
+    private readonly List<TeamMemberInfo> _filteredMembers = new();
+    private List<TeamInfo> _teams = new();
+    private List<TeamMemberInfo> _members = new();
+    private bool _showMemberForm;
+    private TeamMemberFilterModel _memberFilter = new();
+    private TeamMemberCreateModel _newMember = new();
+
+    private readonly (string Label, string Value)[] _periodPresets =
+    {
+        ("전체", "All"),
+        ("오늘", "Today"),
+        ("7일", "7D"),
+        ("1개월", "1M"),
+        ("3개월", "3M")
+    };
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadDataAsync();
+        _newMember = new TeamMemberCreateModel();
+        ApplyMemberFilter();
+    }
+
+    private async Task LoadDataAsync()
+    {
+        var teams = await TeamService.GetTeamsAsync();
+        _teams = teams.OrderBy(t => t.Name).ToList();
+        var members = await TeamService.GetTeamMembersAsync();
+        _members = members.OrderByDescending(m => m.RegisteredAt).ToList();
+    }
+
+    private void ApplyMemberFilter()
+    {
+        var query = _members.AsEnumerable();
+
+        if (_memberFilter.TeamId > 0)
+        {
+            query = query.Where(m => m.TeamId == _memberFilter.TeamId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(_memberFilter.Keyword))
+        {
+            var keyword = _memberFilter.Keyword.Trim();
+            query = query.Where(m =>
+                (m.FullName?.Contains(keyword, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (m.Username?.Contains(keyword, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (m.EmployeeCode?.Contains(keyword, StringComparison.OrdinalIgnoreCase) ?? false));
+        }
+
+        if (TryGetPeriodStart(_memberFilter.Period, out var startDate))
+        {
+            query = query.Where(m => m.RegisteredAt >= startDate);
+        }
+
+        _filteredMembers.Clear();
+        _filteredMembers.AddRange(query.OrderByDescending(m => m.RegisteredAt));
+    }
+
+    private static bool TryGetPeriodStart(string period, out DateTime startDate)
+    {
+        startDate = default;
+        var today = DateTime.Today;
+
+        return period switch
+        {
+            "Today" => Assign(today, out startDate),
+            "7D" => Assign(today.AddDays(-7), out startDate),
+            "1M" => Assign(today.AddMonths(-1), out startDate),
+            "3M" => Assign(today.AddMonths(-3), out startDate),
+            _ => false
+        };
+    }
+
+    private static bool Assign(DateTime value, out DateTime result)
+    {
+        result = value;
+        return true;
+    }
+
+    private void ResetMemberFilter()
+    {
+        _memberFilter = new TeamMemberFilterModel();
+        ApplyMemberFilter();
+    }
+
+    private void ToggleMemberForm()
+    {
+        _showMemberForm = !_showMemberForm;
+        if (_showMemberForm)
+        {
+            _newMember = new TeamMemberCreateModel();
+        }
+    }
+
+    private void SetPeriod(string value)
+    {
+        _memberFilter.Period = value;
+        ApplyMemberFilter();
+    }
+
+    private bool IsPeriodSelected(string value) => string.Equals(_memberFilter.Period, value, StringComparison.OrdinalIgnoreCase);
+
+    private async Task CreateMemberAsync()
+    {
+        if (_newMember.TeamId is null)
+        {
+            return;
+        }
+
+        var team = _teams.FirstOrDefault(t => t.Id == _newMember.TeamId);
+        if (team is null)
+        {
+            return;
+        }
+
+        var member = new TeamMemberInfo
+        {
+            TeamId = team.Id,
+            TeamName = team.Name,
+            Role = _newMember.Role,
+            EmployeeCode = _newMember.EmployeeCode,
+            Username = _newMember.Username,
+            FullName = _newMember.FullName,
+            AllowExcelUpload = _newMember.AllowExcelUpload,
+            IsActive = _newMember.IsActive,
+            RegisteredAt = _newMember.RegisteredAt
+        };
+
+        var created = await TeamService.CreateTeamMemberAsync(member);
+        _members.Add(created);
+        ApplyMemberFilter();
+        _showMemberForm = false;
+        _newMember = new TeamMemberCreateModel();
+    }
+
+    private async Task ToggleMemberUsageAsync(TeamMemberInfo member, ChangeEventArgs args)
+    {
+        if (member is null)
+        {
+            return;
+        }
+
+        var value = args.Value is bool boolean
+            ? boolean
+            : bool.TryParse(args.Value?.ToString(), out var parsed) && parsed;
+
+        await TeamService.UpdateTeamMemberStatusAsync(member.Id, value);
+
+        var target = _members.FirstOrDefault(m => m.Id == member.Id);
+        if (target is not null)
+        {
+            target.IsActive = value;
+        }
+
+        ApplyMemberFilter();
+    }
+
+    private async Task ToggleUploadAsync(TeamMemberInfo member, ChangeEventArgs args)
+    {
+        if (member is null)
+        {
+            return;
+        }
+
+        var value = args.Value is bool boolean
+            ? boolean
+            : bool.TryParse(args.Value?.ToString(), out var parsed) && parsed;
+
+        await TeamService.UpdateTeamMemberUploadPermissionAsync(member.Id, value);
+
+        var target = _members.FirstOrDefault(m => m.Id == member.Id);
+        if (target is not null)
+        {
+            target.AllowExcelUpload = value;
+        }
+
+        ApplyMemberFilter();
+    }
+
+    private class TeamMemberFilterModel
+    {
+        public int TeamId { get; set; }
+        public string Keyword { get; set; } = string.Empty;
+        public string Period { get; set; } = "All";
+    }
+
+    private class TeamMemberCreateModel
+    {
+        [Required(ErrorMessage = "팀을 선택해 주세요.")]
+        public int? TeamId { get; set; }
+
+        [Required(ErrorMessage = "직책을 입력해 주세요.")]
+        public string Role { get; set; } = string.Empty;
+
+        public string EmployeeCode { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "아이디를 입력해 주세요.")]
+        public string Username { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "이름을 입력해 주세요.")]
+        public string FullName { get; set; } = string.Empty;
+
+        public bool AllowExcelUpload { get; set; } = true;
+
+        public bool IsActive { get; set; } = true;
+
+        public DateTime RegisteredAt { get; set; } = DateTime.Today;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/TeamMemberManagementPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/TeamMemberManagementPage.razor.css
@@ -1,0 +1,115 @@
+.team-member-page {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.page-header,
+.filter-card,
+.table-card,
+.new-member-card {
+    border: none;
+    border-radius: 1rem;
+}
+
+.page-header {
+    padding: 1.5rem 2rem;
+    background: linear-gradient(135deg, #fef6ff 0%, #f0f2ff 100%);
+    align-items: center;
+}
+
+.page-header h2 {
+    font-weight: 700;
+}
+
+.summary-box {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.25rem;
+    color: #5a189a;
+}
+
+.summary-label {
+    font-size: 0.85rem;
+    letter-spacing: 0.1em;
+}
+
+.summary-value {
+    font-size: 2rem;
+    font-weight: 700;
+}
+
+.filter-card,
+.new-member-card,
+.table-card {
+    padding: 1.5rem;
+    background-color: #ffffff;
+}
+
+.filter-card label,
+.new-member-card label {
+    font-weight: 600;
+    color: #4a5568;
+}
+
+.filter-card .btn,
+.action-bar .btn {
+    min-width: 6rem;
+}
+
+.filter-card .btn.active,
+.filter-card .btn:active {
+    color: #ffffff;
+    background-color: #5a189a;
+    border-color: #5a189a;
+}
+
+.action-bar {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.new-member-card .card-header {
+    border-bottom: none;
+    background: transparent;
+}
+
+.new-member-card .card-body {
+    padding-top: 0;
+}
+
+.table-card table {
+    margin-bottom: 0;
+}
+
+.table-card thead th {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #4a5568;
+    background-color: #f7f9fc;
+}
+
+.table-card tbody td {
+    vertical-align: middle;
+}
+
+.table-card tbody tr:hover {
+    background-color: #f6f0ff;
+}
+
+@media (max-width: 767.98px) {
+    .page-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1rem;
+    }
+
+    .summary-box {
+        align-items: flex-start;
+    }
+
+    .filter-card .row > div:last-child {
+        margin-top: 0.5rem;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Program.cs
+++ b/src/Web/NexaCRM.WebClient/Program.cs
@@ -56,6 +56,7 @@ builder.Services.AddScoped<IUserFavoritesService, UserFavoritesService>();
 builder.Services.AddScoped<IEmailTemplateService, MockEmailTemplateService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddScoped<INotificationFeedService, MockNotificationFeedService>();
+builder.Services.AddScoped<ITeamService, MockTeamService>();
 
 var culture = new CultureInfo("ko-KR");
 CultureInfo.DefaultThreadCurrentCulture = culture;

--- a/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.en-US.resx
@@ -114,6 +114,12 @@
   <data name="OrganizationStructure" xml:space="preserve">
     <value>Organization Structure</value>
   </data>
+  <data name="TeamManagement" xml:space="preserve">
+    <value>Team Management</value>
+  </data>
+  <data name="TeamMemberManagement" xml:space="preserve">
+    <value>Team Member Management</value>
+  </data>
   <data name="PersonalInfo" xml:space="preserve">
     <value>Personal Information</value>
   </data>

--- a/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.ko-KR.resx
@@ -114,6 +114,12 @@
   <data name="OrganizationStructure" xml:space="preserve">
     <value>조직 구조</value>
   </data>
+  <data name="TeamManagement" xml:space="preserve">
+    <value>팀 관리</value>
+  </data>
+  <data name="TeamMemberManagement" xml:space="preserve">
+    <value>팀원 관리</value>
+  </data>
   <data name="PersonalInfo" xml:space="preserve">
     <value>개인 정보</value>
   </data>

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/ITeamService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/ITeamService.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NexaCRM.WebClient.Models.Teams;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+public interface ITeamService
+{
+    Task<IReadOnlyList<TeamInfo>> GetTeamsAsync();
+    Task<IReadOnlyList<TeamMemberInfo>> GetTeamMembersAsync();
+    Task<TeamInfo> CreateTeamAsync(TeamInfo team);
+    Task<TeamMemberInfo> CreateTeamMemberAsync(TeamMemberInfo member);
+    Task UpdateTeamStatusAsync(int teamId, bool isActive);
+    Task UpdateTeamMemberStatusAsync(int memberId, bool isActive);
+    Task UpdateTeamMemberUploadPermissionAsync(int memberId, bool allow);
+}

--- a/src/Web/NexaCRM.WebClient/Services/Mock/MockTeamService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Mock/MockTeamService.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NexaCRM.WebClient.Models.Teams;
+using NexaCRM.WebClient.Services.Interfaces;
+
+namespace NexaCRM.WebClient.Services.Mock;
+
+public class MockTeamService : ITeamService
+{
+    private readonly List<TeamInfo> _teams = new()
+    {
+        new TeamInfo
+        {
+            Id = 1,
+            TeamCode = "TM0001",
+            Name = "SKY지점",
+            ManagerName = "김태영",
+            MemberCount = 8,
+            IsActive = true,
+            RegisteredAt = DateTime.Today.AddDays(-15)
+        },
+        new TeamInfo
+        {
+            Id = 2,
+            TeamCode = "TM0002",
+            Name = "프라임지점",
+            ManagerName = "이하늘",
+            MemberCount = 5,
+            IsActive = true,
+            RegisteredAt = DateTime.Today.AddDays(-30)
+        },
+        new TeamInfo
+        {
+            Id = 3,
+            TeamCode = "TM0003",
+            Name = "직영",
+            ManagerName = "박지원",
+            MemberCount = 3,
+            IsActive = false,
+            RegisteredAt = DateTime.Today.AddMonths(-2)
+        }
+    };
+
+    private readonly List<TeamMemberInfo> _members = new()
+    {
+        new TeamMemberInfo
+        {
+            Id = 1,
+            TeamId = 1,
+            TeamName = "SKY지점",
+            Role = "직책",
+            EmployeeCode = "FM0017",
+            Username = "fineeee",
+            FullName = "이현정",
+            AllowExcelUpload = true,
+            IsActive = true,
+            RegisteredAt = DateTime.Today.AddDays(-5)
+        },
+        new TeamMemberInfo
+        {
+            Id = 2,
+            TeamId = 2,
+            TeamName = "프라임지점",
+            Role = "직책",
+            EmployeeCode = "FC0005",
+            Username = "abc2",
+            FullName = "이상현",
+            AllowExcelUpload = true,
+            IsActive = true,
+            RegisteredAt = DateTime.Today.AddDays(-12)
+        },
+        new TeamMemberInfo
+        {
+            Id = 3,
+            TeamId = 3,
+            TeamName = "직영",
+            Role = "직책",
+            EmployeeCode = "FM0001",
+            Username = "abcd",
+            FullName = "차은우",
+            AllowExcelUpload = false,
+            IsActive = false,
+            RegisteredAt = DateTime.Today.AddMonths(-1)
+        }
+    };
+
+    public Task<IReadOnlyList<TeamInfo>> GetTeamsAsync() =>
+        Task.FromResult<IReadOnlyList<TeamInfo>>(_teams.Select(CloneTeam).ToList());
+
+    public Task<IReadOnlyList<TeamMemberInfo>> GetTeamMembersAsync() =>
+        Task.FromResult<IReadOnlyList<TeamMemberInfo>>(_members.Select(CloneMember).ToList());
+
+    public Task<TeamInfo> CreateTeamAsync(TeamInfo team)
+    {
+        ArgumentNullException.ThrowIfNull(team);
+
+        var newTeam = new TeamInfo
+        {
+            Id = GenerateTeamId(),
+            TeamCode = string.IsNullOrWhiteSpace(team.TeamCode) ? GenerateTeamCode() : team.TeamCode,
+            Name = team.Name,
+            ManagerName = team.ManagerName,
+            MemberCount = team.MemberCount,
+            IsActive = team.IsActive,
+            RegisteredAt = team.RegisteredAt == default ? DateTime.Today : team.RegisteredAt
+        };
+
+        _teams.Add(newTeam);
+        return Task.FromResult(CloneTeam(newTeam));
+    }
+
+    public Task<TeamMemberInfo> CreateTeamMemberAsync(TeamMemberInfo member)
+    {
+        ArgumentNullException.ThrowIfNull(member);
+
+        var team = _teams.FirstOrDefault(t => t.Id == member.TeamId) ??
+                   _teams.FirstOrDefault(t => string.Equals(t.Name, member.TeamName, StringComparison.OrdinalIgnoreCase));
+
+        if (team is null)
+        {
+            throw new InvalidOperationException("Team not found for the provided member.");
+        }
+
+        var newMember = new TeamMemberInfo
+        {
+            Id = GenerateMemberId(),
+            TeamId = team.Id,
+            TeamName = team.Name,
+            Role = member.Role,
+            EmployeeCode = string.IsNullOrWhiteSpace(member.EmployeeCode) ? GenerateMemberCode() : member.EmployeeCode,
+            Username = member.Username,
+            FullName = member.FullName,
+            AllowExcelUpload = member.AllowExcelUpload,
+            IsActive = member.IsActive,
+            RegisteredAt = member.RegisteredAt == default ? DateTime.Today : member.RegisteredAt
+        };
+
+        _members.Add(newMember);
+        return Task.FromResult(CloneMember(newMember));
+    }
+
+    public Task UpdateTeamStatusAsync(int teamId, bool isActive)
+    {
+        var team = _teams.FirstOrDefault(t => t.Id == teamId);
+        if (team is not null)
+        {
+            team.IsActive = isActive;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateTeamMemberStatusAsync(int memberId, bool isActive)
+    {
+        var member = _members.FirstOrDefault(m => m.Id == memberId);
+        if (member is not null)
+        {
+            member.IsActive = isActive;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateTeamMemberUploadPermissionAsync(int memberId, bool allow)
+    {
+        var member = _members.FirstOrDefault(m => m.Id == memberId);
+        if (member is not null)
+        {
+            member.AllowExcelUpload = allow;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static TeamInfo CloneTeam(TeamInfo source) => new()
+    {
+        Id = source.Id,
+        TeamCode = source.TeamCode,
+        Name = source.Name,
+        ManagerName = source.ManagerName,
+        MemberCount = source.MemberCount,
+        IsActive = source.IsActive,
+        RegisteredAt = source.RegisteredAt
+    };
+
+    private static TeamMemberInfo CloneMember(TeamMemberInfo source) => new()
+    {
+        Id = source.Id,
+        TeamId = source.TeamId,
+        TeamName = source.TeamName,
+        Role = source.Role,
+        EmployeeCode = source.EmployeeCode,
+        Username = source.Username,
+        FullName = source.FullName,
+        AllowExcelUpload = source.AllowExcelUpload,
+        IsActive = source.IsActive,
+        RegisteredAt = source.RegisteredAt
+    };
+
+    private int GenerateTeamId() => _teams.Count == 0 ? 1 : _teams.Max(t => t.Id) + 1;
+
+    private string GenerateTeamCode()
+    {
+        var next = _teams.Count == 0 ? 1 : _teams.Max(t => ParseSuffix(t.TeamCode)) + 1;
+        return $"TM{next:0000}";
+    }
+
+    private int GenerateMemberId() => _members.Count == 0 ? 1 : _members.Max(m => m.Id) + 1;
+
+    private string GenerateMemberCode()
+    {
+        var next = _members.Count == 0 ? 1 : _members.Max(m => ParseSuffix(m.EmployeeCode)) + 1;
+        return $"FM{next:0000}";
+    }
+
+    private static int ParseSuffix(string code)
+    {
+        if (string.IsNullOrWhiteSpace(code) || code.Length <= 2)
+        {
+            return 0;
+        }
+
+        return int.TryParse(code.AsSpan(2), out var value) ? value : 0;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor
@@ -124,6 +124,16 @@
                                         </NavLink>
                                     </RoleBasedComponent>
                                     <RoleBasedComponent RequiredRoles="Manager,Admin">
+                                        <NavLink class="nav-link submenu-link" href="organization/team-management" @onclick="CloseNavMenu">
+                                            <i class="bi bi-people-fill" aria-hidden="true"></i> @Localizer["TeamManagement"]
+                                        </NavLink>
+                                    </RoleBasedComponent>
+                                    <RoleBasedComponent RequiredRoles="Manager,Admin">
+                                        <NavLink class="nav-link submenu-link" href="organization/team-members" @onclick="CloseNavMenu">
+                                            <i class="bi bi-person-badge" aria-hidden="true"></i> @Localizer["TeamMemberManagement"]
+                                        </NavLink>
+                                    </RoleBasedComponent>
+                                    <RoleBasedComponent RequiredRoles="Manager,Admin">
                                         <NavLink class="nav-link submenu-link" href="user-registration-page" @onclick="CloseNavMenu">
                                             <i class="bi bi-person-plus" aria-hidden="true"></i> @Localizer["UserManagement"]
                                         </NavLink>

--- a/src/Web/NexaCRM.WebClient/Shared/NavigationRail.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/NavigationRail.razor
@@ -210,6 +210,12 @@
                     <NavLink class="nav-link panel-item" href="organization/structure" @onclick="CloseMenuOnNavigate"><span>@Localizer["OrganizationStructure"]</span></NavLink>
                 </RoleBasedComponent>
                 <RoleBasedComponent RequiredRoles="Manager,Admin">
+                    <NavLink class="nav-link panel-item" href="organization/team-management" @onclick="CloseMenuOnNavigate"><span>@Localizer["TeamManagement"]</span></NavLink>
+                </RoleBasedComponent>
+                <RoleBasedComponent RequiredRoles="Manager,Admin">
+                    <NavLink class="nav-link panel-item" href="organization/team-members" @onclick="CloseMenuOnNavigate"><span>@Localizer["TeamMemberManagement"]</span></NavLink>
+                </RoleBasedComponent>
+                <RoleBasedComponent RequiredRoles="Manager,Admin">
                     <NavLink class="nav-link panel-item" href="user-registration-page" @onclick="CloseMenuOnNavigate"><span>@Localizer["UserManagement"]</span></NavLink>
                 </RoleBasedComponent>
                 <RoleBasedComponent RequiredRoles="Manager,Admin">


### PR DESCRIPTION
## Summary
- add the new team management links under the organization section of the navigation rail so they are accessible from both menu styles

## Testing
- `dotnet build --configuration Release` *(fails: command not found: dotnet)*
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_68d2a5e407f8832cb0b34e0e63ad6d53