### PR TITLE
feat: add schedule send history view

### DIFF
--- a/src/Web/NexaCRM.WebClient/Models/SmsModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/SmsModels.cs
@@ -8,7 +8,20 @@ public record BulkSmsRequest(IList<string> Recipients, string Message)
     public BulkSmsRequest() : this(new List<string>(), string.Empty) { }
 }
 
-public record SmsHistoryItem(string Recipient, string Message, DateTime SentAt, string Status);
+public record SmsAttachment(string FileName, long FileSizeBytes, string ContentType);
+
+public record SmsHistoryItem(
+    string Recipient,
+    string Message,
+    DateTime SentAt,
+    string Status,
+    string SenderNumber = "",
+    string RecipientName = "",
+    IReadOnlyList<SmsAttachment>? Attachments = null)
+{
+    public bool HasAttachments => Attachments is { Count: > 0 };
+    public int AttachmentCount => Attachments?.Count ?? 0;
+}
 
 public record SmsScheduleItem(Guid Id, DateTime ScheduledAt, BulkSmsRequest Request, bool IsCancelled = false)
 {

--- a/src/Web/NexaCRM.WebClient/Pages/SmsSentHistoryPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SmsSentHistoryPage.razor
@@ -1,0 +1,420 @@
+@page "/schedule/sent-history"
+@using System.Globalization
+@using System.Linq
+@using NexaCRM.WebClient.Models.Sms
+@using NexaCRM.WebClient.Services.Interfaces
+@inject ISmsService SmsService
+@inject Microsoft.Extensions.Localization.IStringLocalizer<SmsSentHistoryPage> Localizer
+
+<ResponsivePage>
+    <section class="sms-sent-history">
+        <header class="sent-history-header">
+            <div class="header-titles">
+                <h3>@Localizer["Title"]</h3>
+                <p>@Localizer["Subtitle"]</p>
+            </div>
+            <button type="button"
+                    class="btn btn-outline-secondary refresh-button"
+                    disabled="@_isLoading"
+                    @onclick="RefreshAsync">
+                <i class="bi bi-arrow-clockwise" aria-hidden="true"></i>
+                <span class="ms-2">@Localizer["Refresh"]</span>
+            </button>
+        </header>
+
+        @{
+            var filteredItems = GetFilteredHistory().ToList();
+            var pagedItems = filteredItems
+                .Skip((_currentPage - 1) * PageSize)
+                .Take(PageSize)
+                .ToList();
+            var totalPages = Math.Max(1, (int)Math.Ceiling(filteredItems.Count / (double)PageSize));
+            var startIndex = (_currentPage - 1) * PageSize;
+            var filteredWithAttachments = filteredItems.Count(item => item.HasAttachments);
+            var filteredAttachmentFiles = filteredItems.Sum(item => item.AttachmentCount);
+            var attachmentRatio = filteredItems.Count > 0
+                ? Math.Round(filteredWithAttachments * 100.0 / filteredItems.Count)
+                : 0;
+        }
+
+        <div class="summary-grid">
+            <div class="summary-card">
+                <div class="summary-label">@Localizer["SummaryTotalMessages"]</div>
+                <div class="summary-value">@filteredItems.Count</div>
+                <div class="summary-meta">@RangeDescriptionText</div>
+            </div>
+            <div class="summary-card">
+                <div class="summary-label">@Localizer["SummaryWithAttachments"]</div>
+                <div class="summary-value">@filteredWithAttachments</div>
+                <div class="summary-meta">@Localizer["SummaryAttachmentRatio", attachmentRatio]</div>
+            </div>
+            <div class="summary-card">
+                <div class="summary-label">@Localizer["SummaryAttachmentFiles"]</div>
+                <div class="summary-value">@filteredAttachmentFiles</div>
+                <div class="summary-meta">@Localizer["SummaryAttachmentFilesMeta"]</div>
+            </div>
+        </div>
+
+        <div class="card filter-card">
+            <div class="card-body">
+                <div class="filter-grid">
+                    <div class="filter-group">
+                        <label class="form-label">@Localizer["FilterDateRange"]</label>
+                        <div class="filter-dates">
+                            <input type="date" class="form-control" @bind="_startDate" @bind:after="OnFilterChanged" />
+                            <span class="filter-separator">~</span>
+                            <input type="date" class="form-control" @bind="_endDate" @bind:after="OnFilterChanged" />
+                        </div>
+                    </div>
+                    <div class="filter-group">
+                        <label class="form-label">@Localizer["FilterQuickSelect"]</label>
+                        <div class="quick-buttons">
+                            <button type="button" class="btn btn-outline-secondary" @onclick="() => ApplyQuickRange(0)">@Localizer["QuickRangeToday"]</button>
+                            <button type="button" class="btn btn-outline-secondary" @onclick="() => ApplyQuickRange(7)">@Localizer["QuickRange7Days"]</button>
+                            <button type="button" class="btn btn-outline-secondary" @onclick="() => ApplyQuickRange(30)">@Localizer["QuickRange30Days"]</button>
+                            <button type="button" class="btn btn-link ms-2 p-0" @onclick="ClearDateRange">@Localizer["QuickRangeClear"]</button>
+                        </div>
+                    </div>
+                    <div class="filter-group">
+                        <label class="form-label">@Localizer["FilterSearch"]</label>
+                        <input class="form-control"
+                               placeholder="@Localizer["FilterSearchPlaceholder"]"
+                               @bind="_searchTerm"
+                               @bind:event="oninput"
+                               @bind:after="OnFilterChanged" />
+                    </div>
+                    <div class="filter-group">
+                        <label class="form-label">@Localizer["FilterStatus"]</label>
+                        <select class="form-select" @bind="_status" @bind:after="OnFilterChanged">
+                            <option value="">@Localizer["FilterStatusAll"]</option>
+                            <option value="Sent">@Localizer["FilterStatusSent"]</option>
+                            <option value="Failed">@Localizer["FilterStatusFailed"]</option>
+                            <option value="Scheduled">@Localizer["FilterStatusScheduled"]</option>
+                        </select>
+                    </div>
+                    <div class="filter-group">
+                        <label class="form-label">@Localizer["FilterAttachment"]</label>
+                        <select class="form-select" @bind="_attachmentFilter" @bind:after="OnFilterChanged">
+                            <option value="all">@Localizer["FilterAttachmentAll"]</option>
+                            <option value="with">@Localizer["FilterAttachmentWith"]</option>
+                            <option value="without">@Localizer["FilterAttachmentWithout"]</option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        @if (_isLoading)
+        {
+            <div class="loading-state">
+                <div class="spinner-border text-secondary" role="status" aria-hidden="true"></div>
+                <span class="ms-2">@Localizer["Loading"]</span>
+            </div>
+        }
+        else if (!filteredItems.Any())
+        {
+            <div class="empty-state" role="status">
+                <i class="bi bi-inbox" aria-hidden="true"></i>
+                <p class="mb-0">@Localizer["NoData"]</p>
+            </div>
+        }
+        else
+        {
+            <div class="table-responsive sent-history-table-wrapper">
+                <table class="table table-hover align-middle sent-history-table">
+                    <thead>
+                        <tr>
+                            <th scope="col">@Localizer["TableNo"]</th>
+                            <th scope="col">@Localizer["TableRecipient"]</th>
+                            <th scope="col">@Localizer["TableSender"]</th>
+                            <th scope="col">@Localizer["TableRecipientName"]</th>
+                            <th scope="col" class="message-column">@Localizer["TableMessage"]</th>
+                            <th scope="col">@Localizer["TableAttachments"]</th>
+                            <th scope="col">@Localizer["TableStatus"]</th>
+                            <th scope="col">@Localizer["TableSentAt"]</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var entry in pagedItems.Select((item, index) => new { item, index }))
+                        {
+                            <tr>
+                                <td>@(startIndex + entry.index + 1)</td>
+                                <td>
+                                    <div class="text-truncate" title="@entry.item.Recipient">@entry.item.Recipient</div>
+                                </td>
+                                <td>
+                                    <div class="text-truncate" title="@entry.item.SenderNumber">@entry.item.SenderNumber</div>
+                                </td>
+                                <td>
+                                    <div class="text-truncate" title="@FormatName(entry.item.RecipientName)">@FormatName(entry.item.RecipientName)</div>
+                                </td>
+                                <td class="message-column">
+                                    <div class="message-preview" title="@entry.item.Message">@entry.item.Message</div>
+                                </td>
+                                <td>
+                                    @if (entry.item.HasAttachments)
+                                    {
+                                        <details class="attachment-details">
+                                            <summary>
+                                                <span class="badge bg-primary rounded-pill">@entry.item.AttachmentCount</span>
+                                                <span class="ms-2">@Localizer["AttachmentSummary", entry.item.AttachmentCount]</span>
+                                            </summary>
+                                            <ul class="attachment-list">
+                                                @foreach (var attachment in entry.item.Attachments ?? Enumerable.Empty<SmsAttachment>())
+                                                {
+                                                    <li>
+                                                        <i class="bi bi-paperclip" aria-hidden="true"></i>
+                                                        <span class="attachment-name">@attachment.FileName</span>
+                                                        <span class="attachment-size">@FormatFileSize(attachment.FileSizeBytes)</span>
+                                                    </li>
+                                                }
+                                            </ul>
+                                        </details>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-muted">@Localizer["AttachmentNone"]</span>
+                                    }
+                                </td>
+                                <td>
+                                    <span class="status-pill @GetStatusClass(entry.item.Status)">@FormatStatus(entry.item.Status)</span>
+                                </td>
+                                <td>
+                                    <time datetime="@entry.item.SentAt.ToString("O")">@FormatSentAt(entry.item.SentAt)</time>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="sent-history-pagination">
+                <button type="button" class="btn btn-outline-primary" @onclick="PrevPage" disabled="@(_currentPage == 1)">
+                    @Localizer["PaginationPrevious"]
+                </button>
+                <span class="pagination-info">@Localizer["PaginationInfo", _currentPage, totalPages, filteredItems.Count]</span>
+                <button type="button" class="btn btn-outline-primary" @onclick="NextPage" disabled="@(_currentPage >= totalPages)">
+                    @Localizer["PaginationNext"]
+                </button>
+            </div>
+        }
+    </section>
+</ResponsivePage>
+
+@code {
+    private List<SmsHistoryItem> _history = new();
+    private bool _isLoading = true;
+    private DateTime? _startDate;
+    private DateTime? _endDate;
+    private string _searchTerm = string.Empty;
+    private string _status = string.Empty;
+    private string _attachmentFilter = "all";
+    private int _currentPage = 1;
+    private const int PageSize = 10;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadHistoryAsync();
+        if (!_startDate.HasValue && !_endDate.HasValue)
+        {
+            _endDate = DateTime.Today;
+            _startDate = DateTime.Today.AddDays(-30);
+        }
+    }
+
+    private async Task LoadHistoryAsync()
+    {
+        _isLoading = true;
+        var items = await SmsService.GetHistoryAsync();
+        _history = items.OrderByDescending(item => item.SentAt).ToList();
+        _isLoading = false;
+        ResetPagination();
+    }
+
+    private async Task RefreshAsync()
+    {
+        await LoadHistoryAsync();
+    }
+
+    private IEnumerable<SmsHistoryItem> GetFilteredHistory()
+    {
+        return _history.Where(item =>
+        {
+            var localDate = item.SentAt.ToLocalTime().Date;
+            if (_startDate.HasValue && localDate < _startDate.Value.Date)
+            {
+                return false;
+            }
+
+            if (_endDate.HasValue && localDate > _endDate.Value.Date)
+            {
+                return false;
+            }
+
+            if (!string.IsNullOrWhiteSpace(_status) && !string.Equals(item.Status, _status, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (!AttachmentMatches(item))
+            {
+                return false;
+            }
+
+            if (!MatchesSearch(item, _searchTerm))
+            {
+                return false;
+            }
+
+            return true;
+        });
+    }
+
+    private int TotalPages => Math.Max(1, (int)Math.Ceiling(GetFilteredHistory().Count() / (double)PageSize));
+
+    private void PrevPage()
+    {
+        if (_currentPage > 1)
+        {
+            _currentPage--;
+        }
+    }
+
+    private void NextPage()
+    {
+        var totalPages = TotalPages;
+        if (_currentPage < totalPages)
+        {
+            _currentPage++;
+        }
+    }
+
+    private void ApplyQuickRange(int days)
+    {
+        if (days <= 0)
+        {
+            _startDate = DateTime.Today;
+            _endDate = DateTime.Today;
+        }
+        else
+        {
+            _endDate = DateTime.Today;
+            _startDate = DateTime.Today.AddDays(-(days - 1));
+        }
+
+        ResetPagination();
+    }
+
+    private void ClearDateRange()
+    {
+        _startDate = null;
+        _endDate = null;
+        ResetPagination();
+    }
+
+    private void OnFilterChanged()
+    {
+        NormalizeRange();
+        ResetPagination();
+    }
+
+    private void ResetPagination()
+    {
+        _currentPage = 1;
+    }
+
+    private void NormalizeRange()
+    {
+        if (_startDate.HasValue && _endDate.HasValue && _startDate > _endDate)
+        {
+            (_startDate, _endDate) = (_endDate, _startDate);
+        }
+    }
+
+    private bool AttachmentMatches(SmsHistoryItem item) => _attachmentFilter switch
+    {
+        "with" => item.HasAttachments,
+        "without" => !item.HasAttachments,
+        _ => true
+    };
+
+    private static bool MatchesSearch(SmsHistoryItem item, string term)
+    {
+        if (string.IsNullOrWhiteSpace(term))
+        {
+            return true;
+        }
+
+        var comparison = StringComparison.OrdinalIgnoreCase;
+        return item.Recipient.Contains(term, comparison)
+            || item.Message.Contains(term, comparison)
+            || item.SenderNumber.Contains(term, comparison)
+            || (!string.IsNullOrWhiteSpace(item.RecipientName) && item.RecipientName.Contains(term, comparison));
+    }
+
+    private string FormatStatus(string status) => status switch
+    {
+        "Sent" => Localizer["StatusSent"],
+        "Failed" => Localizer["StatusFailed"],
+        "Scheduled" => Localizer["StatusScheduled"],
+        _ => status
+    };
+
+    private static string GetStatusClass(string status) => status switch
+    {
+        "Failed" => "status-failed",
+        "Scheduled" => "status-scheduled",
+        _ => "status-sent"
+    };
+
+    private static string FormatFileSize(long bytes)
+    {
+        if (bytes <= 0)
+        {
+            return "0 B";
+        }
+
+        string[] units = { "B", "KB", "MB", "GB", "TB" };
+        double size = bytes;
+        var unitIndex = 0;
+
+        while (size >= 1024 && unitIndex < units.Length - 1)
+        {
+            size /= 1024;
+            unitIndex++;
+        }
+
+        return string.Format(CultureInfo.CurrentCulture, "{0:0.##} {1}", size, units[unitIndex]);
+    }
+
+    private string FormatName(string name) => string.IsNullOrWhiteSpace(name)
+        ? Localizer["UnknownRecipientName"]
+        : name;
+
+    private string FormatSentAt(DateTime dateTime) => dateTime.ToLocalTime().ToString("yyyy-MM-dd HH:mm", CultureInfo.CurrentCulture);
+
+    private string RangeDescriptionText
+    {
+        get
+        {
+            if (_startDate.HasValue && _endDate.HasValue)
+            {
+                return Localizer["RangeDescriptionBetween", FormatDate(_startDate.Value), FormatDate(_endDate.Value)];
+            }
+
+            if (_startDate.HasValue)
+            {
+                return Localizer["RangeDescriptionFrom", FormatDate(_startDate.Value)];
+            }
+
+            if (_endDate.HasValue)
+            {
+                return Localizer["RangeDescriptionUntil", FormatDate(_endDate.Value)];
+            }
+
+            return Localizer["RangeDescriptionAll"];
+        }
+    }
+
+    private static string FormatDate(DateTime dateTime) => dateTime.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
+}

--- a/src/Web/NexaCRM.WebClient/Pages/SmsSentHistoryPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/SmsSentHistoryPage.razor.css
@@ -1,0 +1,254 @@
+.sms-sent-history {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    color: var(--bs-body-color);
+}
+
+.sent-history-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.header-titles h3 {
+    margin-bottom: 0.25rem;
+    font-weight: 600;
+}
+
+.header-titles p {
+    margin: 0;
+    color: var(--bs-secondary-color);
+    font-size: 0.95rem;
+}
+
+.refresh-button {
+    align-self: center;
+    white-space: nowrap;
+}
+
+.summary-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.summary-card {
+    padding: 1rem 1.25rem;
+    background: var(--bs-card-bg);
+    border: 1px solid var(--bs-border-color);
+    border-radius: var(--bs-border-radius-lg);
+    box-shadow: var(--bs-box-shadow-sm);
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.summary-label {
+    font-size: 0.9rem;
+    color: var(--bs-secondary-color);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.summary-value {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--bs-body-color);
+}
+
+.summary-meta {
+    font-size: 0.85rem;
+    color: var(--bs-secondary-color);
+}
+
+.filter-card {
+    border-radius: var(--bs-border-radius-lg);
+    box-shadow: var(--bs-box-shadow-sm);
+}
+
+.filter-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.filter-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.filter-dates {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.filter-separator {
+    color: var(--bs-secondary-color);
+    font-weight: 500;
+}
+
+.quick-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.quick-buttons .btn-link {
+    font-size: 0.9rem;
+}
+
+.loading-state,
+.empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    padding: 2.5rem 1rem;
+    border: 1px dashed var(--bs-border-color);
+    border-radius: var(--bs-border-radius-lg);
+    color: var(--bs-secondary-color);
+    background: var(--bs-body-bg);
+}
+
+.empty-state i {
+    font-size: 2rem;
+    color: var(--bs-secondary-color);
+}
+
+.sent-history-table-wrapper {
+    border-radius: var(--bs-border-radius-lg);
+    border: 1px solid var(--bs-border-color);
+    overflow: hidden;
+    box-shadow: var(--bs-box-shadow-sm);
+}
+
+.sent-history-table thead th {
+    background: var(--bs-tertiary-bg);
+    color: var(--bs-secondary-color);
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.message-column {
+    max-width: 320px;
+    width: 30%;
+}
+
+.message-preview {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    white-space: normal;
+    line-height: 1.4;
+}
+
+.attachment-details summary {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    color: var(--bs-primary);
+    font-weight: 500;
+    list-style: none;
+}
+
+.attachment-details summary::-webkit-details-marker {
+    display: none;
+}
+
+.attachment-details[open] summary {
+    margin-bottom: 0.5rem;
+}
+
+.attachment-list {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.attachment-list li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    color: var(--bs-secondary-color);
+}
+
+.attachment-name {
+    font-weight: 500;
+    color: var(--bs-body-color);
+}
+
+.attachment-size {
+    font-size: 0.8rem;
+}
+
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.65rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.status-sent {
+    background-color: rgba(var(--bs-success-rgb), 0.15);
+    color: var(--bs-success);
+}
+
+.status-failed {
+    background-color: rgba(var(--bs-danger-rgb), 0.15);
+    color: var(--bs-danger);
+}
+
+.status-scheduled {
+    background-color: rgba(var(--bs-warning-rgb), 0.2);
+    color: var(--bs-warning-text-emphasis);
+}
+
+.sent-history-pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.pagination-info {
+    font-size: 0.95rem;
+    color: var(--bs-secondary-color);
+}
+
+@media (max-width: 768px) {
+    .sent-history-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .refresh-button {
+        align-self: flex-start;
+    }
+
+    .message-column {
+        max-width: none;
+        width: auto;
+    }
+
+    .summary-grid {
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/SmsSentHistoryPage.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/SmsSentHistoryPage.en-US.resx
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve">
+    <value>Send History</value>
+  </data>
+  <data name="Subtitle" xml:space="preserve">
+    <value>Review scheduled SMS deliveries and verify attachment usage.</value>
+  </data>
+  <data name="Refresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="SummaryTotalMessages" xml:space="preserve">
+    <value>Records</value>
+  </data>
+  <data name="SummaryWithAttachments" xml:space="preserve">
+    <value>With attachments</value>
+  </data>
+  <data name="SummaryAttachmentRatio" xml:space="preserve">
+    <value>{0}% with files</value>
+  </data>
+  <data name="SummaryAttachmentFiles" xml:space="preserve">
+    <value>Attachment files</value>
+  </data>
+  <data name="SummaryAttachmentFilesMeta" xml:space="preserve">
+    <value>Across selected records</value>
+  </data>
+  <data name="FilterDateRange" xml:space="preserve">
+    <value>Date range</value>
+  </data>
+  <data name="FilterQuickSelect" xml:space="preserve">
+    <value>Quick select</value>
+  </data>
+  <data name="QuickRangeToday" xml:space="preserve">
+    <value>Today</value>
+  </data>
+  <data name="QuickRange7Days" xml:space="preserve">
+    <value>7 days</value>
+  </data>
+  <data name="QuickRange30Days" xml:space="preserve">
+    <value>30 days</value>
+  </data>
+  <data name="QuickRangeClear" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="FilterSearch" xml:space="preserve">
+    <value>Search</value>
+  </data>
+  <data name="FilterSearchPlaceholder" xml:space="preserve">
+    <value>Recipient, name or content</value>
+  </data>
+  <data name="FilterStatus" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="FilterStatusAll" xml:space="preserve">
+    <value>All statuses</value>
+  </data>
+  <data name="FilterStatusSent" xml:space="preserve">
+    <value>Sent</value>
+  </data>
+  <data name="FilterStatusFailed" xml:space="preserve">
+    <value>Failed</value>
+  </data>
+  <data name="FilterStatusScheduled" xml:space="preserve">
+    <value>Scheduled</value>
+  </data>
+  <data name="FilterAttachment" xml:space="preserve">
+    <value>Attachments</value>
+  </data>
+  <data name="FilterAttachmentAll" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="FilterAttachmentWith" xml:space="preserve">
+    <value>With attachments</value>
+  </data>
+  <data name="FilterAttachmentWithout" xml:space="preserve">
+    <value>Without attachments</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Loading history...</value>
+  </data>
+  <data name="NoData" xml:space="preserve">
+    <value>No send history matches the current filters.</value>
+  </data>
+  <data name="TableNo" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="TableRecipient" xml:space="preserve">
+    <value>Recipient</value>
+  </data>
+  <data name="TableSender" xml:space="preserve">
+    <value>Sender</value>
+  </data>
+  <data name="TableRecipientName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="TableMessage" xml:space="preserve">
+    <value>Message</value>
+  </data>
+  <data name="TableAttachments" xml:space="preserve">
+    <value>Attachments</value>
+  </data>
+  <data name="TableStatus" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="TableSentAt" xml:space="preserve">
+    <value>Sent at</value>
+  </data>
+  <data name="AttachmentSummary" xml:space="preserve">
+    <value>{0} file(s)</value>
+  </data>
+  <data name="AttachmentNone" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="PaginationPrevious" xml:space="preserve">
+    <value>Previous</value>
+  </data>
+  <data name="PaginationNext" xml:space="preserve">
+    <value>Next</value>
+  </data>
+  <data name="PaginationInfo" xml:space="preserve">
+    <value>Page {0} of {1} · {2} records</value>
+  </data>
+  <data name="StatusSent" xml:space="preserve">
+    <value>Sent</value>
+  </data>
+  <data name="StatusFailed" xml:space="preserve">
+    <value>Failed</value>
+  </data>
+  <data name="StatusScheduled" xml:space="preserve">
+    <value>Scheduled</value>
+  </data>
+  <data name="UnknownRecipientName" xml:space="preserve">
+    <value>Not provided</value>
+  </data>
+  <data name="RangeDescriptionBetween" xml:space="preserve">
+    <value>{0} – {1}</value>
+  </data>
+  <data name="RangeDescriptionFrom" xml:space="preserve">
+    <value>From {0}</value>
+  </data>
+  <data name="RangeDescriptionUntil" xml:space="preserve">
+    <value>Until {0}</value>
+  </data>
+  <data name="RangeDescriptionAll" xml:space="preserve">
+    <value>All time</value>
+  </data>
+</root>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/SmsSentHistoryPage.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/SmsSentHistoryPage.ko-KR.resx
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve">
+    <value>전송 내역</value>
+  </data>
+  <data name="Subtitle" xml:space="preserve">
+    <value>첨부 파일을 포함한 스케줄 발송 이력을 확인하세요.</value>
+  </data>
+  <data name="Refresh" xml:space="preserve">
+    <value>새로고침</value>
+  </data>
+  <data name="SummaryTotalMessages" xml:space="preserve">
+    <value>전송 건수</value>
+  </data>
+  <data name="SummaryWithAttachments" xml:space="preserve">
+    <value>첨부 포함</value>
+  </data>
+  <data name="SummaryAttachmentRatio" xml:space="preserve">
+    <value>첨부 비율 {0}%</value>
+  </data>
+  <data name="SummaryAttachmentFiles" xml:space="preserve">
+    <value>첨부 파일 수</value>
+  </data>
+  <data name="SummaryAttachmentFilesMeta" xml:space="preserve">
+    <value>선택된 이력 기준</value>
+  </data>
+  <data name="FilterDateRange" xml:space="preserve">
+    <value>조회 기간</value>
+  </data>
+  <data name="FilterQuickSelect" xml:space="preserve">
+    <value>빠른 선택</value>
+  </data>
+  <data name="QuickRangeToday" xml:space="preserve">
+    <value>오늘</value>
+  </data>
+  <data name="QuickRange7Days" xml:space="preserve">
+    <value>7일</value>
+  </data>
+  <data name="QuickRange30Days" xml:space="preserve">
+    <value>30일</value>
+  </data>
+  <data name="QuickRangeClear" xml:space="preserve">
+    <value>전체 보기</value>
+  </data>
+  <data name="FilterSearch" xml:space="preserve">
+    <value>검색</value>
+  </data>
+  <data name="FilterSearchPlaceholder" xml:space="preserve">
+    <value>수신번호, 이름 또는 내용을 입력</value>
+  </data>
+  <data name="FilterStatus" xml:space="preserve">
+    <value>상태</value>
+  </data>
+  <data name="FilterStatusAll" xml:space="preserve">
+    <value>전체 상태</value>
+  </data>
+  <data name="FilterStatusSent" xml:space="preserve">
+    <value>발송 완료</value>
+  </data>
+  <data name="FilterStatusFailed" xml:space="preserve">
+    <value>발송 실패</value>
+  </data>
+  <data name="FilterStatusScheduled" xml:space="preserve">
+    <value>예약됨</value>
+  </data>
+  <data name="FilterAttachment" xml:space="preserve">
+    <value>첨부 파일</value>
+  </data>
+  <data name="FilterAttachmentAll" xml:space="preserve">
+    <value>전체</value>
+  </data>
+  <data name="FilterAttachmentWith" xml:space="preserve">
+    <value>첨부 있음</value>
+  </data>
+  <data name="FilterAttachmentWithout" xml:space="preserve">
+    <value>첨부 없음</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>전송 내역을 불러오는 중입니다...</value>
+  </data>
+  <data name="NoData" xml:space="preserve">
+    <value>조건에 맞는 전송 내역이 없습니다.</value>
+  </data>
+  <data name="TableNo" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="TableRecipient" xml:space="preserve">
+    <value>수신번호</value>
+  </data>
+  <data name="TableSender" xml:space="preserve">
+    <value>발신번호</value>
+  </data>
+  <data name="TableRecipientName" xml:space="preserve">
+    <value>이름</value>
+  </data>
+  <data name="TableMessage" xml:space="preserve">
+    <value>내용</value>
+  </data>
+  <data name="TableAttachments" xml:space="preserve">
+    <value>첨부파일</value>
+  </data>
+  <data name="TableStatus" xml:space="preserve">
+    <value>상태</value>
+  </data>
+  <data name="TableSentAt" xml:space="preserve">
+    <value>발신일시</value>
+  </data>
+  <data name="AttachmentSummary" xml:space="preserve">
+    <value>첨부 {0}건</value>
+  </data>
+  <data name="AttachmentNone" xml:space="preserve">
+    <value>없음</value>
+  </data>
+  <data name="PaginationPrevious" xml:space="preserve">
+    <value>이전</value>
+  </data>
+  <data name="PaginationNext" xml:space="preserve">
+    <value>다음</value>
+  </data>
+  <data name="PaginationInfo" xml:space="preserve">
+    <value>{0} / {1} 페이지 · 총 {2}건</value>
+  </data>
+  <data name="StatusSent" xml:space="preserve">
+    <value>발송 완료</value>
+  </data>
+  <data name="StatusFailed" xml:space="preserve">
+    <value>발송 실패</value>
+  </data>
+  <data name="StatusScheduled" xml:space="preserve">
+    <value>예약됨</value>
+  </data>
+  <data name="UnknownRecipientName" xml:space="preserve">
+    <value>미등록</value>
+  </data>
+  <data name="RangeDescriptionBetween" xml:space="preserve">
+    <value>{0} ~ {1}</value>
+  </data>
+  <data name="RangeDescriptionFrom" xml:space="preserve">
+    <value>{0} 이후</value>
+  </data>
+  <data name="RangeDescriptionUntil" xml:space="preserve">
+    <value>{0} 이전</value>
+  </data>
+  <data name="RangeDescriptionAll" xml:space="preserve">
+    <value>전체 기간</value>
+  </data>
+</root>

--- a/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.en-US.resx
@@ -153,6 +153,9 @@
   <data name="SmsSchedule" xml:space="preserve">
     <value>SMS Schedule</value>
   </data>
+  <data name="ScheduleSentHistory" xml:space="preserve">
+    <value>Send History</value>
+  </data>
   <data name="SmsSettings" xml:space="preserve">
     <value>SMS Settings</value>
   </data>

--- a/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Shared/NavMenu.ko-KR.resx
@@ -153,6 +153,9 @@
   <data name="SmsSchedule" xml:space="preserve">
     <value>문자 예약</value>
   </data>
+  <data name="ScheduleSentHistory" xml:space="preserve">
+    <value>전송 내역</value>
+  </data>
   <data name="SmsSettings" xml:space="preserve">
     <value>문자 설정</value>
   </data>

--- a/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/NavMenu.razor
@@ -301,6 +301,11 @@
                                             <i class="bi bi-envelope-plus" aria-hidden="true"></i> @Localizer["SmsSchedule"]
                                         </NavLink>
                                     </RoleBasedComponent>
+                                    <RoleBasedComponent RequiredRoles="Sales,Manager">
+                                        <NavLink class="nav-link submenu-link" href="schedule/sent-history" @onclick="CloseNavMenu">
+                                            <i class="bi bi-send-check" aria-hidden="true"></i> @Localizer["ScheduleSentHistory"]
+                                        </NavLink>
+                                    </RoleBasedComponent>
                                 </div>
                             }
                         </div>

--- a/src/Web/NexaCRM.WebClient/Shared/NavigationRail.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/NavigationRail.razor
@@ -283,6 +283,9 @@
                 <RoleBasedComponent RequiredRoles="Sales,Manager">
                     <NavLink class="nav-link panel-item" href="schedule/sms" @onclick="CloseMenuOnNavigate"><span>@Localizer["SmsSchedule"]</span></NavLink>
                 </RoleBasedComponent>
+                <RoleBasedComponent RequiredRoles="Sales,Manager">
+                    <NavLink class="nav-link panel-item" href="schedule/sent-history" @onclick="CloseMenuOnNavigate"><span>@Localizer["ScheduleSentHistory"]</span></NavLink>
+                </RoleBasedComponent>
             </nav>
         }
         else if (activeCategory == Category.System)


### PR DESCRIPTION
## Summary
- add a schedule send history page that surfaces filters, attachment insights, and paginated results
- extend SMS history models/services to capture attachment metadata and seed richer sample data
- surface the new page from the schedule navigation menu/rail with localized labels in English and Korean

## Testing
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d2b98ec880832c9fade6c1ab6e65ac