### PR TITLE
Fix QuickActions clipboard script and close dashboard markup

### DIFF
--- a/src/Web/NexaCRM.WebClient/Components/UI/QuickActionsComponent.razor
+++ b/src/Web/NexaCRM.WebClient/Components/UI/QuickActionsComponent.razor
@@ -319,8 +319,8 @@
                     try {{
                         await navigator.clipboard.writeText(value);
                         return;
-                    }} catch (err) {{}}
-                }
+                    }} catch (err) {{ }}
+                }}
                 const textarea = document.createElement('textarea');
                 textarea.value = value;
                 textarea.setAttribute('readonly', '');

--- a/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor
@@ -533,16 +533,27 @@
         <h2 class="text-[#0e131b] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">@Localizer["LeadSourceAnalytics"]</h2>
         <div class="flex flex-wrap gap-4 px-4 py-6">
             <div class="flex min-w-72 flex-1 flex-col gap-2 rounded-lg border border-[#d0d9e7] p-6">
-            <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["LeadsBySource"]</p>
-            <div class="grid min-h-[180px] gap-x-4 gap-y-6 grid-cols-[auto_1fr] items-center py-3">
-                <p class="text-[#4d6a99] text-[13px] font-bold leading-normal tracking-[0.015em]">@Localizer["Website"]</p>
-                <div class="h-full flex-1"><div class="border-[#4d6a99] bg-[#e7ecf3] border-r-2 h-full" style="width: 100%;"></div></div>
-                <p class="text-[#4d6a99] text-[13px] font-bold leading-normal tracking-[0.015em]">@Localizer["Referral"]</p>
-                <div class="h-full flex-1"><div class="border-[#4d6a99] bg-[#e7ecf3] border-r-2 h-full" style="width: 60%;"></div></div>
-                <p class="text-[#4d6a99] text-[13px] font-bold leading-normal tracking-[0.015em]">@Localizer["SocialMedia"]</p>
-                <div class="h-full flex-1"><div class="border-[#4d6a99] bg-[#e7ecf3] border-r-2 h-full" style="width: 30%;"></div></div>
-                <p class="text-[#4d6a99] text-[13px] font-bold leading-normal tracking-[0.015em]">@Localizer["EmailCampaign"]</p>
-                <div class="h-full flex-1"><div class="border-[#4d6a99] bg-[#e7ecf3] border-r-2 h-full" style="width: 60%;"></div></div>
+                <p class="text-[#0e131b] text-base font-medium leading-normal">@Localizer["LeadsBySource"]</p>
+                <div class="grid min-h-[180px] gap-x-4 gap-y-6 grid-cols-[auto_1fr] items-center py-3">
+                    <p class="text-[#4d6a99] text-[13px] font-bold leading-normal tracking-[0.015em]">@Localizer["Website"]</p>
+                    <div class="h-full flex-1">
+                        <div class="border-[#4d6a99] bg-[#e7ecf3] border-r-2 h-full" style="width: 100%;"></div>
+                    </div>
+                    <p class="text-[#4d6a99] text-[13px] font-bold leading-normal tracking-[0.015em]">@Localizer["Referral"]</p>
+                    <div class="h-full flex-1">
+                        <div class="border-[#4d6a99] bg-[#e7ecf3] border-r-2 h-full" style="width: 60%;"></div>
+                    </div>
+                    <p class="text-[#4d6a99] text-[13px] font-bold leading-normal tracking-[0.015em]">@Localizer["SocialMedia"]</p>
+                    <div class="h-full flex-1">
+                        <div class="border-[#4d6a99] bg-[#e7ecf3] border-r-2 h-full" style="width: 30%;"></div>
+                    </div>
+                    <p class="text-[#4d6a99] text-[13px] font-bold leading-normal tracking-[0.015em]">@Localizer["EmailCampaign"]</p>
+                    <div class="h-full flex-1">
+                        <div class="border-[#4d6a99] bg-[#e7ecf3] border-r-2 h-full" style="width: 60%;"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
         </main>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- escape the QuickActions clipboard JavaScript string properly to avoid Razor parsing errors
- close the lead source analytics markup in MainDashboard.razor and restore consistent indentation

## Testing
- dotnet build --configuration Release
- dotnet test ./tests/BlazorWebApp.Tests --configuration Release

------
https://chatgpt.com/codex/tasks/task_b_68d2c9a7e6f8832ca0b8f7b1f5507348