### PR TITLE
feat: refresh reports layout and dark mode styling

### DIFF
--- a/docs/tablet-desktop-ui-enhancement-checklist.md
+++ b/docs/tablet-desktop-ui-enhancement-checklist.md
@@ -1,0 +1,81 @@
+# 태블릿·데스크탑 UX/UI 고도화 진단 리포트
+
+## 0. 맥락 파악 (사전 진단)
+### 진단
+* `MainDashboard`는 모바일 헤더·퀵 액션·알림 패널을 항상 렌더링하고 그 아래에 데스크탑 사이드바와 콘텐츠 래퍼를 두어 뷰포트에 따라 서로 겹치는 구조입니다. 태블릿·데스크탑 전환 시 어떤 계층을 숨기거나 재배치할지 명확한 규칙이 없어 시각적 충돌과 중복 내비게이션이 발생할 수 있습니다.【F:src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor†L12-L195】
+* 전역 `ResponsivePage` 래퍼는 부트스트랩 그리드 한 컬럼만 감싸고, `mobile.css`는 768px 이상에서 최대 폭 800px만 지정해 태블릿 폭 확장이나 멀티컬럼 구성이 제한됩니다.【F:src/Web/NexaCRM.WebClient/Shared/ResponsivePage.razor†L1-L8】【F:src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css†L339-L349】
+* `StatisticsDashboardPage`는 접근성 있는 퀵 범위 버튼, 요약 타일, SVG 차트 뼈대를 제공하지만 데스크탑 환경에서의 데이터 밀도·상호작용·애니메이션 정의는 비어 있습니다.【F:src/Web/NexaCRM.WebClient/Pages/StatisticsDashboardPage.razor†L10-L220】
+### 제안
+* 화면 크기별로 모바일 헤더/패널과 데스크탑 사이드바의 우선순위를 문서화하고, 공통 툴바 또는 스위처 패턴을 지정합니다.
+* 태블릿(≥768px)과 데스크탑(≥1200px)용 최대 폭, 패딩, 그리드 토큰을 재설계하여 `ResponsivePage`와 전역 CSS에 반영합니다.
+* 통계 대시보드의 주요 지표·차트 유형·상호작용 수준을 정량화해 추후 컴포넌트 고도화의 기준선으로 삼습니다.
+
+## 1. 레이아웃 & 반응형 시스템
+#### 1.1 공통 체크
+* 진단: 대시보드 영역은 Tailwind 유틸(`w-80`, `flex`, `gap`) 중심으로 구성되어 있고, 기기별 컨테이너 폭이나 컬럼 수를 제어하는 디자인 토큰이 없습니다.【F:src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor†L156-L195】
+* 제안: CSS 커스텀 프로퍼티/유틸을 정의해 태블릿·데스크탑에서 12컬럼 기반 레이아웃과 섹션 간 공통 스페이싱을 표준화합니다.
+#### 1.2 태블릿(768–1199px)
+* 진단: 모바일 퀵 액션 바가 고정 렌더링되고, 사이드바 폭 `w-80`(≈320px)과 본문 영역 구분이 부족해 태블릿에서 비좁은 레이아웃이 예상됩니다.【F:src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor†L62-L102】【F:src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor†L156-L195】
+* 제안: 태블릿에서는 퀵 액션을 콘텐츠 상단 카드로 이동하고, 접힘 가능한 네비게이션 레일과 1~2열 카드 배치를 재구성합니다.
+#### 1.3 데스크탑(≥1200px)
+* 진단: 데스크탑 특정 `max-width` 제어가 없어 초광폭 모니터에서 콘텐츠가 과도하게 넓어질 수 있고, 멀티패널 구성이나 3열 그리드 정의가 없습니다.【F:src/Web/NexaCRM.WebClient/Shared/ResponsivePage.razor†L1-L8】
+* 제안: 1200~1440px 기본 최대 폭과 1600px 이상 확장 전략을 문서화하고, 사이드바·필터·알림 패널 동시 노출이 가능한 멀티컬럼 레이아웃을 설계합니다.
+
+## 2. 내비게이션 & 정보 구조
+### 진단
+* 사이드 네비게이션은 `AuthorizeView` 기반으로 역할별 링크를 노출하지만, 활성 상태·뱃지·접힘 인터랙션이 정의되지 않았습니다.【F:src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor†L160-L195】
+* 모바일 퀵 액션 버튼과 데스크탑 사이드바가 동일 목적의 링크를 중복 제공하며, 전역 검색·알림·설정 흐름이 기기별로 분리되어 있습니다.【F:src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor†L26-L118】
+### 제안
+* 태블릿 이상에서 네비게이션 레일+헤더 단축 버튼 체계를 정의하고 권한·상태 뱃지, 현재 위치 표시를 명확히 합니다.
+* 전역 검색/알림/설정 우선순위, 포커스 순서, 스킵 링크 등 내비게이션 흐름을 키보드 기준으로 문서화합니다.
+
+## 3. 대시보드 & 차트 고도화
+### 진단
+* 요약 타일과 추세 차트는 SVG 기반 시각화를 제공하지만, 실시간 업데이트 피드백·툴팁·범례 토글 등 상호작용 요소가 없습니다.【F:src/Web/NexaCRM.WebClient/Pages/StatisticsDashboardPage.razor†L74-L220】
+* 로딩 단계는 `LoadingSpinner`만 호출하고 차트 스켈레톤이나 애니메이션 규칙은 정의되어 있지 않습니다.【F:src/Web/NexaCRM.WebClient/Pages/StatisticsDashboardPage.razor†L63-L71】【F:src/Web/NexaCRM.WebClient/Components/UI/LoadingSpinner.razor†L3-L170】
+### 제안
+* KPI 타일에 상승/하락 애니메이션, 목표 대비 지표, 최신 업데이트 타임스탬프를 추가하고, 차트에 호버·포커스 툴팁·평균선·범례 토글을 설계합니다.
+* 로딩과 실시간 갱신 상태에 스켈레톤/펄스/프로그레시브 라인 드로잉 애니메이션을 도입합니다.
+
+## 4. 데이터 테이블·폼 경험
+### 진단
+* `ReportsPage`는 필드 추가/필터/미리보기 테이블을 단일 컬럼으로 배치해, 태블릿 이상에서 폼과 목록을 동시에 다루기 어렵습니다.【F:src/Web/NexaCRM.WebClient/Pages/ReportsPage.razor†L10-L65】
+* 인라인 검증·저장/취소 영역 고정·스텝바이저드 흐름 등 편집 UX 요소가 부재합니다.【F:src/Web/NexaCRM.WebClient/Pages/ReportsPage.razor†L10-L115】
+### 제안
+* 태블릿에서는 폼과 저장 목록을 2열로 배치하고, 데스크탑에서는 필드 그룹/필터 패널을 구분해 인라인 검증, 고정 액션 영역, 드릴다운 가능한 테이블을 설계합니다.
+
+## 5. 컴포넌트 & 상호작용 모듈
+### 진단
+* `QuickActionsComponent`는 기기 감지 후 `tel:`/`mailto:`/알림 창 호출만 제공해 다단계 확장이나 통합 피드백이 부족합니다.【F:src/Web/NexaCRM.WebClient/Components/UI/QuickActionsComponent.razor†L6-L134】
+* 로딩 스피너는 스켈레톤/프로그레스 옵션을 지원하지만 레이아웃·색상 토큰 연동이 미흡합니다.【F:src/Web/NexaCRM.WebClient/Components/UI/LoadingSpinner.razor†L3-L200】
+### 제안
+* 데스크탑 회의 예약·알림 전송은 모달/슬라이드오버·툴팁·성공/실패 토스트와 연계하고, 액션 완료 이벤트를 대시보드 카드 상태와 연결합니다.
+* 필터 패널·태그 바·세그먼트 컨트롤 등 반복 UI를 컴포넌트화하고 상태별 스타일 가이드를 문서화합니다.
+
+## 6. 애니메이션 & 마이크로 인터랙션
+### 진단
+* 네비게이션 링크와 버튼은 0.2초 컬러 전환만 정의되어 등장/퇴장, 상태 변화에 대한 모션 스케일이 없습니다.【F:src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor.css†L1-L37】
+### 제안
+* 등장/퇴장 0.3~0.4초 이징 커브, 스크롤 연동 페이드/슬라이드, 탭 전환 모션, 토스트 진입/퇴장 애니메이션을 기기별로 세분화하고 `prefers-reduced-motion` 대응을 포함합니다.
+
+## 7. 시각 디자인 & 테마
+### 진단
+* 다크 모드용 색상 재정의는 존재하지만, 전역 토큰과 차트/버튼/태그 간 일관성·명암비 기준이 정리되어 있지 않습니다.【F:src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor.css†L81-L199】
+### 제안
+* 브랜드/상태 색상, 그림자, 타이포그래피 스케일을 기기별로 조정하고 다크 모드 대비 4.5:1 이상을 보장하는 팔레트, KPI용 대체 폰트 적용 지침을 마련합니다.
+
+## 8. 접근성 & 국제화
+### 진단
+* 통계 대시보드 툴바는 ARIA 역할·라이브 영역을 일부 정의했으나 키보드 포커스 스타일, 스킵 링크, 언어 길이 변동 대응은 부족합니다.【F:src/Web/NexaCRM.WebClient/Pages/StatisticsDashboardPage.razor†L19-L59】
+### 제안
+* 포커스 상태, 스킵 링크, ARIA 속성(`aria-live`, `aria-pressed`, `aria-expanded`)을 전역 컴포넌트에 확장하고 다국어 문자열 길이에 맞춘 버튼 최소 폭·차트 축 레이아웃을 설계합니다.
+
+## 9. 성능 & 기술 고려 사항
+### 진단
+* 통계 페이지는 서버 호출 후 전역 로딩 스피너만 표시하며, 데이터 스트리밍·프로그레시브 하이드레이션·가상 스크롤 등 고해상도 기기 성능 최적화 전략은 마련되지 않았습니다.【F:src/Web/NexaCRM.WebClient/Pages/StatisticsDashboardPage.razor†L63-L205】
+* 퀵 액션은 브라우저 `alert` 호출에 의존해 비동기 상태 관리나 사용자 선호 저장 전략이 없습니다.【F:src/Web/NexaCRM.WebClient/Components/UI/QuickActionsComponent.razor†L74-L134】
+### 제안
+* 대시보드 데이터는 스트리밍/청크 로딩, 리소스 분할, LCP ≤2.5초 목표를 위한 CSS/JS 최적화를 문서화하고, 차트·테이블에는 가상 스크롤·부분 업데이트를 도입합니다.
+* 사용자 맞춤 위젯 순서/보기 설정 저장·복원을 위한 상태 관리 및 스토리지 전략을 정의합니다.
+
+> 이 문서는 태블릿·데스크탑 UI 고도화 시 발견된 현황과 개선 포인트를 번호 순서(0~9)로 정리한 것으로, 디자인 시스템·개발 태스크 우선순위 산정에 직접 활용할 수 있도록 구성했습니다.

--- a/src/Web/NexaCRM.WebClient/Components/UI/QuickActionsComponent.razor
+++ b/src/Web/NexaCRM.WebClient/Components/UI/QuickActionsComponent.razor
@@ -1,5 +1,7 @@
 @using Microsoft.Extensions.Localization
 @using Microsoft.JSInterop
+@using System.Text.Json
+@using System.Linq
 @inject IStringLocalizer<QuickActionsComponent> Localizer
 @inject IJSRuntime JSRuntime
 
@@ -50,6 +52,47 @@
             </button>
         }
     </div>
+
+    <div class="quick-actions-feedback" aria-live="polite">
+        @if (!string.IsNullOrWhiteSpace(actionAnnouncement))
+        {
+            <span>@actionAnnouncement</span>
+        }
+    </div>
+
+    @if (showToast && !string.IsNullOrEmpty(toastMessage))
+    {
+        <div class="quick-actions-toast" role="status">
+            <span>@toastMessage</span>
+            <button type="button" class="quick-actions-toast__dismiss" @onclick="DismissToast">
+                <span class="sr-only">@Localizer["QuickActionsToastDismiss"]</span>
+                ×
+            </button>
+        </div>
+    }
+
+    @if (showActionSheet)
+    {
+        <div class="quick-actions-sheet-backdrop" role="presentation" @onclick="CloseActionSheet">
+            <div class="quick-actions-sheet" role="dialog" aria-modal="true" aria-labelledby="quickActionSheetTitle" aria-describedby="quickActionSheetDescription" @onclick:stopPropagation="true">
+                <header class="quick-actions-sheet__header">
+                    <h3 id="quickActionSheetTitle">@actionSheetTitle</h3>
+                    <p id="quickActionSheetDescription">@actionSheetDescription</p>
+                </header>
+                <div class="quick-actions-sheet__actions">
+                    @if (!string.IsNullOrWhiteSpace(actionSheetPrimaryHref) && !string.IsNullOrWhiteSpace(actionSheetPrimaryText))
+                    {
+                        <a class="quick-actions-sheet__primary" href="@actionSheetPrimaryHref" @onclick="async () => await ConfirmPendingActionFromLink()">@actionSheetPrimaryText</a>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(actionSheetSecondaryText))
+                    {
+                        <button type="button" class="quick-actions-sheet__secondary" @onclick="async () => await ExecuteSecondaryAction()">@actionSheetSecondaryText</button>
+                    }
+                    <button type="button" class="quick-actions-sheet__tertiary" @onclick="CloseActionSheet">@Localizer["QuickActionsCancel"]</button>
+                </div>
+            </div>
+        </div>
+    }
 </div>
 
 @code {
@@ -64,28 +107,36 @@
     [Parameter] public string CssClass { get; set; } = "";
     [Parameter] public EventCallback<string> OnActionCompleted { get; set; }
 
+    private bool showActionSheet;
+    private string? pendingAction;
+    private string? actionSheetTitle;
+    private string? actionSheetDescription;
+    private string? actionSheetPrimaryText;
+    private string? actionSheetPrimaryHref;
+    private string? actionSheetSecondaryText;
+    private Func<Task>? secondaryAction;
+    private string? actionAnnouncement;
+    private string? toastMessage;
+    private bool showToast;
+
     private async Task HandleCallAction()
     {
-        if (string.IsNullOrEmpty(PhoneNumber)) return;
+        if (string.IsNullOrEmpty(PhoneNumber))
+        {
+            return;
+        }
 
         try
         {
-            // Detect if we're on mobile or desktop
-            var isMobile = await JSRuntime.InvokeAsync<bool>("eval", "window.matchMedia('(max-width: 767px)').matches");
-            
-            if (isMobile)
+            if (await IsMobileViewportAsync())
             {
-                // On mobile, use tel: protocol to open phone app
                 await JSRuntime.InvokeVoidAsync("eval", $"window.location.href = 'tel:{PhoneNumber}'");
+                await AnnounceAndCompleteAsync("call", Localizer["QuickActionsCallLaunched", ResolveDisplayName(PhoneNumber)]);
             }
             else
             {
-                // On desktop, show options (could be VoIP integration in the future)
-                await JSRuntime.InvokeVoidAsync("alert", $"Call {CustomerName ?? "customer"} at {PhoneNumber}");
-                // TODO: Integrate with VoIP solution like Twilio, Zoom Phone, etc.
+                PrepareCallActionSheet();
             }
-
-            await OnActionCompleted.InvokeAsync("call");
         }
         catch (Exception ex)
         {
@@ -95,17 +146,28 @@
 
     private async Task HandleEmailAction()
     {
-        if (string.IsNullOrEmpty(Email)) return;
+        if (string.IsNullOrEmpty(Email))
+        {
+            return;
+        }
 
         try
         {
-            // Use mailto: protocol to open email client
-            var subject = $"Follow-up with {CustomerName ?? "Customer"}";
-            var body = $"Hello {CustomerName ?? ""},\n\nI wanted to follow up with you regarding...\n\nBest regards";
+            var displayName = ResolveDisplayName(Email);
+            var subject = Localizer["QuickActionsEmailSubject", displayName];
+            var body = Localizer["QuickActionsEmailBody", displayName];
             var mailtoUrl = $"mailto:{Email}?subject={Uri.EscapeDataString(subject)}&body={Uri.EscapeDataString(body)}";
-            
-            await JSRuntime.InvokeVoidAsync("eval", $"window.location.href = '{mailtoUrl}'");
-            await OnActionCompleted.InvokeAsync("email");
+            var clipboardTemplate = Localizer["QuickActionsEmailClipboardTemplate", Email, subject, body];
+
+            if (await IsMobileViewportAsync())
+            {
+                await JSRuntime.InvokeVoidAsync("eval", $"window.location.href = '{mailtoUrl}'");
+                await AnnounceAndCompleteAsync("email", Localizer["QuickActionsEmailLaunched", displayName]);
+            }
+            else
+            {
+                PrepareEmailActionSheet(mailtoUrl, clipboardTemplate);
+            }
         }
         catch (Exception ex)
         {
@@ -117,24 +179,193 @@
     {
         try
         {
-            // Create a calendar event - this could be enhanced to integrate with specific calendar systems
-            var startDate = DateTime.Now.AddDays(1).ToString("yyyyMMddTHHmmssZ");
-            var endDate = DateTime.Now.AddDays(1).AddHours(1).ToString("yyyyMMddTHHmmssZ");
-            var eventTitle = $"Meeting with {CustomerName ?? "Customer"}";
-            var eventDetails = $"Sales meeting with {CustomerName ?? "customer"}";
-            
-            // Create .ics file content for calendar integration
-            var icsContent = $"BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//NexaCRM//EN\nBEGIN:VEVENT\nUID:{Guid.NewGuid()}\nDTSTART:{startDate}\nDTEND:{endDate}\nSUMMARY:{eventTitle}\nDESCRIPTION:{eventDetails}\nEND:VEVENT\nEND:VCALENDAR";
-            
-            // For now, we'll show a notification. In production, this could integrate with calendar APIs
-            await JSRuntime.InvokeVoidAsync("alert", $"Schedule meeting with {CustomerName ?? "customer"}. Calendar integration coming soon!");
-            
-            // TODO: Integrate with calendar systems (Google Calendar, Outlook, etc.)
-            await OnActionCompleted.InvokeAsync("meeting");
+            var displayName = ResolveDisplayName(Localizer["QuickActionsUnknownContact"]);
+            var summary = Localizer["QuickActionsMeetingSummary", displayName];
+            var description = Localizer["QuickActionsMeetingDescription", displayName];
+            var start = DateTime.UtcNow.AddDays(1);
+            var end = start.AddHours(1);
+            var icsContent = $"BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//NexaCRM//EN\nBEGIN:VEVENT\nUID:{Guid.NewGuid()}\nDTSTAMP:{DateTime.UtcNow:yyyyMMddTHHmmssZ}\nDTSTART:{start:yyyyMMddTHHmmssZ}\nDTEND:{end:yyyyMMddTHHmmssZ}\nSUMMARY:{summary}\nDESCRIPTION:{description}\nEND:VEVENT\nEND:VCALENDAR";
+            var fileName = GetMeetingFileName();
+
+            await TriggerFileDownloadAsync(fileName, icsContent);
+            await AnnounceAndCompleteAsync("meeting", Localizer["QuickActionsMeetingPrepared", displayName]);
         }
         catch (Exception ex)
         {
             Console.WriteLine($"Error handling meeting action: {ex.Message}");
         }
+    }
+
+    private async Task<bool> IsMobileViewportAsync()
+    {
+        try
+        {
+            return await JSRuntime.InvokeAsync<bool>("eval", "window.matchMedia('(max-width: 767px)').matches");
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private void PrepareCallActionSheet()
+    {
+        var displayName = ResolveDisplayName(PhoneNumber);
+        pendingAction = "call";
+        actionSheetTitle = Localizer["QuickActionsCallDialogTitle", displayName];
+        actionSheetDescription = Localizer["QuickActionsCallDialogDescription", displayName];
+        actionSheetPrimaryText = Localizer["QuickActionsCallPrimary"];
+        actionSheetPrimaryHref = $"tel:{PhoneNumber}";
+        actionSheetSecondaryText = Localizer["QuickActionsCopyNumber"];
+        secondaryAction = async () =>
+        {
+            await CopyToClipboardAsync(PhoneNumber!);
+            await AnnounceAndCompleteAsync("call", Localizer["QuickActionsCopySuccess"]);
+        };
+        showActionSheet = true;
+        StateHasChanged();
+    }
+
+    private void PrepareEmailActionSheet(string mailtoUrl, string clipboardTemplate)
+    {
+        var displayName = ResolveDisplayName(Email);
+        pendingAction = "email";
+        actionSheetTitle = Localizer["QuickActionsEmailDialogTitle", displayName];
+        actionSheetDescription = Localizer["QuickActionsEmailDialogDescription"];
+        actionSheetPrimaryText = Localizer["QuickActionsEmailPrimary"];
+        actionSheetPrimaryHref = mailtoUrl;
+        actionSheetSecondaryText = Localizer["QuickActionsEmailCopy"];
+        secondaryAction = async () =>
+        {
+            await CopyToClipboardAsync(clipboardTemplate);
+            await AnnounceAndCompleteAsync("email", Localizer["QuickActionsEmailCopySuccess"]);
+        };
+        showActionSheet = true;
+        StateHasChanged();
+    }
+
+    private async Task ConfirmPendingActionFromLink()
+    {
+        var action = pendingAction;
+        CloseActionSheet();
+
+        if (string.Equals(action, "call", StringComparison.OrdinalIgnoreCase))
+        {
+            await AnnounceAndCompleteAsync("call", Localizer["QuickActionsCallLaunched", ResolveDisplayName(PhoneNumber)]);
+        }
+        else if (string.Equals(action, "email", StringComparison.OrdinalIgnoreCase))
+        {
+            await AnnounceAndCompleteAsync("email", Localizer["QuickActionsEmailLaunched", ResolveDisplayName(Email)]);
+        }
+    }
+
+    private async Task ExecuteSecondaryAction()
+    {
+        var action = secondaryAction;
+        CloseActionSheet();
+
+        if (action is not null)
+        {
+            await action();
+        }
+    }
+
+    private void CloseActionSheet()
+    {
+        showActionSheet = false;
+        pendingAction = null;
+        actionSheetTitle = null;
+        actionSheetDescription = null;
+        actionSheetPrimaryText = null;
+        actionSheetPrimaryHref = null;
+        actionSheetSecondaryText = null;
+        secondaryAction = null;
+        StateHasChanged();
+    }
+
+    private async Task AnnounceAndCompleteAsync(string actionKey, string message)
+    {
+        actionAnnouncement = message;
+        toastMessage = message;
+        showToast = true;
+        await OnActionCompleted.InvokeAsync(actionKey);
+        StateHasChanged();
+    }
+
+    private void DismissToast()
+    {
+        showToast = false;
+        toastMessage = null;
+        StateHasChanged();
+    }
+
+    private string ResolveDisplayName(string? fallback)
+    {
+        if (!string.IsNullOrWhiteSpace(CustomerName))
+        {
+            return CustomerName!;
+        }
+
+        return string.IsNullOrWhiteSpace(fallback) ? Localizer["QuickActionsUnknownContact"] : fallback!;
+    }
+
+    private async Task CopyToClipboardAsync(string value)
+    {
+        var encoded = JsonSerializer.Serialize(value);
+        var script = $@"
+            (async () => {{
+                const value = {encoded};
+                if (navigator.clipboard && navigator.clipboard.writeText) {{
+                    try {{
+                        await navigator.clipboard.writeText(value);
+                        return;
+                    }} catch (err) {{}}
+                }
+                const textarea = document.createElement('textarea');
+                textarea.value = value;
+                textarea.setAttribute('readonly', '');
+                textarea.style.position = 'absolute';
+                textarea.style.left = '-9999px';
+                document.body.appendChild(textarea);
+                textarea.select();
+                document.execCommand('copy');
+                document.body.removeChild(textarea);
+            }})();
+        ";
+
+        await JSRuntime.InvokeVoidAsync("eval", script);
+    }
+
+    private string GetMeetingFileName()
+    {
+        var baseName = string.IsNullOrWhiteSpace(CustomerName) ? "customer" : CustomerName!.ToLowerInvariant();
+        var sanitized = new string(baseName.Where(c => char.IsLetterOrDigit(c) || c == '-').ToArray());
+        if (string.IsNullOrWhiteSpace(sanitized))
+        {
+            sanitized = "customer";
+        }
+
+        return $"meeting-with-{sanitized}.ics";
+    }
+
+    private async Task TriggerFileDownloadAsync(string fileName, string content)
+    {
+        var base64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(content));
+        var base64Json = JsonSerializer.Serialize(base64);
+        var fileNameJson = JsonSerializer.Serialize(fileName);
+        var script = $@"
+            (function() {{
+                const data = {base64Json};
+                const fileName = {fileNameJson};
+                const link = document.createElement('a');
+                link.href = 'data:text/calendar;base64,' + data;
+                link.download = fileName;
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+            }})();
+        ";
+
+        await JSRuntime.InvokeVoidAsync("eval", script);
     }
 }

--- a/src/Web/NexaCRM.WebClient/Components/UI/QuickActionsComponent.razor.css
+++ b/src/Web/NexaCRM.WebClient/Components/UI/QuickActionsComponent.razor.css
@@ -6,6 +6,75 @@
     @apply flex items-center gap-2 flex-wrap;
 }
 
+.quick-actions-feedback {
+    @apply mt-2 text-sm text-slate-600;
+    min-height: 1.25rem;
+}
+
+.quick-actions-toast {
+    @apply mt-3 flex items-center gap-3 rounded-lg bg-slate-900/90 text-white px-4 py-2 shadow-xl;
+    backdrop-filter: blur(4px);
+    max-width: 28rem;
+    line-height: 1.35;
+}
+
+.quick-actions-toast__dismiss {
+    @apply bg-transparent border-none cursor-pointer text-white text-xl leading-none font-bold;
+}
+
+.quick-actions-sheet-backdrop {
+    @apply fixed inset-0 z-40 flex items-center justify-center bg-slate-900/40;
+    backdrop-filter: blur(6px);
+}
+
+.quick-actions-sheet {
+    @apply flex flex-col gap-5 bg-white;
+    width: min(90%, 28rem);
+    border-radius: 1.25rem;
+    padding: 1.5rem;
+    box-shadow: 0 28px 60px rgba(15, 23, 42, 0.18);
+}
+
+.quick-actions-sheet__header {
+    @apply flex flex-col gap-2;
+}
+
+.quick-actions-sheet__header h3 {
+    @apply text-lg font-semibold text-slate-900;
+}
+
+.quick-actions-sheet__header p {
+    @apply text-sm text-slate-600;
+}
+
+.quick-actions-sheet__actions {
+    @apply flex flex-col gap-3;
+}
+
+.quick-actions-sheet__primary {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 font-semibold text-white shadow-lg transition-colors;
+}
+
+.quick-actions-sheet__primary:hover,
+.quick-actions-sheet__primary:focus-visible {
+    @apply bg-blue-700;
+    outline: none;
+}
+
+.quick-actions-sheet__secondary {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg border border-slate-300 px-4 py-2.5 font-semibold text-slate-700 transition-colors;
+}
+
+.quick-actions-sheet__secondary:hover,
+.quick-actions-sheet__secondary:focus-visible {
+    @apply bg-slate-100;
+    outline: none;
+}
+
+.quick-actions-sheet__tertiary {
+    @apply text-sm font-medium text-slate-500 hover:text-slate-700 transition-colors;
+}
+
 .quick-action-btn {
     @apply flex items-center justify-center gap-2 px-3 py-2 rounded-lg border-2 transition-all duration-200 cursor-pointer;
     min-height: 44px; /* Touch-friendly minimum size */
@@ -68,7 +137,17 @@
         @apply flex-row justify-center gap-4;
         width: 100%;
     }
-    
+
+    .quick-actions-sheet-backdrop {
+        @apply items-end;
+    }
+
+    .quick-actions-sheet {
+        width: 100%;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+
     .quick-action-btn {
         @apply flex-1 min-w-0;
         min-height: 48px; /* Larger touch target on mobile */
@@ -76,6 +155,17 @@
     
     .action-label {
         @apply text-xs;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .quick-action-btn,
+    .quick-actions-toast,
+    .quick-actions-sheet,
+    .quick-actions-sheet__primary,
+    .quick-actions-sheet__secondary {
+        transition-duration: 0.01ms !important;
+        animation-duration: 0.01ms !important;
     }
 }
 

--- a/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor
@@ -9,6 +9,8 @@
 @attribute [Authorize(Roles = "Sales,Manager")]
 @implements IDisposable
 
+<a href="#mainDashboardContent" class="dashboard-skip-link">@Localizer["SkipToMainContent"]</a>
+
 <div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;' data-page="main-dashboard">
     <!-- Mobile Header Bar -->
     <div class="mobile-header mobile-header--active">
@@ -60,7 +62,7 @@
     </div>
 
     <!-- Mobile Quick Actions Bar -->
-    <div class="mobile-quick-actions">
+    <div class="mobile-quick-actions" role="navigation" aria-label="@Localizer["QuickActionsLabel"]">
         <AuthorizeView>
             <Authorized>
                 @{
@@ -154,101 +156,89 @@
     </div>
 
     <div class="layout-container flex h-full grow flex-col">
-    <div class="gap-1 px-6 flex flex-1 justify-center py-5 dashboard-container">
-        <div class="layout-content-container flex flex-col w-80 dashboard-sidebar">
-        <div class="flex h-full min-h-[700px] flex-col justify-between bg-slate-50 p-4">
-            <div class="flex flex-col gap-4">
-            <div class="flex flex-col">
-                <h1 class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["CRM"]</h1>
+        <div class="dashboard-container">
+        <aside class="dashboard-sidebar" aria-labelledby="dashboardNavigationTitle">
+            <nav class="dashboard-sidebar__panel" aria-label="@Localizer["PrimaryNavigation"]">
+            <div class="dashboard-sidebar__section">
+                <div class="dashboard-sidebar__brand">
+                <h1 id="dashboardNavigationTitle" class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["CRM"]</h1>
                 <p class="text-[#4d6a99] text-sm font-normal leading-normal">@Localizer["AcmeCo"]</p>
-            </div>
-            <div class="flex flex-col gap-2">
-                <div class="flex items-center gap-3 px-3 py-2 rounded-lg bg-[#e7ecf3]">
-                <div class="text-[#0e131b]" data-icon="House" data-size="24px" data-weight="fill">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
-                    <path
-                        d="M224,115.55V208a16,16,0,0,1-16,16H168a16,16,0,0,1-16-16V168a8,8,0,0,0-8-8H112a8,8,0,0,0-8,8v40a16,16,0,0,1-16,16H48a16,16,0,0,1-16-16V115.55a16,16,0,0,1,5.17-11.78l80-75.48.11-.11a16,16,0,0,1,21.53,0,1.14,1.14,0,0,0,.11.11l80,75.48A16,16,0,0,1,224,115.55Z"
-                    ></path>
-                    </svg>
                 </div>
-                <p class="text-[#0e131b] text-sm font-medium leading-normal">@Localizer["Dashboard"]</p>
+                <div class="dashboard-sidebar__links" role="list">
+                <div class="dashboard-sidebar__home" role="listitem">
+                    <div class="flex items-center gap-3 px-3 py-2 rounded-lg bg-[#e7ecf3]">
+                    <div class="text-[#0e131b]" data-icon="House" data-size="24px" data-weight="fill">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                        <path d="M224,115.55V208a16,16,0,0,1-16,16H168a16,16,0,0,1-16-16V168a8,8,0,0,0-8-8H112a8,8,0,0,0-8,8v40a16,16,0,0,1-16,16H48a16,16,0,0,1-16-16V115.55a16,16,0,0,1,5.17-11.78l80-75.48.11-.11a16,16,0,0,1,21.53,0,1.14,1.14,0,0,0,.11.11l80,75.48A16,16,0,0,1,224,115.55Z"></path>
+                        </svg>
+                    </div>
+                    <p class="text-[#0e131b] text-sm font-medium leading-normal">@Localizer["Dashboard"]</p>
+                    </div>
                 </div>
                 <AuthorizeView>
                     <Authorized>
-                        @{
-                            var salesLink = "/sales-pipeline-page";
-                            if (context.User.IsInRole("Manager"))
-                            {
-                                salesLink = "/sales-manager-dashboard";
-                            }
+                    @{
+                        var salesLink = "/sales-pipeline-page";
+                        if (context.User.IsInRole("Manager"))
+                        {
+                            salesLink = "/sales-manager-dashboard";
                         }
-                        <a href="@salesLink" class="flex items-center gap-3 px-3 py-2 nav-link">
-                            <div class="text-[#0e131b] nav-link-icon" data-icon="CurrencyDollar" data-size="24px" data-weight="regular">
-                                <svg class="nav-link-icon-graphic" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
-                                <path
-                                    d="M152,120H136V56h8a32,32,0,0,1,32,32,8,8,0,0,0,16,0,48.05,48.05,0,0,0-48-48h-8V24a8,8,0,0,0-16,0V40h-8a48,48,0,0,0,0,96h8v64H104a32,32,0,0,1-32-32,8,8,0,0,0-16,0,48.05,48.05,0,0,0,48,48h16v16a8,8,0,0,0,16,0V216h16a48,48,0,0,0,0-96Zm-40,0a32,32,0,0,1,0-64h8v64Zm40,80H136V136h16a32,32,0,0,1,0,64Z"
-                                ></path>
-                                </svg>
-                            </div>
-                            <p class="text-[#0e131b] text-sm font-medium leading-normal nav-link-text">@Localizer["Sales"]</p>
-                        </a>
-                        <a href="/contacts" class="flex items-center gap-3 px-3 py-2 nav-link">
-                            <div class="text-[#0e131b] nav-link-icon" data-icon="Users" data-size="24px" data-weight="regular">
-                                <svg class="nav-link-icon-graphic" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
-                                <path
-                                    d="M117.25,157.92a60,60,0,1,0-66.5,0A95.83,95.83,0,0,0,3.53,195.63a8,8,0,1,0,13.4,8.74,80,80,0,0,1,134.14,0,8,8,0,0,0,13.4-8.74A95.83,95.83,0,0,0,117.25,157.92ZM40,108a44,44,0,1,1,44,44A44.05,44.05,0,0,1,40,108Zm210.14,98.7a8,8,0,0,1-11.07-2.33A79.83,79.83,0,0,0,172,168a8,8,0,0,1,0-16,44,44,0,1,0-16.34-84.87,8,8,0,1,1-5.94-14.85,60,60,0,0,1,55.53,105.64,95.83,95.83,0,0,1,47.22,37.71A8,8,0,0,1,250.14,206.7Z"
-                                ></path>
-                                </svg>
-                            </div>
-                            <p class="text-[#0e131b] text-sm font-medium leading-normal nav-link-text">@Localizer["Contacts"]</p>
-                        </a>
+                    }
+                    <a href="@salesLink" class="dashboard-sidebar__nav-link" role="listitem">
+                        <div class="text-[#0e131b] nav-link-icon" data-icon="CurrencyDollar" data-size="24px" data-weight="regular">
+                        <svg class="nav-link-icon-graphic" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                            <path d="M152,120H136V56h8a32,32,0,0,1,32,32,8,8,0,0,0,16,0,48.05,48.05,0,0,0-48-48h-8V24a8,8,0,0,0-16,0V40h-8a48,48,0,0,0,0,96h8v64H104a32,32,0,0,1-32-32,8,8,0,0,0-16,0,48.05,48.05,0,0,0,48,48h16v16a8,8,0,0,0,16,0V216h16a48,48,0,0,0,0-96Zm-40,0a32,32,0,0,1,0-64h8v64Zm40,80H136V136h16a32,32,0,0,1,0,64Z"></path>
+                        </svg>
+                        </div>
+                        <p class="text-[#0e131b] text-sm font-medium leading-normal nav-link-text">@Localizer["Sales"]</p>
+                    </a>
+                    <a href="/contacts" class="dashboard-sidebar__nav-link" role="listitem">
+                        <div class="text-[#0e131b] nav-link-icon" data-icon="Users" data-size="24px" data-weight="regular">
+                        <svg class="nav-link-icon-graphic" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                            <path d="M117.25,157.92a60,60,0,1,0-66.5,0A95.83,95.83,0,0,0,3.53,195.63a8,8,0,1,0,13.4,8.74,80,80,0,0,1,134.14,0,8,8,0,0,0,13.4-8.74A95.83,95.83,0,0,0,117.25,157.92ZM40,108a44,44,0,1,1,44,44A44.05,44.05,0,0,1,40,108Zm210.14,98.7a8,8,0,0,1-11.07-2.33A79.83,79.83,0,0,0,172,168a8,8,0,0,1,0-16,44,44,0,1,0-16.34-84.87,8,8,0,1,1-5.94-14.85,60,60,0,0,1,55.53,105.64,95.83,95.83,0,0,1,47.22,37.71A8,8,0,0,1,250.14,206.7Z"></path>
+                        </svg>
+                        </div>
+                        <p class="text-[#0e131b] text-sm font-medium leading-normal nav-link-text">@Localizer["Contacts"]</p>
+                    </a>
                     </Authorized>
                 </AuthorizeView>
-                <a href="/marketing-campaign-management-interface" class="flex items-center gap-3 px-3 py-2 nav-link">
+                <a href="/marketing-campaign-management-interface" class="dashboard-sidebar__nav-link" role="listitem">
                     <div class="text-[#0e131b] nav-link-icon" data-icon="Megaphone" data-size="24px" data-weight="regular">
-                        <svg class="nav-link-icon-graphic" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
-                        <path
-                            d="M240,120a48.05,48.05,0,0,0-48-48H152.2c-2.91-.17-53.62-3.74-101.91-44.24A16,16,0,0,0,24,40V200a16,16,0,0,0,26.29,12.25c37.77-31.68,77-40.76,93.71-43.3v31.72A16,16,0,0,0,151.12,214l11,7.33A16,16,0,0,0,186.5,212l11.77-44.36A48.07,48.07,0,0,0,240,120ZM40,199.93V40h0c42.81,35.91,86.63,45,104,47.24v65.48C126.65,155,82.84,164.07,40,199.93Zm131,8,0,.11-11-7.33V168h21.6ZM192,152H160V88h32a32,32,0,1,1,0,64Z"
-                        ></path>
-                        </svg>
+                    <svg class="nav-link-icon-graphic" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                        <path d="M240,120a48.05,48.05,0,0,0-48-48H152.2c-2.91-.17-53.62-3.74-101.91-44.24A16,16,0,0,0,24,40V200a16,16,0,0,0,26.29,12.25c37.77-31.68,77-40.76,93.71-43.3v31.72A16,16,0,0,0,151.12,214l11,7.33A16,16,0,0,0,186.5,212l11.77-44.36A48.07,48.07,0,0,0,240,120ZM40,199.93V40h0c42.81,35.91,86.63,45,104,47.24v65.48C126.65,155,82.84,164.07,40,199.93Zm131,8,0,.11-11-7.33V168h21.6ZM192,152H160V88h32a32,32,0,1,1,0,64Z"></path>
+                    </svg>
                     </div>
                     <p class="text-[#0e131b] text-sm font-medium leading-normal nav-link-text">@Localizer["Marketing"]</p>
                 </a>
-                <a href="/customer-support-dashboard" class="flex items-center gap-3 px-3 py-2 nav-link">
+                <a href="/customer-support-dashboard" class="dashboard-sidebar__nav-link" role="listitem">
                     <div class="text-[#0e131b] nav-link-icon" data-icon="Headset" data-size="24px" data-weight="regular">
-                        <svg class="nav-link-icon-graphic" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
-                        <path
-                            d="M201.89,54.66A103.43,103.43,0,0,0,128.79,24H128A104,104,0,0,0,24,128v56a24,24,0,0,0,24,24H64a24,24,0,0,0,24-24V144a24,24,0,0,0-24-24H40.36A88.12,88.12,0,0,1,190.54,65.93,87.39,87.39,0,0,1,215.65,120H192a24,24,0,0,0-24,24v40a24,24,0,0,0,24,24h24a24,24,0,0,1-24,24H136a8,8,0,0,0,0,16h56a40,40,0,0,0,40-40V128A103.41,103.41,0,0,0,201.89,54.66ZM64,136a8,8,0,0,1,8,8v40a8,8,0,0,1-8,8H48a8,8,0,0,1-8-8V136Zm128,56a8,8,0,0,1-8-8V144a8,8,0,0,1,8-8h24v56Z"
-                        ></path>
-                        </svg>
+                    <svg class="nav-link-icon-graphic" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                        <path d="M201.89,54.66A103.43,103.43,0,0,0,128.79,24H128A104,104,0,0,0,24,128v56a24,24,0,0,0,24,24H64a24,24,0,0,0,24-24V144a24,24,0,0,0-24-24H40.36A88.12,88.12,0,0,1,190.54,65.93,87.39,87.39,0,0,1,215.65,120H192a24,24,0,0,0-24,24v40a24,24,0,0,0,24,24h24a24,24,0,0,1-24,24H136a8,8,0,0,0,0,16h56a40,40,0,0,0,40-40V128A103.41,103.41,0,0,0,201.89,54.66ZM64,136a8,8,0,0,1,8,8v40a8,8,0,0,1-8,8H48a8,8,0,0,1-8-8V136Zm128,56a8,8,0,0,1-8-8V144a8,8,0,0,1,8-8h24v56Z"></path>
+                    </svg>
                     </div>
                     <p class="text-[#0e131b] text-sm font-medium leading-normal nav-link-text">@Localizer["Service"]</p>
                 </a>
-                <a href="/reports-page" class="flex items-center gap-3 px-3 py-2 nav-link">
+                <a href="/reports-page" class="dashboard-sidebar__nav-link" role="listitem">
                     <div class="text-[#0e131b] nav-link-icon" data-icon="PresentationChart" data-size="24px" data-weight="regular">
-                        <svg class="nav-link-icon-graphic" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
-                        <path
-                            d="M216,40H136V24a8,8,0,0,0-16,0V40H40A16,16,0,0,0,24,56V176a16,16,0,0,0,16,16H79.36L57.75,219a8,8,0,0,0,12.5,10l29.59-37h56.32l29.59,37a8,8,0,1,0,12.5-10l-21.61-27H216a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40Zm0,136H40V56H216V176ZM104,120v24a8,8,0,0,1-16,0V120a8,8,0,0,1,16,0Zm32-16v40a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Zm32-16v56a8,8,0,0,1-16,0V88a8,8,0,0,1,16,0Z"
-                        ></path>
-                        </svg>
+                    <svg class="nav-link-icon-graphic" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                        <path d="M216,40H136V24a8,8,0,0,0-16,0V40H40A16,16,0,0,0,24,56V176a16,16,0,0,0,16,16H79.36L57.75,219a8,8,0,0,0,12.5,10l29.59-37h56.32l29.59,37a8,8,0,1,0,12.5-10l-21.61-27H216a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40Zm0,136H40V56H216V176ZM104,120v24a8,8,0,0,1-16,0V120a8,8,0,0,1,16,0Zm32-16v40a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Zm32-16v56a8,8,0,0,1-16,0V88a8,8,0,0,1,16,0Z"></path>
+                    </svg>
                     </div>
                     <p class="text-[#0e131b] text-sm font-medium leading-normal nav-link-text">@Localizer["Reports"]</p>
                 </a>
-                <a href="/settings-page" class="flex items-center gap-3 px-3 py-2 nav-link">
+                <a href="/settings-page" class="dashboard-sidebar__nav-link" role="listitem">
                     <div class="text-[#0e131b] nav-link-icon" data-icon="Gear" data-size="24px" data-weight="regular">
-                        <svg class="nav-link-icon-graphic" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
-                        <path
-                            d="M128,80a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Zm88-29.84q.06-2.16,0-4.32l14.92-18.64a8,8,0,0,0,1.48-7.06,107.21,107.21,0,0,0-10.88-26.25,8,8,0,0,0-6-3.93l-23.72-2.64q-1.48-1.56-3-3L186,40.54a8,8,0,0,0-3.94-6,107.71,107.71,0,0,0-26.25-10.87,8,8,0,0,0-7.06,1.49L130.16,40Q128,40,125.84,40L107.2,25.11a8,8,0,0,0-7.06-1.48A107.6,107.6,0,0,0,73.89,34.51a8,8,0,0,0-3.93,6L67.32,64.27q-1.56,1.49-3,3L40.54,70a8,8,0,0,0-6,3.94,107.71,107.71,0,0,0-10.87,26.25,8,8,0,0,0,1.49,7.06L40,125.84Q40,128,40,130.16L25.11,148.8a8,8,0,0,0-1.48,7.06,107.21,107.21,0,0,0,10.88,26.25,8,8,0,0,0,6,3.93l23.72,2.64q1.49,1.56,3,3L70,215.46a8,8,0,0,0,3.94,6,107.71,107.71,0,0,0,26.25,10.87,8,8,0,0,0,7.06-1.49L125.84,216q2.16.06,4.32,0l18.64,14.92a8,8,0,0,0,7.06,1.48,107.21,107.21,0,0,0,26.25-10.88,8,8,0,0,0,3.93-6l2.64-23.72q1.56-1.48,3-3L215.46,186a8,8,0,0,0,6-3.94,107.71,107.71,0,0,0,10.87-26.25,8,8,0,0,0-1.49-7.06Zm-16.1-6.5a73.93,73.93,0,0,1,0,8.68,8,8,0,0,0,1.74,5.48l14.19,17.73a91.57,91.57,0,0,1-6.23,15L187,173.11a8,8,0,0,0-5.1,2.64,74.11,74.11,0,0,1-6.14,6.14,8,8,0,0,0-2.64,5.1l-2.51,22.58a91.32,91.32,0,0,1-15,6.23l-17.74-14.19a8,8,0,0,0-5-1.75h-.48a73.93,73.93,0,0,1-8.68,0,8,8,0,0,0-5.48,1.74L100.45,215.8a91.57,91.57,0,0,1-15-6.23L82.89,187a8,8,0,0,0-2.64-5.1,74.11,74.11,0,0,1-6.14-6.14,8,8,0,0,0-5.1-2.64L46.43,170.6a91.32,91.32,0,0,1-6.23-15l14.19-17.74a8,8,0,0,0,1.74-5.48,73.93,73.93,0,0,1,0-8.68,8,8,0,0,0-1.74-5.48L40.2,100.45a91.57,91.57,0,0,1,6.23-15L69,82.89a8,8,0,0,0,5.1-2.64,74.11,74.11,0,0,1,6.14-6.14A8,8,0,0,0,82.89,69L85.4,46.43a91.32,91.32,0,0,1,15-6.23l17.74,14.19a8,8,0,0,0,5.48,1.74,73.93,73.93,0,0,1,8.68,0,8,8,0,0,0,5.48-1.74L155.55,40.2a91.57,91.57,0,0,1,15,6.23L173.11,69a8,8,0,0,0,2.64,5.1,74.11,74.11,0,0,1,6.14,6.14,8,8,0,0,0,5.1,2.64l22.58,2.51a91.32,91.32,0,0,1,6.23,15l-14.19,17.74A8,8,0,0,0,199.87,123.66Z"
-                        ></path>
-                        </svg>
+                    <svg class="nav-link-icon-graphic" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                        <path d="M128,80a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Zm88-29.84q.06-2.16,0-4.32l14.92-18.64a8,8,0,0,0,1.48-7.06,107.21,107.21,0,0,0-10.88-26.25,8,8,0,0,0-6-3.93l-23.72-2.64q-1.48-1.56-3-3L186,40.54a8,8,0,0,0-3.94-6,107.71,107.71,0,0,0-26.25-10.87,8,8,0,0,0-7.06,1.49L130.16,40Q128,40,125.84,40L107.2,25.11a8,8,0,0,0-7.06-1.48A107.6,107.6,0,0,0,73.89,34.51a8,8,0,0,0-3.93,6L67.32,64.27q-1.56,1.49-3,3L40.54,70a8,8,0,0,0-6,3.94,107.71,107.71,0,0,0-10.87,26.25,8,8,0,0,0,1.49,7.06L40,125.84Q40,128,40,130.16L25.11,148.8a8,8,0,0,0-1.48,7.06,107.21,107.21,0,0,0,10.88,26.25,8,8,0,0,0,6,3.93l23.72,2.64q1.49,1.56,3,3L70,215.46a8,8,0,0,0,3.94,6,107.71,107.71,0,0,0,26.25,10.87,8,8,0,0,0,7.06-1.49L125.84,216q2.16.06,4.32,0l18.64,14.92a8,8,0,0,0,7.06,1.48,107.21,107.21,0,0,0,26.25-10.88,8,8,0,0,0,3.93-6l2.64-23.72q1.56-1.48,3-3L215.46,186a8,8,0,0,0,6-3.94,107.71,107.71,0,0,0,10.87-26.25,8,8,0,0,0-1.49-7.06Zm-16.1-6.5a73.93,73.93,0,0,1,0,8.68,8,8,0,0,0,1.74,5.48l14.19,17.73a91.57,91.57,0,0,1-6.23,15L187,173.11a8,8,0,0,0-5.1,2.64,74.11,74.11,0,0,1-6.14,6.14,8,8,0,0,0-2.64,5.1l-2.51,22.58a91.32,91.32,0,0,1-15,6.23l-17.74-14.19a8,8,0,0,0-5-1.75h-.48a73.93,73.93,0,0,1-8.68,0,8,8,0,0,0-5.48,1.74L100.45,215.8a91.57,91.57,0,0,1-15-6.23L82.89,187a8,8,0,0,0-2.64-5.1,74.11,74.11,0,0,1-6.14-6.14,8,8,0,0,0-5.1-2.64L46.43,170.6a91.32,91.32,0,0,1-6.23-15l14.19-17.74a8,8,0,0,0,1.74-5.48,73.93,73.93,0,0,1,0-8.68,8,8,0,0,0-1.74-5.48L40.2,100.45a91.57,91.57,0,0,1,6.23-15L69,82.89a8,8,0,0,0,5.1-2.64,74.11,74.11,0,0,1,6.14-6.14A8,8,0,0,0,82.89,69L85.4,46.43a91.32,91.32,0,0,1,15-6.23l17.74,14.19a8,8,0,0,0,5.48,1.74,73.93,73.93,0,0,1,8.68,0,8,8,0,0,0,5.48-1.74L155.55,40.2a91.57,91.57,0,0,1,15,6.23L173.11,69a8,8,0,0,0,2.64,5.1,74.11,74.11,0,0,1,6.14,6.14,8,8,0,0,0,5.1,2.64l22.58,2.51a91.32,91.32,0,0,1,6.23,15l-14.19,17.74A8,8,0,0,0,199.87,123.66Z"></path>
+                    </svg>
                     </div>
                     <p class="text-[#0e131b] text-sm font-medium leading-normal nav-link-text">@Localizer["Settings"]</p>
                 </a>
+                </div>
             </div>
-            </div>
-        </div>
-        </div>
-        <div class="layout-content-container flex flex-col max-w-[960px] flex-1 dashboard-main-content">
+            </nav>
+        </aside>
+        <main id="mainDashboardContent" class="dashboard-main-content" tabindex="-1">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-10 py-3 dashboard-header dashboard-top-nav">
             <div class="flex items-center gap-4 text-[#0e131b]">
             <div class="size-4">
@@ -553,13 +543,10 @@
                 <div class="h-full flex-1"><div class="border-[#4d6a99] bg-[#e7ecf3] border-r-2 h-full" style="width: 30%;"></div></div>
                 <p class="text-[#4d6a99] text-[13px] font-bold leading-normal tracking-[0.015em]">@Localizer["EmailCampaign"]</p>
                 <div class="h-full flex-1"><div class="border-[#4d6a99] bg-[#e7ecf3] border-r-2 h-full" style="width: 60%;"></div></div>
-            </div>
-            </div>
-        </div>
+        </main>
         </div>
     </div>
-    </div>
-    
+
     <!-- Mobile Quick Actions Floating Button -->
     <NexaCRM.WebClient.Components.UI.FloatingActionButton 
         ShowCallAction="true" 

--- a/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor.css
@@ -1,3 +1,194 @@
+:root {
+    --dashboard-shell-max-mobile: 100%;
+    --dashboard-shell-max-tablet: 62rem;
+    --dashboard-shell-max-desktop: 78rem;
+    --dashboard-sidebar-width: 19rem;
+    --dashboard-gap: 1.75rem;
+    --dashboard-surface: #f8fafc;
+    --dashboard-border: rgba(208, 217, 231, 0.65);
+    --dashboard-focus-ring: #6366f1;
+    --dashboard-main-surface: #ffffff;
+    --dashboard-main-shadow: 0 24px 56px rgba(15, 23, 42, 0.08);
+    --dashboard-panel-shadow: 0 26px 48px rgba(15, 23, 42, 0.08);
+}
+
+.dashboard-skip-link {
+    position: absolute;
+    top: -999px;
+    left: -999px;
+    z-index: 2000;
+    padding: 0.75rem 1.25rem;
+    background-color: #0f172a;
+    color: #f8fafc;
+    border-radius: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    box-shadow: 0 14px 30px rgba(15, 23, 42, 0.2);
+    transition: transform 0.3s ease, top 0.3s ease, left 0.3s ease;
+}
+
+.dashboard-skip-link:focus-visible {
+    top: 1.25rem;
+    left: 1.5rem;
+    outline: 3px solid var(--dashboard-focus-ring);
+    outline-offset: 3px;
+}
+
+.dashboard-container {
+    width: min(100%, var(--dashboard-shell-max-mobile));
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    padding: 1.75rem 1.25rem 4.5rem;
+    transition: padding 0.25s ease;
+}
+
+.dashboard-sidebar {
+    display: none;
+}
+
+.dashboard-sidebar__panel {
+    background-color: var(--dashboard-surface);
+    border-radius: 1.5rem;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    border: 1px solid var(--dashboard-border);
+    box-shadow: var(--dashboard-panel-shadow);
+    min-height: 100%;
+}
+
+.dashboard-sidebar__brand {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.dashboard-sidebar__links {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.dashboard-sidebar__home {
+    margin-bottom: 0.75rem;
+}
+
+.dashboard-sidebar__nav-link {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+    padding: 0.75rem 0.9rem;
+    border-radius: 0.85rem;
+    color: #0e131b;
+    text-decoration: none;
+    transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.dashboard-sidebar__nav-link p {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 500;
+}
+
+.dashboard-sidebar__nav-link:hover,
+.dashboard-sidebar__nav-link:focus-visible {
+    background-color: rgba(231, 236, 243, 0.9);
+    color: #0e131b;
+    outline: none;
+    transform: translateX(2px);
+}
+
+.dashboard-sidebar__nav-link:focus-visible {
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.35);
+}
+
+.dashboard-main-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    padding: 1rem 0 3.5rem;
+    min-height: 100%;
+}
+
+.dashboard-main-content:focus-visible {
+    outline: 3px solid var(--dashboard-focus-ring);
+    outline-offset: 4px;
+}
+
+@media (max-width: 767px) {
+    .dashboard-main-content {
+        padding-top: 70px;
+    }
+}
+
+@media (min-width: 768px) {
+    .dashboard-container {
+        width: min(100%, var(--dashboard-shell-max-tablet));
+        display: grid;
+        grid-template-columns: minmax(0, var(--dashboard-sidebar-width)) minmax(0, 1fr);
+        gap: var(--dashboard-gap);
+        align-items: start;
+        padding: 2.5rem 2rem 5rem;
+    }
+
+    .dashboard-sidebar {
+        display: block;
+        position: sticky;
+        top: 1.75rem;
+        height: fit-content;
+    }
+
+    .mobile-header,
+    .mobile-quick-actions,
+    .mobile-notifications-panel {
+        display: none !important;
+        visibility: hidden !important;
+        opacity: 0 !important;
+    }
+
+    .dashboard-main-content {
+        background-color: var(--dashboard-main-surface);
+        border-radius: 1.5rem;
+        padding: 2.25rem 2.25rem 3rem;
+        box-shadow: var(--dashboard-main-shadow);
+        border: 1px solid var(--dashboard-border);
+    }
+}
+
+@media (min-width: 1200px) {
+    .dashboard-container {
+        width: min(100%, var(--dashboard-shell-max-desktop));
+        padding-inline: 3rem;
+    }
+
+    .dashboard-sidebar {
+        top: 2rem;
+    }
+
+    .dashboard-main-content {
+        padding: 2.75rem 3rem 3.25rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .dashboard-skip-link,
+    .dashboard-sidebar__nav-link,
+    .dashboard-button,
+    .mobile-header,
+    .mobile-quick-actions {
+        transition-duration: 0.01ms !important;
+        transition-property: none !important;
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+    }
+}
+
 /* Dashboard base styling */
 .nav-link {
     color: #0e131b;
@@ -20,10 +211,6 @@
 
 .nav-link-text {
     margin: 0;
-}
-
-.dashboard-main-content {
-    padding-top: 70px;
 }
 
 .dashboard-button {
@@ -78,193 +265,117 @@
     color: #0e131b;
 }
 
-/* 다크 모드에서 텍스트 색상 수정 */
-[data-theme="dark"] .text-\[#0e131b\] {
-    color: #ffffff !important;
-}
-
-[data-theme="dark"] .text-\[#4d6a99\] {
-    color: #b0b0b0 !important;
-}
-
-/* 다크 모드에서 아이콘 색상 수정 */
-[data-theme="dark"] .text-\[#0e131b\][data-icon] {
-    color: #ffffff !important;
-}
-
-/* 다크 모드에서 배경과 텍스트 조합 */
-[data-theme="dark"] .bg-\[#e7ecf3\] {
-    background-color: #374151 !important;
-}
-
-[data-theme="dark"] .bg-\[#e7ecf3\].text-\[#0e131b\] {
-    background-color: #374151 !important;
-    color: #ffffff !important;
-}
-
-[data-theme="dark"] .bg-\[#e7ecf3\].text-\[#4d6a99\] {
-    background-color: #374151 !important;
-    color: #d1d5db !important;
-}
-
-/* 다크 모드에서 플레이스홀더 텍스트 색상 */
-[data-theme="dark"] .placeholder\:text-\[#4d6a99\]::placeholder {
-    color: #9ca3af !important;
-}
-
-/* 다크 모드에서 사이드바 배경 */
-[data-theme="dark"] .bg-slate-50 {
-    background-color: #1f2937 !important;
-}
-
-/* 다크 모드에서 메인 컨테이너 배경 */
-[data-theme="dark"] .group\/design-root.bg-slate-50 {
+/* 다크 모드 토큰 및 보조 스타일 */
+[data-theme="dark"] .group\/design-root {
+    --dashboard-surface: #1f2937;
+    --dashboard-border: rgba(75, 85, 99, 0.65);
+    --dashboard-focus-ring: #a5b4fc;
+    --dashboard-main-surface: #0f172a;
+    --dashboard-main-shadow: 0 28px 60px rgba(0, 0, 0, 0.5);
+    --dashboard-panel-shadow: 0 26px 52px rgba(0, 0, 0, 0.55);
     background-color: #111827 !important;
 }
 
-/* 다크 모드에서 대시보드 카드 배경과 텍스트 */
-[data-theme="dark"] .dashboard-card {
-    background-color: #374151 !important;
-    border-color: #4b5563 !important;
-    color: #ffffff !important;
+[data-theme="dark"] .group\/design-root .text-\[#0e131b\] {
+    color: #f8fafc !important;
 }
 
-[data-theme="dark"] .dashboard-card .text-\[#0e131b\] {
-    color: #ffffff !important;
+[data-theme="dark"] .group\/design-root .text-\[#4d6a99\] {
+    color: #d1d5db !important;
 }
 
-[data-theme="dark"] .dashboard-card h2 {
-    color: #ffffff !important;
+[data-theme="dark"] .group\/design-root .nav-link-icon,
+[data-theme="dark"] .group\/design-root .nav-link-icon-graphic,
+[data-theme="dark"] .group\/design-root .nav-link-text {
+    color: #f8fafc !important;
+    fill: currentColor !important;
 }
 
-[data-theme="dark"] .dashboard-card span {
-    color: #ffffff !important;
+[data-theme="dark"] .group\/design-root .dashboard-sidebar__nav-link {
+    color: #f8fafc !important;
 }
 
-/* 다크 모드에서 모든 버튼과 링크 텍스트 */
-[data-theme="dark"] button {
-    color: #ffffff !important;
+[data-theme="dark"] .group\/design-root .dashboard-sidebar__nav-link:hover,
+[data-theme="dark"] .group\/design-root .dashboard-sidebar__nav-link:focus-visible {
+    background-color: #2f3a4f !important;
+    color: #f8fafc !important;
 }
 
-[data-theme="dark"] button .text-\[#0e131b\] {
-    color: #ffffff !important;
-}
-
-[data-theme="dark"] button h2 {
-    color: #ffffff !important;
-}
-
-[data-theme="dark"] .bg-slate-50 {
+[data-theme="dark"] .group\/design-root .bg-\[#e7ecf3\] {
     background-color: #374151 !important;
 }
 
-/* 다크 모드에서 헤더 배경과 텍스트 */
-[data-theme="dark"] .dashboard-header {
+[data-theme="dark"] .group\/design-root .bg-\[#e7ecf3\] .text-\[#0e131b\] {
+    color: #f8fafc !important;
+}
+
+[data-theme="dark"] .group\/design-root .placeholder\:text-\[#4d6a99\]::placeholder {
+    color: #9ca3af !important;
+}
+
+[data-theme="dark"] .group\/design-root .bg-slate-50 {
+    background-color: #1f2937 !important;
+}
+
+[data-theme="dark"] .group\/design-root .dashboard-skip-link {
+    background-color: #312e81 !important;
+    color: #f8fafc !important;
+}
+
+[data-theme="dark"] .group\/design-root .dashboard-header {
     background-color: #1f2937 !important;
     border-color: #374151 !important;
 }
 
-[data-theme="dark"] .dashboard-header .text-\[#0e131b\] {
-    color: #ffffff !important;
-}
-
-/* 다크 모드에서 버튼 색상 */
-[data-theme="dark"] .dashboard-button {
+[data-theme="dark"] .group\/design-root .dashboard-button,
+[data-theme="dark"] .group\/design-root .priority-button {
     background-color: #374151 !important;
-    color: #ffffff !important;
+    color: #f8fafc !important;
 }
 
-[data-theme="dark"] .dashboard-button:hover {
+[data-theme="dark"] .group\/design-root .dashboard-button:hover,
+[data-theme="dark"] .group\/design-root .dashboard-button:focus-visible {
     background-color: #4b5563 !important;
 }
 
-/* 다크 모드에서 입력 필드 */
-[data-theme="dark"] .form-input {
-    background-color: #374151 !important;
-    color: #ffffff !important;
+[data-theme="dark"] .group\/design-root .priority-button {
     border-color: #4b5563 !important;
 }
 
-[data-theme="dark"] .form-input:focus {
+[data-theme="dark"] .group\/design-root .form-input {
+    background-color: #374151 !important;
+    border-color: #4b5563 !important;
+    color: #f8fafc !important;
+}
+
+[data-theme="dark"] .group\/design-root .form-input:focus {
     border-color: #6b7280 !important;
 }
 
-/* 다크 모드에서 웰컴 텍스트 */
-[data-theme="dark"] .dashboard-welcome {
-    color: #ffffff !important;
-}
-
-/* 다크 모드에서 네비게이션 링크 */
-[data-theme="dark"] a .text-\[#0e131b\] {
-    color: #ffffff !important;
-}
-
-/* 다크 모드에서 선택된 네비게이션 아이템 */
-[data-theme="dark"] .bg-\[#e7ecf3\] {
-    background-color: #374151 !important;
-}
-
-[data-theme="dark"] .bg-\[#e7ecf3\] .text-\[#0e131b\] {
-    color: #ffffff !important;
-}
-
-/* 다크 모드에서 제목과 헤딩 */
-[data-theme="dark"] h1.text-\[#0e131b\] {
-    color: #ffffff !important;
-}
-
-[data-theme="dark"] h2.text-\[#0e131b\] {
-    color: #ffffff !important;
-}
-
-[data-theme="dark"] h3.text-\[#0e131b\] {
-    color: #ffffff !important;
-}
-
-/* 다크 모드에서 단락 텍스트 */
-[data-theme="dark"] p.text-\[#0e131b\] {
-    color: #ffffff !important;
-}
-
-[data-theme="dark"] p.text-\[#4d6a99\] {
-    color: #d1d5db !important;
-}
-
-/* 다크 모드에서 테이블과 그리드 */
-[data-theme="dark"] .dashboard-grid .text-\[#0e131b\] {
-    color: #ffffff !important;
-}
-
-/* 다크 모드에서 모든 div 요소의 텍스트 색상 */
-[data-theme="dark"] div.text-\[#0e131b\] {
-    color: #ffffff !important;
-}
-
-[data-theme="dark"] div.text-\[#4d6a99\] {
-    color: #d1d5db !important;
-}
-
-/* 다크 모드에서 스팬 요소 */
-[data-theme="dark"] span.text-\[#0e131b\] {
-    color: #ffffff !important;
-}
-
-[data-theme="dark"] span.text-\[#4d6a99\] {
-    color: #d1d5db !important;
-}
-
-/* 다크 모드에서 보더 색상 */
-[data-theme="dark"] .border-\[#d0d9e7\] {
+[data-theme="dark"] .group\/design-root .dashboard-table-container {
     border-color: #4b5563 !important;
 }
 
-[data-theme="dark"] .border-b-\[#e7ecf3\] {
+[data-theme="dark"] .group\/design-root .dashboard-table-container th,
+[data-theme="dark"] .group\/design-root .dashboard-table-container td {
+    color: #f8fafc !important;
+    border-color: #4b5563 !important;
+}
+
+[data-theme="dark"] .group\/design-root .dashboard-table-container .text-\[#4d6a99\] {
+    color: #d1d5db !important;
+}
+
+[data-theme="dark"] .group\/design-root .border-\[#d0d9e7\] {
+    border-color: #4b5563 !important;
+}
+
+[data-theme="dark"] .group\/design-root .border-b-\[#e7ecf3\] {
     border-bottom-color: #374151 !important;
 }
 
-/* 다크 모드에서 사용자 아바타 영역 주변 요소들 */
-[data-theme="dark"] .dashboard-header div {
-    color: #ffffff !important;
+[data-theme="dark"] .group\/design-root button {
+    color: #f8fafc !important;
 }
 
 /* 모바일 헤더 기본 스타일 */
@@ -367,144 +478,8 @@
     .dashboard-main-content {
         width: 100%;
         max-width: 100%;
-        padding-top: 70px;
-    }
-}
-
-/* 반응형 다크 모드 지원 */
-@media (max-width: 768px) {
-    [data-theme="dark"] .mobile-header {
-        background-color: #1f2937;
-        border-bottom-color: #374151;
     }
 
-    [data-theme="dark"] .mobile-header .mobile-title,
-    [data-theme="dark"] .mobile-header button {
-        color: #ffffff;
-    }
-    
-    /* 다크 모드에서 대시보드 카드 버튼 텍스트 */
-    [data-theme="dark"] .dashboard-card {
-        background-color: #374151 !important;
-        border-color: #4b5563 !important;
-        color: #ffffff !important;
-    }
-    
-    [data-theme="dark"] .dashboard-card h2 {
-        color: #ffffff !important;
-    }
-    
-    [data-theme="dark"] .dashboard-card svg {
-        color: #ffffff !important;
-    }
-    
-    /* 다크 모드에서 모든 버튼 텍스트 */
-    [data-theme="dark"] button .text-\[#0e131b\] {
-        color: #ffffff !important;
-    }
-    
-    [data-theme="dark"] .bg-slate-50 {
-        background-color: #374151 !important;
-    }
-    
-    /* 다크 모드에서 우선순위 버튼 */
-    [data-theme="dark"] .priority-button {
-        background-color: #374151 !important;
-        color: #ffffff !important;
-        border-color: #4b5563 !important;
-    }
-    
-    [data-theme="dark"] .priority-button span {
-        color: #ffffff !important;
-    }
-    
-    /* 다크 모드에서 테이블 스타일 */
-    [data-theme="dark"] .dashboard-table-container {
-        background-color: #374151 !important;
-        border-color: #4b5563 !important;
-    }
-    
-    [data-theme="dark"] .dashboard-table-container table {
-        background-color: #374151 !important;
-    }
-    
-    [data-theme="dark"] .dashboard-table-container th {
-        background-color: #374151 !important;
-        color: #ffffff !important;
-    }
-    
-    [data-theme="dark"] .dashboard-table-container td {
-        background-color: #374151 !important;
-        color: #ffffff !important;
-        border-color: #4b5563 !important;
-    }
-    
-    [data-theme="dark"] .dashboard-table-container .text-\[#4d6a99\] {
-        color: #d1d5db !important;
-    }
-    
-    /* 다크 모드에서 사이드바 네비게이션 링크 */
-    [data-theme="dark"] .dashboard-sidebar {
-        background-color: #1f2937 !important;
-    }
-    
-    [data-theme="dark"] .dashboard-sidebar a {
-        color: #ffffff !important;
-    }
-    
-    [data-theme="dark"] .dashboard-sidebar a p {
-        color: #ffffff !important;
-    }
-    
-    [data-theme="dark"] .dashboard-sidebar a .text-\[#0e131b\] {
-        color: #ffffff !important;
-    }
-    
-    [data-theme="dark"] .dashboard-sidebar a div[data-icon] {
-        color: #ffffff !important;
-    }
-    
-    [data-theme="dark"] .dashboard-sidebar a svg {
-        color: #ffffff !important;
-    }
-    
-    [data-theme="dark"] .dashboard-sidebar a:hover {
-        background-color: #374151 !important;
-    }
-    
-    [data-theme="dark"] .dashboard-sidebar .bg-\[#e7ecf3\] {
-        background-color: #374151 !important;
-    }
-    
-    /* 더 강력한 다크 모드 텍스트 색상 적용 */
-    [data-theme="dark"] .dashboard-sidebar * {
-        color: #ffffff !important;
-    }
-    
-    /* 네비게이션 링크 다크 모드 강화 */
-    [data-theme="dark"] .nav-link {
-        color: #ffffff !important;
-    }
-    
-    [data-theme="dark"] .nav-link * {
-        color: #ffffff !important;
-        fill: #ffffff !important;
-    }
-    
-    [data-theme="dark"] .nav-link p {
-        color: #ffffff !important;
-    }
-    
-    [data-theme="dark"] .nav-link div {
-        color: #ffffff !important;
-    }
-    
-    [data-theme="dark"] .nav-link svg {
-        color: #ffffff !important;
-        fill: #ffffff !important;
-    }
-    
-    /* 모바일에서 대시보드 섹션 표시 */
     .dashboard-grid {
         grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
         gap: 0.75rem;
@@ -534,3 +509,17 @@
         min-height: 120px;
     }
 }
+
+/* 반응형 다크 모드 지원 */
+@media (max-width: 768px) {
+    [data-theme="dark"] .mobile-header {
+        background-color: #1f2937;
+        border-bottom-color: #374151;
+    }
+
+    [data-theme="dark"] .mobile-header .mobile-title,
+    [data-theme="dark"] .mobile-header button {
+        color: #ffffff;
+    }
+}
+

--- a/src/Web/NexaCRM.WebClient/Pages/ReportsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/ReportsPage.razor
@@ -5,65 +5,97 @@
 @inject IStringLocalizer<ReportsPage> Localizer
 @inject IReportService ReportService
 
-<h1 class="text-2xl font-bold mb-4">@Localizer["ReportsTitle"]</h1>
+<ResponsivePage LayoutMode="expanded">
+    <div class="reports-layout">
+        <section class="reports-layout__form" aria-labelledby="reportBuilderTitle">
+            <h1 id="reportBuilderTitle" class="reports-layout__title">@Localizer["ReportsTitle"]</h1>
+            <EditForm Model="currentDefinition" class="reports-form">
+                <div class="reports-field">
+                    <label class="reports-field__label" for="reportNameInput">@Localizer["ReportName"]</label>
+                    <InputText id="reportNameInput" @bind-Value="currentDefinition.Name" class="form-input reports-input" />
+                </div>
 
-<EditForm Model="currentDefinition">
-    <InputText @bind-Value="currentDefinition.Name" placeholder='@Localizer["ReportName"]' class="form-input mb-2" />
-    <div class="report-form-row mb-2">
-        <InputText @bind-Value="newField" placeholder='@Localizer["Field"]' class="form-input flex-1" />
-        <button type="button" class="px-2 py-1 bg-[#e7ecf3] rounded" @onclick="AddField">@Localizer["Add"]</button>
-    </div>
-    <ul class="mb-2">
-        @foreach (var field in currentDefinition.SelectedFields)
-        {
-            <li>@field</li>
-        }
-    </ul>
-    <div class="report-form-row mb-2">
-        <InputText @bind-Value="filterKey" placeholder='@Localizer["FilterKey"]' class="form-input flex-1" />
-        <InputText @bind-Value="filterValue" placeholder='@Localizer["FilterValue"]' class="form-input flex-1" />
-        <button type="button" class="px-2 py-1 bg-[#e7ecf3] rounded" @onclick="AddFilter">@Localizer["Add"]</button>
-    </div>
-    <ul class="mb-2">
-        @foreach (var filter in currentDefinition.Filters)
-        {
-            <li>@filter.Key: @filter.Value</li>
-        }
-    </ul>
-    <div class="report-actions mb-4">
-        <button type="button" class="px-3 py-1 bg-[#e7ecf3] rounded" @onclick="SaveDefinition">@Localizer["SaveDefinition"]</button>
-        <button type="button" class="px-3 py-1 bg-[#e7ecf3] rounded" @onclick="GenerateReport">@Localizer["GenerateReport"]</button>
-    </div>
-</EditForm>
+                <div class="reports-field reports-field--row">
+                    <label class="reports-field__label" for="newFieldInput">@Localizer["Field"]</label>
+                    <div class="reports-field__controls">
+                        <InputText id="newFieldInput" @bind-Value="newField" class="form-input reports-input" />
+                        <button type="button" class="reports-chip-button" @onclick="AddField">@Localizer["Add"]</button>
+                    </div>
+                </div>
 
-<h2 class="text-xl font-bold mb-2">@Localizer["SavedReports"]</h2>
-<ul class="mb-4">
-    @foreach (var def in savedDefinitions)
-    {
-        <li><button class="underline" @onclick="() => LoadDefinition(def)">@def.Name</button></li>
-    }
-</ul>
-
-<h2 class="text-xl font-bold mb-2">@Localizer["Preview"]</h2>
-@if (preview != null)
-{
-    <div class="report-preview">
-        <h3 class="font-bold mb-2">@preview.Title</h3>
-        <div class="report-table-container">
-            <table class="table-auto border-collapse w-full">
-                <thead>
-                    <tr><th class="border px-2">Field</th><th class="border px-2">Value</th></tr>
-                </thead>
-                <tbody>
-                    @foreach (var item in preview.Data)
+                <ul class="reports-token-list" aria-live="polite">
+                    @foreach (var field in currentDefinition.SelectedFields)
                     {
-                        <tr><td class="border px-2">@item.Key</td><td class="border px-2">@item.Value</td></tr>
+                        <li class="reports-token-item">@field</li>
                     }
-                </tbody>
-            </table>
-        </div>
+                </ul>
+
+                <div class="reports-field reports-field--filters">
+                    <div class="reports-field__group">
+                        <label class="reports-field__label" for="filterKeyInput">@Localizer["FilterKey"]</label>
+                        <InputText id="filterKeyInput" @bind-Value="filterKey" class="form-input reports-input" />
+                    </div>
+                    <div class="reports-field__group">
+                        <label class="reports-field__label" for="filterValueInput">@Localizer["FilterValue"]</label>
+                        <InputText id="filterValueInput" @bind-Value="filterValue" class="form-input reports-input" />
+                    </div>
+                    <button type="button" class="reports-chip-button" @onclick="AddFilter">@Localizer["Add"]</button>
+                </div>
+
+                <ul class="reports-token-list reports-token-list--filters" aria-live="polite">
+                    @foreach (var filter in currentDefinition.Filters)
+                    {
+                        <li class="reports-token-item">@filter.Key: @filter.Value</li>
+                    }
+                </ul>
+
+                <div class="reports-form__actions">
+                    <button type="button" class="reports-action" @onclick="SaveDefinition">@Localizer["SaveDefinition"]</button>
+                    <button type="button" class="reports-action reports-action--primary" @onclick="GenerateReport">@Localizer["GenerateReport"]</button>
+                </div>
+            </EditForm>
+        </section>
+
+        <aside class="reports-layout__aside" aria-labelledby="savedReportsTitle">
+            <div class="reports-summary">
+                <h2 id="savedReportsTitle" class="reports-summary__title">@Localizer["SavedReports"]</h2>
+                <ul class="reports-summary__list">
+                    @foreach (var def in savedDefinitions)
+                    {
+                        <li><button class="reports-summary__link" @onclick="() => LoadDefinition(def)">@def.Name</button></li>
+                    }
+                </ul>
+
+                <section class="reports-preview" aria-labelledby="reportPreviewTitle">
+                    <h3 id="reportPreviewTitle" class="reports-preview__title">@Localizer["Preview"]</h3>
+                    @if (preview != null)
+                    {
+                        <div class="reports-preview__content">
+                            <h4 class="reports-preview__heading">@preview.Title</h4>
+                            <div class="reports-preview__table" role="region" aria-live="polite">
+                                <table class="table-auto border-collapse w-full">
+                                    <thead>
+                                        <tr><th class="border px-2">Field</th><th class="border px-2">Value</th></tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (var item in preview.Data)
+                                        {
+                                            <tr><td class="border px-2">@item.Key</td><td class="border px-2">@item.Value</td></tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    }
+                    else
+                    {
+                        <p class="reports-preview__placeholder">@Localizer["ReportsPreviewEmpty"]</p>
+                    }
+                </section>
+            </div>
+        </aside>
     </div>
-}
+</ResponsivePage>
 
 @code {
     private ReportDefinition currentDefinition = new();

--- a/src/Web/NexaCRM.WebClient/Pages/ReportsPage.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/ReportsPage.razor.css
@@ -1,32 +1,293 @@
-/* ReportsPage mobile responsive styles */
+/* Reports page responsive layout */
+.reports-layout {
+    display: grid;
+    gap: clamp(1.5rem, 3vw, 2.25rem);
+}
 
-.report-form-row {
+.reports-layout__form,
+.reports-summary {
+    background-color: #ffffff;
+    border-radius: 1.25rem;
+    border: 1px solid rgba(208, 217, 231, 0.65);
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+    padding: clamp(1.5rem, 4vw, 2.25rem);
+}
+
+.reports-layout__title {
+    margin: 0;
+    font-size: 1.65rem;
+    font-weight: 700;
+    color: #0e131b;
+}
+
+.reports-layout__form {
     display: flex;
-    gap: 0.5rem;
+    flex-direction: column;
+    gap: clamp(1.25rem, 3vw, 1.75rem);
 }
 
-.report-actions {
+.reports-form {
     display: flex;
+    flex-direction: column;
+    gap: clamp(1rem, 3vw, 1.5rem);
+}
+
+.reports-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+}
+
+.reports-field__label {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.reports-input {
+    width: 100%;
+    min-height: 2.75rem;
+}
+
+.reports-field__controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.reports-field__controls > * {
+    flex: 1 1 10rem;
+    min-width: 0;
+}
+
+.reports-field__group {
+    display: flex;
+    flex-direction: column;
     gap: 0.5rem;
+    flex: 1 1 12rem;
 }
 
-.report-table-container {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+.reports-field--filters {
+    gap: 1rem;
 }
 
-@media (max-width: 640px) {
-    .report-form-row,
-    .report-actions {
+.reports-chip-button,
+.reports-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    min-height: 2.75rem;
+    padding: 0.55rem 1.1rem;
+    border-radius: 0.75rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    cursor: pointer;
+    border: 1px solid transparent;
+    background-color: #e7ecf3;
+    color: #0e131b;
+    transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.reports-chip-button:hover,
+.reports-chip-button:focus-visible,
+.reports-action:hover,
+.reports-action:focus-visible {
+    background-color: #d7e2f0;
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.25);
+}
+
+.reports-action {
+    flex: 0 0 auto;
+    min-width: 8.75rem;
+}
+
+.reports-action--primary {
+    background-color: #4f46e5;
+    color: #ffffff;
+}
+
+.reports-action--primary:hover,
+.reports-action--primary:focus-visible {
+    background-color: #4338ca;
+}
+
+.reports-token-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.reports-token-item {
+    background-color: #e7ecf3;
+    color: #0e131b;
+    border-radius: 999px;
+    padding: 0.35rem 0.85rem;
+    font-size: 0.85rem;
+    font-weight: 500;
+}
+
+.reports-form__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: flex-start;
+}
+
+.reports-layout__aside {
+    display: flex;
+}
+
+.reports-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    width: 100%;
+}
+
+.reports-summary__title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #0e131b;
+    margin: 0;
+}
+
+.reports-summary__list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.reports-summary__link {
+    width: 100%;
+    text-align: left;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.65rem;
+    border: 1px solid transparent;
+    background: none;
+    color: #1f2937;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.reports-summary__link:hover,
+.reports-summary__link:focus-visible {
+    background-color: #e7ecf3;
+    color: #111827;
+    outline: none;
+}
+
+.reports-preview {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid rgba(208, 217, 231, 0.6);
+}
+
+.reports-preview__title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #0e131b;
+    margin: 0;
+}
+
+.reports-preview__content {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.reports-preview__heading {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #111827;
+}
+
+.reports-preview__table {
+    max-height: 24rem;
+    overflow: auto;
+    border-radius: 0.85rem;
+    border: 1px solid rgba(208, 217, 231, 0.6);
+}
+
+.reports-preview__table table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.reports-preview__table th,
+.reports-preview__table td {
+    padding: 0.75rem 0.85rem;
+    text-align: left;
+    border-bottom: 1px solid rgba(208, 217, 231, 0.45);
+    font-size: 0.9rem;
+}
+
+.reports-preview__placeholder {
+    margin: 0;
+    font-size: 0.95rem;
+    color: #4b5563;
+    padding: 0.75rem 0.25rem;
+}
+
+@media (min-width: 640px) {
+    .reports-field--row,
+    .reports-field--filters {
+        flex-direction: row;
+        align-items: flex-end;
+    }
+
+    .reports-field--filters {
+        align-items: stretch;
+    }
+
+    .reports-field__controls > * {
+        flex: 1 1 14rem;
+    }
+
+    .reports-form__actions {
+        justify-content: flex-end;
+    }
+}
+
+@media (min-width: 768px) {
+    .reports-layout {
+        grid-template-columns: minmax(0, 1.75fr) minmax(0, 1fr);
+        align-items: start;
+    }
+
+    .reports-form__actions {
+        justify-content: flex-start;
+    }
+}
+
+@media (max-width: 639px) {
+    .reports-form__actions {
         flex-direction: column;
+        align-items: stretch;
     }
 
-    .report-form-row > *,
-    .report-actions > * {
+    .reports-action {
         width: 100%;
     }
+}
 
-    .report-actions button {
-        width: 100%;
+@media (prefers-reduced-motion: reduce) {
+    .reports-chip-button,
+    .reports-action,
+    .reports-summary__link {
+        transition-duration: 0.01ms !important;
+        transition-property: none !important;
     }
 }

--- a/src/Web/NexaCRM.WebClient/Resources/Components/UI/QuickActionsComponent.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Components/UI/QuickActionsComponent.en-US.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="CallCustomer" xml:space="preserve">
+    <value>Call customer</value>
+  </data>
+  <data name="EmailCustomer" xml:space="preserve">
+    <value>Email customer</value>
+  </data>
+  <data name="ScheduleMeeting" xml:space="preserve">
+    <value>Schedule meeting</value>
+  </data>
+  <data name="Call" xml:space="preserve">
+    <value>Call</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="Meeting" xml:space="preserve">
+    <value>Meeting</value>
+  </data>
+  <data name="QuickActionsToastDismiss" xml:space="preserve">
+    <value>Dismiss notification</value>
+  </data>
+  <data name="QuickActionsCancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="QuickActionsCallDialogTitle" xml:space="preserve">
+    <value>Call {0}</value>
+  </data>
+  <data name="QuickActionsCallDialogDescription" xml:space="preserve">
+    <value>Choose how you'd like to reach {0}. We'll open your default calling app.</value>
+  </data>
+  <data name="QuickActionsCallPrimary" xml:space="preserve">
+    <value>Start call</value>
+  </data>
+  <data name="QuickActionsCopyNumber" xml:space="preserve">
+    <value>Copy number</value>
+  </data>
+  <data name="QuickActionsCallLaunched" xml:space="preserve">
+    <value>Calling {0}.</value>
+  </data>
+  <data name="QuickActionsCopySuccess" xml:space="preserve">
+    <value>Phone number copied to clipboard.</value>
+  </data>
+  <data name="QuickActionsEmailSubject" xml:space="preserve">
+    <value>Follow-up with {0}</value>
+  </data>
+  <data name="QuickActionsEmailBody" xml:space="preserve">
+    <value>Hello {0},&#x0a;&#x0a;I wanted to follow up with you regarding...&#x0a;&#x0a;Best regards</value>
+  </data>
+  <data name="QuickActionsEmailClipboardTemplate" xml:space="preserve">
+    <value>To: {0}&#x0a;Subject: {1}&#x0a;&#x0a;{2}</value>
+  </data>
+  <data name="QuickActionsEmailDialogTitle" xml:space="preserve">
+    <value>Email {0}</value>
+  </data>
+  <data name="QuickActionsEmailDialogDescription" xml:space="preserve">
+    <value>Open your email client or copy the prepared template.</value>
+  </data>
+  <data name="QuickActionsEmailPrimary" xml:space="preserve">
+    <value>Compose email</value>
+  </data>
+  <data name="QuickActionsEmailCopy" xml:space="preserve">
+    <value>Copy template</value>
+  </data>
+  <data name="QuickActionsEmailLaunched" xml:space="preserve">
+    <value>Email draft created for {0}.</value>
+  </data>
+  <data name="QuickActionsEmailCopySuccess" xml:space="preserve">
+    <value>Email template copied to clipboard.</value>
+  </data>
+  <data name="QuickActionsMeetingSummary" xml:space="preserve">
+    <value>Meeting with {0}</value>
+  </data>
+  <data name="QuickActionsMeetingDescription" xml:space="preserve">
+    <value>Sales meeting with {0}.</value>
+  </data>
+  <data name="QuickActionsMeetingPrepared" xml:space="preserve">
+    <value>Calendar invite prepared for {0}.</value>
+  </data>
+  <data name="QuickActionsUnknownContact" xml:space="preserve">
+    <value>customer</value>
+  </data>
+</root>

--- a/src/Web/NexaCRM.WebClient/Resources/Components/UI/QuickActionsComponent.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Components/UI/QuickActionsComponent.ko-KR.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="CallCustomer" xml:space="preserve">
+    <value>고객에게 전화하기</value>
+  </data>
+  <data name="EmailCustomer" xml:space="preserve">
+    <value>고객에게 이메일 보내기</value>
+  </data>
+  <data name="ScheduleMeeting" xml:space="preserve">
+    <value>미팅 일정 잡기</value>
+  </data>
+  <data name="Call" xml:space="preserve">
+    <value>전화</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>이메일</value>
+  </data>
+  <data name="Meeting" xml:space="preserve">
+    <value>미팅</value>
+  </data>
+  <data name="QuickActionsToastDismiss" xml:space="preserve">
+    <value>알림 닫기</value>
+  </data>
+  <data name="QuickActionsCancel" xml:space="preserve">
+    <value>취소</value>
+  </data>
+  <data name="QuickActionsCallDialogTitle" xml:space="preserve">
+    <value>{0}에게 전화하기</value>
+  </data>
+  <data name="QuickActionsCallDialogDescription" xml:space="preserve">
+    <value>{0}에게 연결할 방법을 선택하세요. 기본 통화 앱이 열립니다.</value>
+  </data>
+  <data name="QuickActionsCallPrimary" xml:space="preserve">
+    <value>전화 시작</value>
+  </data>
+  <data name="QuickActionsCopyNumber" xml:space="preserve">
+    <value>번호 복사</value>
+  </data>
+  <data name="QuickActionsCallLaunched" xml:space="preserve">
+    <value>{0}에게 전화를 연결합니다.</value>
+  </data>
+  <data name="QuickActionsCopySuccess" xml:space="preserve">
+    <value>전화번호가 클립보드에 복사되었습니다.</value>
+  </data>
+  <data name="QuickActionsEmailSubject" xml:space="preserve">
+    <value>{0}님 후속 연락</value>
+  </data>
+  <data name="QuickActionsEmailBody" xml:space="preserve">
+    <value>{0}님,&#x0a;&#x0a;안부 인사드립니다. 관련하여 다시 연락드리고자 합니다...&#x0a;&#x0a;감사합니다.</value>
+  </data>
+  <data name="QuickActionsEmailClipboardTemplate" xml:space="preserve">
+    <value>받는사람: {0}&#x0a;제목: {1}&#x0a;&#x0a;{2}</value>
+  </data>
+  <data name="QuickActionsEmailDialogTitle" xml:space="preserve">
+    <value>{0}에게 이메일 보내기</value>
+  </data>
+  <data name="QuickActionsEmailDialogDescription" xml:space="preserve">
+    <value>이메일 클라이언트를 열거나 준비된 템플릿을 복사하세요.</value>
+  </data>
+  <data name="QuickActionsEmailPrimary" xml:space="preserve">
+    <value>이메일 작성</value>
+  </data>
+  <data name="QuickActionsEmailCopy" xml:space="preserve">
+    <value>템플릿 복사</value>
+  </data>
+  <data name="QuickActionsEmailLaunched" xml:space="preserve">
+    <value>{0}님을 위한 이메일 초안을 열었습니다.</value>
+  </data>
+  <data name="QuickActionsEmailCopySuccess" xml:space="preserve">
+    <value>이메일 템플릿이 클립보드에 복사되었습니다.</value>
+  </data>
+  <data name="QuickActionsMeetingSummary" xml:space="preserve">
+    <value>{0}과(와)의 미팅</value>
+  </data>
+  <data name="QuickActionsMeetingDescription" xml:space="preserve">
+    <value>{0}과(와)의 영업 미팅.</value>
+  </data>
+  <data name="QuickActionsMeetingPrepared" xml:space="preserve">
+    <value>{0}을(를) 위한 캘린더 초안을 준비했습니다.</value>
+  </data>
+  <data name="QuickActionsUnknownContact" xml:space="preserve">
+    <value>고객</value>
+  </data>
+</root>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/MainDashboard.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/MainDashboard.en-US.resx
@@ -6,6 +6,15 @@
   <data name="AcmeCo" xml:space="preserve">
     <value>Acme Co.</value>
   </data>
+  <data name="SkipToMainContent" xml:space="preserve">
+    <value>Skip to main dashboard content</value>
+  </data>
+  <data name="QuickActionsLabel" xml:space="preserve">
+    <value>Mobile quick actions</value>
+  </data>
+  <data name="PrimaryNavigation" xml:space="preserve">
+    <value>Primary navigation</value>
+  </data>
   <data name="Dashboard" xml:space="preserve">
     <value>Dashboard</value>
   </data>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/MainDashboard.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/MainDashboard.ko-KR.resx
@@ -6,6 +6,15 @@
   <data name="AcmeCo" xml:space="preserve">
     <value>Acme Co.</value>
   </data>
+  <data name="SkipToMainContent" xml:space="preserve">
+    <value>메인 대시보드 콘텐츠로 바로가기</value>
+  </data>
+  <data name="QuickActionsLabel" xml:space="preserve">
+    <value>모바일 퀵 액션</value>
+  </data>
+  <data name="PrimaryNavigation" xml:space="preserve">
+    <value>주 탐색</value>
+  </data>
   <data name="Dashboard" xml:space="preserve">
     <value>대시보드</value>
   </data>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/ReportsPage.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/ReportsPage.en-US.resx
@@ -72,4 +72,7 @@
   <data name="Preview" xml:space="preserve">
     <value>Preview</value>
   </data>
+  <data name="ReportsPreviewEmpty" xml:space="preserve">
+    <value>Select fields and generate the report to see a preview.</value>
+  </data>
 </root>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/ReportsPage.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/ReportsPage.ko-KR.resx
@@ -72,4 +72,7 @@
   <data name="Preview" xml:space="preserve">
     <value>미리보기</value>
   </data>
+  <data name="ReportsPreviewEmpty" xml:space="preserve">
+    <value>필드를 선택하고 보고서를 생성하면 미리보기가 표시됩니다.</value>
+  </data>
 </root>

--- a/src/Web/NexaCRM.WebClient/Shared/ResponsivePage.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/ResponsivePage.razor
@@ -1,13 +1,20 @@
 @using Microsoft.AspNetCore.Components
-<div class="responsive-page">
-    <div class="row">
-        <div class="col-12">
-            @ChildContent
-        </div>
+<div class="responsive-page" data-layout="@LayoutMode">
+    <div class="responsive-page__inner" id="@ElementId" role="@Role">
+        @ChildContent
     </div>
 </div>
 
 @code {
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public string LayoutMode { get; set; } = "constrained";
+
+    [Parameter]
+    public string? ElementId { get; set; }
+
+    [Parameter]
+    public string? Role { get; set; }
 }

--- a/src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css
+++ b/src/Web/NexaCRM.WebClient/wwwroot/css/mobile.css
@@ -338,14 +338,49 @@
 
 /* Responsive page container */
 .responsive-page {
-    padding: 1rem;
+    --responsive-page-max-width: 56rem;
+    --responsive-page-padding-inline: clamp(1.25rem, 4vw, 1.75rem);
+    padding-inline: var(--responsive-page-padding-inline);
+    width: 100%;
+}
+
+.responsive-page__inner {
+    width: min(100%, var(--responsive-page-max-width));
+    margin: 0 auto;
+    padding-block: clamp(1.5rem, 3vw, 2rem);
+}
+
+.responsive-page[data-layout="fluid"] .responsive-page__inner {
+    width: 100%;
+    max-width: none;
+}
+
+.responsive-page[data-layout="expanded"] {
+    --responsive-page-max-width: 68rem;
+}
+
+.responsive-page[data-layout="wide"] {
+    --responsive-page-max-width: 74rem;
 }
 
 @media (min-width: 768px) {
     .responsive-page {
-        max-width: 800px;
-        margin: 0 auto;
-        padding: 2rem;
+        --responsive-page-max-width: 64rem;
+        --responsive-page-padding-inline: clamp(2rem, 5vw, 3rem);
+    }
+
+    .responsive-page__inner {
+        padding-block: clamp(2rem, 3vw, 2.5rem);
+    }
+}
+
+@media (min-width: 1200px) {
+    .responsive-page {
+        --responsive-page-max-width: 76rem;
+    }
+
+    .responsive-page__inner {
+        padding-block: 2.75rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- update the reports page markup and CSS to use the new responsive layout tokens, action styles, and preview placeholder messaging
- scope dashboard dark-mode overrides to CSS variables for the refreshed layout and mobile grid adjustments
- add localized resources, including the ReportsPreviewEmpty string and QuickActions component dialog copy, for English and Korean

## Testing
- `dotnet build --configuration Release` *(fails: `dotnet` CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d2a4823cac832c889d340b3109103b