### PR TITLE
Finalize Supabase service integrations for Phase 2

### DIFF
--- a/src/Web/NexaCRM.WebClient/Models/Supabase/AuditLogRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/AuditLogRecord.cs
@@ -1,0 +1,30 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("audit_logs")]
+public sealed class AuditLogRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("actor_id")]
+    public Guid? ActorId { get; set; }
+
+    [Column("action")]
+    public string Action { get; set; } = string.Empty;
+
+    [Column("entity_type")]
+    public string EntityType { get; set; } = string.Empty;
+
+    [Column("entity_id")]
+    public string? EntityId { get; set; }
+
+    [Column("payload_json")]
+    public string? PayloadJson { get; set; }
+
+    [Column("created_at")]
+    public DateTime? CreatedAt { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/IntegrationEventRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/IntegrationEventRecord.cs
@@ -1,0 +1,27 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("integration_events")]
+public sealed class IntegrationEventRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("event_type")]
+    public string EventType { get; set; } = string.Empty;
+
+    [Column("payload_json")]
+    public string PayloadJson { get; set; } = string.Empty;
+
+    [Column("status")]
+    public string Status { get; set; } = "pending";
+
+    [Column("published_at")]
+    public DateTime? PublishedAt { get; set; }
+
+    [Column("created_at")]
+    public DateTime? CreatedAt { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/NotificationFeedRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/NotificationFeedRecord.cs
@@ -1,0 +1,36 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("notification_feed")]
+public sealed class NotificationFeedRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("user_id")]
+    public Guid UserId { get; set; }
+
+    [Column("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [Column("message")]
+    public string? Message { get; set; }
+
+    [Column("type")]
+    public string Type { get; set; } = "info";
+
+    [Column("is_read")]
+    public bool IsRead { get; set; }
+
+    [Column("metadata")]
+    public string? Metadata { get; set; }
+
+    [Column("created_at")]
+    public DateTime? CreatedAt { get; set; }
+
+    [Column("updated_at")]
+    public DateTime? UpdatedAt { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/SmsRecords.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/SmsRecords.cs
@@ -1,0 +1,136 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("sms_settings")]
+public sealed class SmsSettingsRecord : BaseModel
+{
+    [PrimaryKey("user_id")]
+    public Guid UserId { get; set; }
+
+    [Column("provider_api_key")]
+    public string? ProviderApiKey { get; set; }
+
+    [Column("provider_api_secret")]
+    public string? ProviderApiSecret { get; set; }
+
+    [Column("sender_id")]
+    public string? SenderId { get; set; }
+
+    [Column("default_template")]
+    public string? DefaultTemplate { get; set; }
+
+    [Column("updated_at")]
+    public DateTime? UpdatedAt { get; set; }
+}
+
+[Table("sms_sender_numbers")]
+public sealed class SmsSenderRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public int Id { get; set; }
+
+    [Column("user_id")]
+    public Guid UserId { get; set; }
+
+    [Column("number")]
+    public string Number { get; set; } = string.Empty;
+
+    [Column("label")]
+    public string? Label { get; set; }
+
+    [Column("is_default")]
+    public bool IsDefault { get; set; }
+
+    [Column("created_at")]
+    public DateTime? CreatedAt { get; set; }
+}
+
+[Table("sms_templates")]
+public sealed class SmsTemplateRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public int Id { get; set; }
+
+    [Column("user_id")]
+    public Guid UserId { get; set; }
+
+    [Column("template_code")]
+    public string? TemplateCode { get; set; }
+
+    [Column("content")]
+    public string Content { get; set; } = string.Empty;
+
+    [Column("is_default")]
+    public bool IsDefault { get; set; }
+
+    [Column("created_at")]
+    public DateTime? CreatedAt { get; set; }
+}
+
+[Table("sms_history")]
+public sealed class SmsHistoryRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("user_id")]
+    public Guid UserId { get; set; }
+
+    [Column("recipient")]
+    public string Recipient { get; set; } = string.Empty;
+
+    [Column("message")]
+    public string Message { get; set; } = string.Empty;
+
+    [Column("sent_at")]
+    public DateTime? SentAt { get; set; }
+
+    [Column("status")]
+    public string Status { get; set; } = "Sent";
+
+    [Column("sender_number")]
+    public string? SenderNumber { get; set; }
+
+    [Column("recipient_name")]
+    public string? RecipientName { get; set; }
+
+    [Column("attachments")]
+    public string? AttachmentsJson { get; set; }
+
+    [Column("error_message")]
+    public string? ErrorMessage { get; set; }
+
+    [Column("metadata")]
+    public string? MetadataJson { get; set; }
+}
+
+[Table("sms_schedules")]
+public sealed class SmsScheduleRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("user_id")]
+    public Guid UserId { get; set; }
+
+    [Column("scheduled_at")]
+    public DateTime ScheduledAt { get; set; }
+
+    [Column("payload_json")]
+    public string PayloadJson { get; set; } = string.Empty;
+
+    [Column("is_cancelled")]
+    public bool IsCancelled { get; set; }
+
+    [Column("status")]
+    public string Status { get; set; } = "scheduled";
+
+    [Column("created_at")]
+    public DateTime? CreatedAt { get; set; }
+
+    [Column("dispatched_at")]
+    public DateTime? DispatchedAt { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/SupportTicketRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/SupportTicketRecord.cs
@@ -1,0 +1,54 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("support_tickets")]
+public sealed class SupportTicketRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public int Id { get; set; }
+
+    [Column("subject")]
+    public string? Subject { get; set; }
+
+    [Column("description")]
+    public string? Description { get; set; }
+
+    [Column("status")]
+    public string Status { get; set; } = "Open";
+
+    [Column("priority")]
+    public string Priority { get; set; } = "Medium";
+
+    [Column("customer_id")]
+    public int? CustomerId { get; set; }
+
+    [Column("customer_name")]
+    public string? CustomerName { get; set; }
+
+    [Column("agent_id")]
+    public Guid? AgentId { get; set; }
+
+    [Column("agent_name")]
+    public string? AgentName { get; set; }
+
+    [Column("category")]
+    public string? Category { get; set; }
+
+    [Column("tenant_unit_id")]
+    public long? TenantUnitId { get; set; }
+
+    [Column("created_by")]
+    public Guid? CreatedBy { get; set; }
+
+    [Column("created_at")]
+    public DateTime? CreatedAt { get; set; }
+
+    [Column("updated_at")]
+    public DateTime? UpdatedAt { get; set; }
+
+    [Column("last_reply_at")]
+    public DateTime? LastReplyAt { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/SupportTicket.cs
+++ b/src/Web/NexaCRM.WebClient/Models/SupportTicket.cs
@@ -11,6 +11,7 @@ namespace NexaCRM.WebClient.Models
         public TicketStatus Status { get; set; }
         public TicketPriority Priority { get; set; }
         public string? CustomerName { get; set; }
+        public Guid? AgentId { get; set; }
         public string? AgentName { get; set; }
         public DateTime CreatedAt { get; set; }
         public string? Category { get; set; }

--- a/src/Web/NexaCRM.WebClient/Program.cs
+++ b/src/Web/NexaCRM.WebClient/Program.cs
@@ -55,7 +55,7 @@ builder.Services.AddScoped<AuthenticationStateProvider>(provider => provider.Get
 builder.Services.AddScoped<IContactService, SupabaseContactService>();
 builder.Services.AddScoped<IDealService, SupabaseDealService>();
 builder.Services.AddScoped<ITaskService, SupabaseTaskService>();
-builder.Services.AddScoped<ISupportTicketService, MockSupportTicketService>();
+builder.Services.AddScoped<ISupportTicketService, SupabaseSupportTicketService>();
 builder.Services.AddScoped<IAgentService, MockAgentService>();
 builder.Services.AddScoped<IMarketingCampaignService, MockMarketingCampaignService>();
 builder.Services.AddScoped<IReportService, MockReportService>();
@@ -73,13 +73,13 @@ builder.Services.AddScoped<IDbAdminService, DbAdminService>();
 builder.Services.AddScoped<IStatisticsService, StatisticsService>();
 builder.Services.AddScoped<ICustomerCenterService, CustomerCenterService>();
 builder.Services.AddScoped<INoticeService, NoticeService>();
-builder.Services.AddScoped<ISmsService, SmsService>();
+builder.Services.AddScoped<ISmsService, SupabaseSmsService>();
 builder.Services.AddScoped<ISystemInfoService, SystemInfoService>();
 builder.Services.AddScoped<IFaqService, FaqService>();
 builder.Services.AddScoped<IUserFavoritesService, UserFavoritesService>();
 builder.Services.AddScoped<IEmailTemplateService, MockEmailTemplateService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
-builder.Services.AddScoped<INotificationFeedService, MockNotificationFeedService>();
+builder.Services.AddScoped<INotificationFeedService, SupabaseNotificationFeedService>();
 builder.Services.AddScoped<ITeamService, MockTeamService>();
 
 var culture = new CultureInfo("ko-KR");

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/ISupportTicketService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/ISupportTicketService.cs
@@ -1,3 +1,4 @@
+using System;
 using NexaCRM.WebClient.Models;
 using System.Collections.Generic;
 
@@ -5,6 +6,10 @@ namespace NexaCRM.WebClient.Services.Interfaces
 {
     public interface ISupportTicketService
     {
+        event Action<SupportTicket>? TicketUpserted;
+        event Action<int>? TicketDeleted;
+        event Action<int>? LiveTicketCountChanged;
+
         System.Threading.Tasks.Task<IEnumerable<SupportTicket>> GetTicketsAsync();
         System.Threading.Tasks.Task<SupportTicket?> GetTicketByIdAsync(int id);
         System.Threading.Tasks.Task<IEnumerable<SupportTicket>> GetLiveInteractionsAsync();

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/ITaskService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/ITaskService.cs
@@ -1,3 +1,4 @@
+using System;
 using NexaCRM.WebClient.Models;
 using System.Collections.Generic;
 
@@ -5,6 +6,9 @@ namespace NexaCRM.WebClient.Services.Interfaces
 {
     public interface ITaskService
     {
+        event Action<Models.Task>? TaskUpserted;
+        event Action<int>? TaskDeleted;
+
         System.Threading.Tasks.Task<IEnumerable<Models.Task>> GetTasksAsync();
         System.Threading.Tasks.Task<Models.Task?> GetTaskByIdAsync(int id);
         System.Threading.Tasks.Task CreateTaskAsync(Models.Task task);

--- a/src/Web/NexaCRM.WebClient/Services/Mock/MockTaskService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Mock/MockTaskService.cs
@@ -11,6 +11,9 @@ namespace NexaCRM.WebClient.Services.Mock
     {
         private readonly List<Models.Task> _tasks;
 
+        public event Action<Models.Task>? TaskUpserted;
+        public event Action<int>? TaskDeleted;
+
         public MockTaskService()
         {
             _tasks = new List<Models.Task>
@@ -36,6 +39,7 @@ namespace NexaCRM.WebClient.Services.Mock
         {
             task.Id = _tasks.Max(t => t.Id) + 1;
             _tasks.Add(task);
+            TaskUpserted?.Invoke(task);
             return System.Threading.Tasks.Task.CompletedTask;
         }
 
@@ -50,6 +54,7 @@ namespace NexaCRM.WebClient.Services.Mock
                 existingTask.IsCompleted = task.IsCompleted;
                 existingTask.Priority = task.Priority;
                 existingTask.AssignedTo = task.AssignedTo;
+                TaskUpserted?.Invoke(existingTask);
             }
             return System.Threading.Tasks.Task.CompletedTask;
         }
@@ -60,6 +65,7 @@ namespace NexaCRM.WebClient.Services.Mock
             if (task != null)
             {
                 _tasks.Remove(task);
+                TaskDeleted?.Invoke(id);
             }
             return System.Threading.Tasks.Task.CompletedTask;
         }

--- a/src/Web/NexaCRM.WebClient/Services/SupabaseNotificationFeedService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SupabaseNotificationFeedService.cs
@@ -1,0 +1,387 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NexaCRM.WebClient.Services.Interfaces;
+using NexaCRM.WebClient.Models.Supabase;
+using PostgrestOperator = Supabase.Postgrest.Constants.Operator;
+using PostgrestOrdering = Supabase.Postgrest.Constants.Ordering;
+using RealtimeEventType = Supabase.Realtime.Constants.EventType;
+using RealtimeListenType = Supabase.Realtime.PostgresChanges.PostgresChangesOptions.ListenType;
+using Supabase.Realtime.Interfaces;
+using Supabase.Realtime.PostgresChanges;
+
+namespace NexaCRM.WebClient.Services;
+
+public sealed class SupabaseNotificationFeedService : INotificationFeedService, IAsyncDisposable
+{
+    private readonly SupabaseClientProvider _clientProvider;
+    private readonly ILogger<SupabaseNotificationFeedService> _logger;
+    private readonly Dictionary<Guid, NotificationFeedItem> _cache = new();
+    private readonly object _syncRoot = new();
+    private readonly SemaphoreSlim _subscriptionLock = new(1, 1);
+    private bool _subscriptionInitialized;
+    private IRealtimeChannel? _realtimeChannel;
+    private IRealtimeChannel.PostgresChangesHandler? _changeHandler;
+    private Guid? _userId;
+
+    public event Action<int>? UnreadCountChanged;
+
+    public SupabaseNotificationFeedService(
+        SupabaseClientProvider clientProvider,
+        ILogger<SupabaseNotificationFeedService> logger)
+    {
+        _clientProvider = clientProvider;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<NotificationFeedItem>> GetAsync()
+    {
+        try
+        {
+            await EnsureRealtimeSubscriptionAsync();
+            var client = await _clientProvider.GetClientAsync();
+            var userId = EnsureUserId(client);
+
+            var response = await client.From<NotificationFeedRecord>()
+                .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+                .Order(x => x.CreatedAt, PostgrestOrdering.Descending)
+                .Get();
+
+            var records = response.Models ?? new List<NotificationFeedRecord>();
+            var items = records.Select(MapToItem).ToList();
+
+            lock (_syncRoot)
+            {
+                _cache.Clear();
+                foreach (var item in items)
+                {
+                    _cache[item.Id] = item;
+                }
+            }
+
+            NotifyUnreadCount();
+            return items;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load notification feed from Supabase.");
+            throw;
+        }
+    }
+
+    public async Task<int> GetUnreadCountAsync()
+    {
+        await EnsureRealtimeSubscriptionAsync();
+
+        lock (_syncRoot)
+        {
+            if (_cache.Count > 0)
+            {
+                return _cache.Values.Count(item => !item.IsRead);
+            }
+        }
+
+        var client = await _clientProvider.GetClientAsync();
+        var userId = EnsureUserId(client);
+
+        var response = await client.From<NotificationFeedRecord>()
+            .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+            .Filter(x => x.IsRead, PostgrestOperator.Equals, false)
+            .Get();
+
+        return response.Models.Count;
+    }
+
+    public async Task MarkAllReadAsync()
+    {
+        await EnsureRealtimeSubscriptionAsync();
+
+        List<Guid> unreadIds;
+        lock (_syncRoot)
+        {
+            unreadIds = _cache.Values
+                .Where(item => !item.IsRead)
+                .Select(item => item.Id)
+                .ToList();
+        }
+
+        foreach (var id in unreadIds)
+        {
+            await MarkAsReadAsync(id);
+        }
+    }
+
+    public async Task MarkAsReadAsync(Guid id)
+    {
+        await EnsureRealtimeSubscriptionAsync();
+        var client = await _clientProvider.GetClientAsync();
+        var userId = EnsureUserId(client);
+
+        NotificationFeedItem? item;
+        lock (_syncRoot)
+        {
+            _cache.TryGetValue(id, out item);
+        }
+
+        if (item is null)
+        {
+            var response = await client.From<NotificationFeedRecord>()
+                .Filter(x => x.Id, PostgrestOperator.Equals, id)
+                .Get();
+            var record = response.Models.FirstOrDefault();
+            if (record is null)
+            {
+                return;
+            }
+
+            item = MapToItem(record);
+        }
+
+        if (item.IsRead)
+        {
+            return;
+        }
+
+        var updatedItem = item with { IsRead = true };
+        var updatedRecord = MapToRecord(updatedItem, userId);
+        await client.From<NotificationFeedRecord>()
+            .Filter(x => x.Id, PostgrestOperator.Equals, id)
+            .Update(updatedRecord);
+
+        StoreNotification(updatedItem);
+    }
+
+    public async Task AddAsync(NotificationFeedItem item)
+    {
+        if (item is null)
+        {
+            throw new ArgumentNullException(nameof(item));
+        }
+
+        await EnsureRealtimeSubscriptionAsync();
+        var client = await _clientProvider.GetClientAsync();
+        var userId = EnsureUserId(client);
+        var timestampedItem = item with { TimestampUtc = item.TimestampUtc == default ? DateTime.UtcNow : item.TimestampUtc };
+        var record = MapToRecord(timestampedItem, userId);
+        var response = await client.From<NotificationFeedRecord>().Insert(record);
+        var inserted = response.Models.FirstOrDefault();
+        if (inserted is not null)
+        {
+            StoreNotification(inserted);
+        }
+    }
+
+    private async Task EnsureRealtimeSubscriptionAsync()
+    {
+        if (_subscriptionInitialized)
+        {
+            return;
+        }
+
+        await _subscriptionLock.WaitAsync();
+        try
+        {
+            if (_subscriptionInitialized)
+            {
+                return;
+            }
+
+            var client = await _clientProvider.GetClientAsync();
+            EnsureUserId(client);
+            _changeHandler ??= HandleRealtimeChange;
+            _realtimeChannel = await client.From<NotificationFeedRecord>()
+                .On(RealtimeListenType.All, _changeHandler);
+
+            _subscriptionInitialized = true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to subscribe to Supabase notification realtime channel.");
+        }
+        finally
+        {
+            _subscriptionLock.Release();
+        }
+    }
+
+    private void HandleRealtimeChange(IRealtimeChannel sender, PostgresChangesResponse change)
+    {
+        try
+        {
+            var eventType = change.Payload?.Data?.Type;
+            if (eventType is null)
+            {
+                return;
+            }
+
+            var record = change.Model<NotificationFeedRecord>();
+            var targetUserId = record?.UserId ?? change.OldModel<NotificationFeedRecord>()?.UserId;
+            if (_userId.HasValue && targetUserId.HasValue && targetUserId.Value != _userId.Value)
+            {
+                return;
+            }
+
+            switch (eventType.Value)
+            {
+                case RealtimeEventType.Insert:
+                case RealtimeEventType.Update:
+                    if (record is null)
+                    {
+                        return;
+                    }
+
+                    StoreNotification(record);
+                    break;
+                case RealtimeEventType.Delete:
+                    HandleNotificationDeleted(change);
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to process notification realtime payload.");
+        }
+    }
+
+    private void HandleNotificationDeleted(PostgresChangesResponse change)
+    {
+        var record = change.OldModel<NotificationFeedRecord>();
+        Guid? notificationId = record?.Id;
+
+        if (!notificationId.HasValue)
+        {
+            var rawId = change.Payload?.Data?.Ids?.FirstOrDefault();
+            if (rawId is not null && Guid.TryParse(rawId.ToString(), out var parsedId))
+            {
+                notificationId = parsedId;
+            }
+        }
+
+        if (!notificationId.HasValue)
+        {
+            return;
+        }
+
+        var shouldNotify = false;
+        int currentUnread = 0;
+        lock (_syncRoot)
+        {
+            var previousUnread = _cache.Values.Count(item => !item.IsRead);
+            _cache.Remove(notificationId.Value);
+            currentUnread = _cache.Values.Count(item => !item.IsRead);
+            shouldNotify = previousUnread != currentUnread;
+        }
+
+        if (shouldNotify)
+        {
+            NotifyUnreadCount(currentUnread);
+        }
+    }
+
+    private void StoreNotification(NotificationFeedRecord record) => StoreNotification(MapToItem(record));
+
+    private void StoreNotification(NotificationFeedItem item)
+    {
+        var shouldNotify = false;
+        int currentUnread = 0;
+        lock (_syncRoot)
+        {
+            var previousUnread = _cache.Values.Count(existing => !existing.IsRead);
+            _cache[item.Id] = item;
+            currentUnread = _cache.Values.Count(existing => !existing.IsRead);
+            shouldNotify = previousUnread != currentUnread;
+        }
+
+        if (shouldNotify)
+        {
+            NotifyUnreadCount(currentUnread);
+        }
+    }
+
+    private NotificationFeedRecord MapToRecord(NotificationFeedItem item, Guid userId)
+    {
+        var timestamp = item.TimestampUtc == default ? DateTime.UtcNow : item.TimestampUtc;
+        return new NotificationFeedRecord
+        {
+            Id = item.Id == Guid.Empty ? Guid.NewGuid() : item.Id,
+            UserId = userId,
+            Title = item.Title,
+            Message = item.Message,
+            Type = item.Type,
+            IsRead = item.IsRead,
+            CreatedAt = timestamp,
+            UpdatedAt = timestamp
+        };
+    }
+
+    private static NotificationFeedItem MapToItem(NotificationFeedRecord record)
+    {
+        return new NotificationFeedItem
+        {
+            Id = record.Id,
+            Title = record.Title,
+            Message = record.Message ?? string.Empty,
+            TimestampUtc = record.CreatedAt?.ToUniversalTime() ?? DateTime.UtcNow,
+            IsRead = record.IsRead,
+            Type = record.Type ?? "info"
+        };
+    }
+
+    private void NotifyUnreadCount(int? countOverride = null)
+    {
+        int count;
+        if (countOverride.HasValue)
+        {
+            count = countOverride.Value;
+        }
+        else
+        {
+            lock (_syncRoot)
+            {
+                count = _cache.Values.Count(item => !item.IsRead);
+            }
+        }
+
+        UnreadCountChanged?.Invoke(count);
+    }
+
+    private Guid EnsureUserId(Supabase.Client client)
+    {
+        var rawId = client.Auth.CurrentUser?.Id;
+        if (string.IsNullOrWhiteSpace(rawId) || !Guid.TryParse(rawId, out var parsed))
+        {
+            throw new InvalidOperationException("Supabase user id is required for notifications.");
+        }
+
+        if (!_userId.HasValue || _userId.Value != parsed)
+        {
+            _userId = parsed;
+        }
+
+        return _userId.Value;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (_realtimeChannel is not null && _changeHandler is not null)
+        {
+            try
+            {
+                _realtimeChannel.RemovePostgresChangeHandler(RealtimeListenType.All, _changeHandler);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to remove notification realtime handler.");
+            }
+        }
+
+        _realtimeChannel = null;
+        _changeHandler = null;
+        _subscriptionInitialized = false;
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Services/SupabaseSmsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SupabaseSmsService.cs
@@ -1,0 +1,494 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using NexaCRM.WebClient.Models.Settings;
+using NexaCRM.WebClient.Models.Sms;
+using NexaCRM.WebClient.Models.Supabase;
+using NexaCRM.WebClient.Services.Interfaces;
+using PostgrestOperator = Supabase.Postgrest.Constants.Operator;
+using PostgrestOrdering = Supabase.Postgrest.Constants.Ordering;
+using Supabase.Postgrest.Exceptions;
+
+namespace NexaCRM.WebClient.Services;
+
+public sealed class SupabaseSmsService : ISmsService
+{
+    private readonly SupabaseClientProvider _clientProvider;
+    private readonly ILogger<SupabaseSmsService> _logger;
+
+    public SupabaseSmsService(SupabaseClientProvider clientProvider, ILogger<SupabaseSmsService> logger)
+    {
+        _clientProvider = clientProvider;
+        _logger = logger;
+    }
+
+    public async Task SendBulkAsync(IEnumerable<BulkSmsRequest> batches, IProgress<int>? progress = null)
+    {
+        if (batches is null)
+        {
+            throw new ArgumentNullException(nameof(batches));
+        }
+
+        var batchList = batches.ToList();
+        if (batchList.Count == 0)
+        {
+            progress?.Report(100);
+            return;
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var userId = EnsureUserId(client);
+            var settings = await LoadSettingsAsync(client, userId) ?? new SmsSettings();
+            var defaultSender = settings.SenderNumbers.FirstOrDefault() ?? settings.SenderId ?? string.Empty;
+
+            var historyRecords = new List<SmsHistoryRecord>();
+            var eventPayloads = new List<object>();
+
+            foreach (var (request, index) in batchList.Select((value, idx) => (value, idx)))
+            {
+                foreach (var recipient in request.Recipients)
+                {
+                    historyRecords.Add(new SmsHistoryRecord
+                    {
+                        Id = Guid.NewGuid(),
+                        UserId = userId,
+                        Recipient = recipient,
+                        RecipientName = string.Empty,
+                        Message = request.Message,
+                        SentAt = DateTime.UtcNow,
+                        Status = "Queued",
+                        SenderNumber = defaultSender,
+                        AttachmentsJson = null,
+                        MetadataJson = null
+                    });
+                }
+
+                eventPayloads.Add(new
+                {
+                    Request = request,
+                    RequestedAt = DateTime.UtcNow
+                });
+
+                progress?.Report((index + 1) * 100 / batchList.Count);
+            }
+
+            if (historyRecords.Count > 0)
+            {
+                await client.From<SmsHistoryRecord>().Insert(historyRecords);
+            }
+
+            foreach (var payload in eventPayloads)
+            {
+                await CreateIntegrationEventAsync(client, "sms.dispatch.requested", payload);
+            }
+
+            await CreateAuditLogAsync(client, userId, "sms.send.bulk", JsonConvert.SerializeObject(batchList));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send bulk SMS via Supabase.");
+            throw;
+        }
+    }
+
+    public async Task<IEnumerable<string>> GetSenderNumbersAsync()
+    {
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var userId = EnsureUserId(client);
+
+            var response = await client.From<SmsSenderRecord>()
+                .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+                .Order(x => x.CreatedAt, PostgrestOrdering.Ascending)
+                .Get();
+
+            return response.Models.Select(record => record.Number).ToList();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load SMS sender numbers from Supabase.");
+            throw;
+        }
+    }
+
+    public async Task SaveSenderNumberAsync(string number)
+    {
+        if (string.IsNullOrWhiteSpace(number))
+        {
+            return;
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var userId = EnsureUserId(client);
+
+            var normalized = number.Trim();
+            var existing = await client.From<SmsSenderRecord>()
+                .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+                .Filter(x => x.Number, PostgrestOperator.Equals, normalized)
+                .Get();
+
+            if (existing.Models.Count > 0)
+            {
+                return;
+            }
+
+            var record = new SmsSenderRecord
+            {
+                UserId = userId,
+                Number = normalized,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            await client.From<SmsSenderRecord>().Insert(record);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save SMS sender number to Supabase.");
+            throw;
+        }
+    }
+
+    public async Task DeleteSenderNumberAsync(string number)
+    {
+        if (string.IsNullOrWhiteSpace(number))
+        {
+            return;
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var userId = EnsureUserId(client);
+
+            await client.From<SmsSenderRecord>()
+                .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+                .Filter(x => x.Number, PostgrestOperator.Equals, number.Trim())
+                .Delete();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete SMS sender number from Supabase.");
+            throw;
+        }
+    }
+
+    public async Task<SmsSettings?> GetSettingsAsync()
+    {
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var userId = EnsureUserId(client);
+            return await LoadSettingsAsync(client, userId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load SMS settings from Supabase.");
+            throw;
+        }
+    }
+
+    public async Task SaveSettingsAsync(SmsSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var userId = EnsureUserId(client);
+
+            var record = new SmsSettingsRecord
+            {
+                UserId = userId,
+                ProviderApiKey = settings.ProviderApiKey,
+                ProviderApiSecret = settings.ProviderApiSecret,
+                SenderId = settings.SenderId,
+                DefaultTemplate = settings.DefaultTemplate,
+                UpdatedAt = DateTime.UtcNow
+            };
+
+            await client.From<SmsSettingsRecord>()
+                .Upsert(record);
+
+            var existingNumbers = await client.From<SmsSenderRecord>()
+                .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+                .Get();
+
+            var existingSet = existingNumbers.Models
+                .Select(r => r.Number)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            var desiredNumbers = settings.SenderNumbers
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .Select(n => n.Trim())
+                .Where(n => n.Length > 0)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var number in desiredNumbers)
+            {
+                if (!existingSet.Contains(number))
+                {
+                    await SaveSenderNumberAsync(number);
+                }
+            }
+
+            foreach (var recordNumber in existingNumbers.Models)
+            {
+                if (!desiredNumbers.Contains(recordNumber.Number))
+                {
+                    await client.From<SmsSenderRecord>()
+                        .Filter(x => x.Id, PostgrestOperator.Equals, recordNumber.Id)
+                        .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+                        .Delete();
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save SMS settings to Supabase.");
+            throw;
+        }
+    }
+
+    public async Task<IEnumerable<SmsHistoryItem>> GetHistoryAsync()
+    {
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var userId = EnsureUserId(client);
+
+            var response = await client.From<SmsHistoryRecord>()
+                .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+                .Order(x => x.SentAt, PostgrestOrdering.Descending)
+                .Get();
+
+            return response.Models.Select(MapToHistoryItem).ToList();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load SMS history from Supabase.");
+            throw;
+        }
+    }
+
+    public async Task ScheduleAsync(SmsScheduleItem schedule)
+    {
+        ArgumentNullException.ThrowIfNull(schedule);
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var userId = EnsureUserId(client);
+
+            var record = new SmsScheduleRecord
+            {
+                Id = schedule.Id == Guid.Empty ? Guid.NewGuid() : schedule.Id,
+                UserId = userId,
+                ScheduledAt = schedule.ScheduledAt,
+                PayloadJson = JsonConvert.SerializeObject(schedule.Request),
+                IsCancelled = schedule.IsCancelled,
+                Status = schedule.IsCancelled ? "cancelled" : "scheduled",
+                CreatedAt = DateTime.UtcNow
+            };
+
+            await client.From<SmsScheduleRecord>().Upsert(record);
+
+            await CreateIntegrationEventAsync(client, "sms.schedule.created", new
+            {
+                ScheduleId = record.Id,
+                record.ScheduledAt,
+                schedule.Request
+            });
+
+            await CreateAuditLogAsync(client, userId, "sms.schedule", JsonConvert.SerializeObject(schedule));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to schedule SMS via Supabase.");
+            throw;
+        }
+    }
+
+    public async Task<IEnumerable<SmsScheduleItem>> GetUpcomingSchedulesAsync()
+    {
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var userId = EnsureUserId(client);
+
+            var response = await client.From<SmsScheduleRecord>()
+                .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+                .Filter(x => x.IsCancelled, PostgrestOperator.Equals, false)
+                .Order(x => x.ScheduledAt, PostgrestOrdering.Ascending)
+                .Get();
+
+            return response.Models.Select(MapToScheduleItem).ToList();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load SMS schedules from Supabase.");
+            throw;
+        }
+    }
+
+    public async Task CancelAsync(Guid id)
+    {
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var userId = EnsureUserId(client);
+
+            var record = new SmsScheduleRecord
+            {
+                IsCancelled = true,
+                Status = "cancelled"
+            };
+
+            await client.From<SmsScheduleRecord>()
+                .Filter(x => x.Id, PostgrestOperator.Equals, id)
+                .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+                .Update(record);
+
+            await CreateIntegrationEventAsync(client, "sms.schedule.cancelled", new { ScheduleId = id });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to cancel SMS schedule in Supabase.");
+            throw;
+        }
+    }
+
+    private async Task<SmsSettings?> LoadSettingsAsync(Supabase.Client client, Guid userId)
+    {
+        var response = await client.From<SmsSettingsRecord>()
+            .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+            .Get();
+
+        var record = response.Models.FirstOrDefault();
+        var numbers = await client.From<SmsSenderRecord>()
+            .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+            .Order(x => x.CreatedAt, PostgrestOrdering.Ascending)
+            .Get();
+
+        var settings = record is null
+            ? new SmsSettings()
+            : new SmsSettings
+            {
+                ProviderApiKey = record.ProviderApiKey ?? string.Empty,
+                ProviderApiSecret = record.ProviderApiSecret ?? string.Empty,
+                SenderId = record.SenderId ?? string.Empty,
+                DefaultTemplate = record.DefaultTemplate ?? string.Empty
+            };
+
+        settings.SenderNumbers.Clear();
+        foreach (var number in numbers.Models.Select(r => r.Number))
+        {
+            settings.SenderNumbers.Add(number);
+        }
+
+        var templatesResponse = await client.From<SmsTemplateRecord>()
+            .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+            .Get();
+
+        settings.Templates.Clear();
+        foreach (var template in templatesResponse.Models.Select(t => t.Content))
+        {
+            settings.Templates.Add(template);
+        }
+
+        return settings;
+    }
+
+    private static SmsHistoryItem MapToHistoryItem(SmsHistoryRecord record)
+    {
+        var attachments = string.IsNullOrWhiteSpace(record.AttachmentsJson)
+            ? Array.Empty<SmsAttachment>()
+            : JsonConvert.DeserializeObject<List<SmsAttachment>>(record.AttachmentsJson!) ?? new List<SmsAttachment>();
+
+        return new SmsHistoryItem(
+            record.Recipient,
+            record.Message,
+            record.SentAt?.ToLocalTime() ?? DateTime.UtcNow,
+            record.Status,
+            record.SenderNumber ?? string.Empty,
+            record.RecipientName ?? string.Empty,
+            attachments);
+    }
+
+    private static SmsScheduleItem MapToScheduleItem(SmsScheduleRecord record)
+    {
+        BulkSmsRequest request;
+        if (string.IsNullOrWhiteSpace(record.PayloadJson))
+        {
+            request = new BulkSmsRequest();
+        }
+        else
+        {
+            request = JsonConvert.DeserializeObject<BulkSmsRequest>(record.PayloadJson) ?? new BulkSmsRequest();
+        }
+
+        return new SmsScheduleItem(record.Id, record.ScheduledAt, request, record.IsCancelled);
+    }
+
+    private async Task CreateAuditLogAsync(Supabase.Client client, Guid userId, string action, string payload)
+    {
+        try
+        {
+            var record = new AuditLogRecord
+            {
+                Id = Guid.NewGuid(),
+                ActorId = userId,
+                Action = action,
+                EntityType = "sms",
+                EntityId = userId.ToString(),
+                PayloadJson = payload,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            await client.From<AuditLogRecord>().Insert(record);
+        }
+        catch (PostgrestException ex)
+        {
+            _logger.LogWarning(ex, "Skipping SMS audit log write because the Supabase audit table is unavailable.");
+        }
+    }
+
+    private async Task CreateIntegrationEventAsync(Supabase.Client client, string eventType, object payload)
+    {
+        try
+        {
+            var record = new IntegrationEventRecord
+            {
+                Id = Guid.NewGuid(),
+                EventType = eventType,
+                PayloadJson = JsonConvert.SerializeObject(payload),
+                Status = "pending",
+                CreatedAt = DateTime.UtcNow
+            };
+
+            await client.From<IntegrationEventRecord>().Insert(record);
+        }
+        catch (PostgrestException ex)
+        {
+            _logger.LogWarning(ex, "Skipping integration event {EventType} because the Supabase edge pipeline is unavailable.", eventType);
+        }
+    }
+
+    private Guid EnsureUserId(Supabase.Client client)
+    {
+        var rawId = client.Auth.CurrentUser?.Id;
+        if (string.IsNullOrWhiteSpace(rawId) || !Guid.TryParse(rawId, out var parsed))
+        {
+            throw new InvalidOperationException("Supabase user id is required for SMS operations.");
+        }
+
+        return parsed;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Services/SupabaseSupportTicketService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SupabaseSupportTicketService.cs
@@ -1,0 +1,444 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NexaCRM.WebClient.Models;
+using NexaCRM.WebClient.Models.Enums;
+using NexaCRM.WebClient.Models.Supabase;
+using NexaCRM.WebClient.Services.Interfaces;
+using PostgrestOperator = Supabase.Postgrest.Constants.Operator;
+using PostgrestOrdering = Supabase.Postgrest.Constants.Ordering;
+using RealtimeEventType = Supabase.Realtime.Constants.EventType;
+using RealtimeListenType = Supabase.Realtime.PostgresChanges.PostgresChangesOptions.ListenType;
+using Supabase.Realtime.Interfaces;
+using Supabase.Realtime.PostgresChanges;
+
+namespace NexaCRM.WebClient.Services;
+
+public sealed class SupabaseSupportTicketService : ISupportTicketService, IAsyncDisposable
+{
+    private readonly SupabaseClientProvider _clientProvider;
+    private readonly ILogger<SupabaseSupportTicketService> _logger;
+    private readonly Dictionary<int, SupportTicket> _cache = new();
+    private readonly object _syncRoot = new();
+    private readonly SemaphoreSlim _subscriptionLock = new(1, 1);
+    private bool _subscriptionInitialized;
+    private IRealtimeChannel? _realtimeChannel;
+    private IRealtimeChannel.PostgresChangesHandler? _changeHandler;
+
+    public event Action<SupportTicket>? TicketUpserted;
+    public event Action<int>? TicketDeleted;
+    public event Action<int>? LiveTicketCountChanged;
+
+    public SupabaseSupportTicketService(
+        SupabaseClientProvider clientProvider,
+        ILogger<SupabaseSupportTicketService> logger)
+    {
+        _clientProvider = clientProvider;
+        _logger = logger;
+    }
+
+    public async Task<IEnumerable<SupportTicket>> GetTicketsAsync()
+    {
+        try
+        {
+            await EnsureRealtimeSubscriptionAsync();
+
+            var client = await _clientProvider.GetClientAsync();
+            var response = await client.From<SupportTicketRecord>()
+                .Order(x => x.CreatedAt, PostgrestOrdering.Descending)
+                .Get();
+
+            var records = response.Models ?? new List<SupportTicketRecord>();
+            var tickets = records.Select(MapToTicket).ToList();
+
+            lock (_syncRoot)
+            {
+                _cache.Clear();
+                foreach (var ticket in tickets)
+                {
+                    _cache[ticket.Id] = ticket;
+                }
+            }
+
+            NotifyLiveTicketCount();
+            return tickets;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load support tickets from Supabase.");
+            throw;
+        }
+    }
+
+    public async Task<SupportTicket?> GetTicketByIdAsync(int id)
+    {
+        try
+        {
+            await EnsureRealtimeSubscriptionAsync();
+
+            lock (_syncRoot)
+            {
+                if (_cache.TryGetValue(id, out var cached))
+                {
+                    return cached;
+                }
+            }
+
+            var client = await _clientProvider.GetClientAsync();
+            var response = await client.From<SupportTicketRecord>()
+                .Filter(x => x.Id, PostgrestOperator.Equals, id)
+                .Get();
+
+            var record = response.Models.FirstOrDefault();
+            if (record is null)
+            {
+                return null;
+            }
+
+            var ticket = MapToTicket(record);
+            lock (_syncRoot)
+            {
+                _cache[ticket.Id] = ticket;
+            }
+
+            NotifyLiveTicketCount();
+            return ticket;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load support ticket {TicketId} from Supabase.", id);
+            throw;
+        }
+    }
+
+    public async Task<IEnumerable<SupportTicket>> GetLiveInteractionsAsync()
+    {
+        await EnsureRealtimeSubscriptionAsync();
+
+        List<SupportTicket> snapshot;
+        lock (_syncRoot)
+        {
+            if (_cache.Count == 0)
+            {
+                snapshot = new List<SupportTicket>();
+            }
+            else
+            {
+                snapshot = _cache.Values.ToList();
+            }
+        }
+
+        if (snapshot.Count == 0)
+        {
+            snapshot = (await GetTicketsAsync()).ToList();
+        }
+
+        return snapshot.Where(ticket =>
+            ticket.Status == TicketStatus.Open || ticket.Status == TicketStatus.InProgress).ToList();
+    }
+
+    public async Task CreateTicketAsync(SupportTicket ticket)
+    {
+        ArgumentNullException.ThrowIfNull(ticket);
+
+        try
+        {
+            await EnsureRealtimeSubscriptionAsync();
+            var client = await _clientProvider.GetClientAsync();
+            var currentUserId = client.Auth.CurrentUser?.Id;
+            var createdAt = ticket.CreatedAt == default ? DateTime.UtcNow : ticket.CreatedAt;
+            var agentId = ticket.AgentId ?? ParseGuid(ticket.AgentName);
+
+            var record = new SupportTicketRecord
+            {
+                Subject = ticket.Subject,
+                Description = ticket.Description,
+                Status = ticket.Status.ToString(),
+                Priority = ticket.Priority.ToString(),
+                CustomerId = null,
+                CustomerName = ticket.CustomerName,
+                AgentName = ticket.AgentName,
+                AgentId = agentId,
+                Category = ticket.Category,
+                CreatedBy = ParseGuid(currentUserId),
+                CreatedAt = createdAt,
+                UpdatedAt = createdAt,
+                TenantUnitId = null
+            };
+
+            var response = await client.From<SupportTicketRecord>().Insert(record);
+            var inserted = response.Models.FirstOrDefault();
+            if (inserted is not null)
+            {
+                var created = MapToTicket(inserted);
+                StoreTicket(created);
+                TicketUpserted?.Invoke(created);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create support ticket in Supabase.");
+            throw;
+        }
+    }
+
+    public async Task UpdateTicketAsync(SupportTicket ticket)
+    {
+        ArgumentNullException.ThrowIfNull(ticket);
+
+        try
+        {
+            await EnsureRealtimeSubscriptionAsync();
+            var client = await _clientProvider.GetClientAsync();
+            var agentId = ticket.AgentId ?? ParseGuid(ticket.AgentName);
+
+            var record = new SupportTicketRecord
+            {
+                Id = ticket.Id,
+                Subject = ticket.Subject,
+                Description = ticket.Description,
+                Status = ticket.Status.ToString(),
+                Priority = ticket.Priority.ToString(),
+                CustomerName = ticket.CustomerName,
+                AgentName = ticket.AgentName,
+                AgentId = agentId,
+                Category = ticket.Category,
+                UpdatedAt = DateTime.UtcNow
+            };
+
+            var response = await client.From<SupportTicketRecord>()
+                .Filter(x => x.Id, PostgrestOperator.Equals, ticket.Id)
+                .Update(record);
+
+            var updatedRecord = response.Models.FirstOrDefault() ?? record;
+            var updated = MapToTicket(updatedRecord);
+            StoreTicket(updated);
+            TicketUpserted?.Invoke(updated);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to update support ticket {TicketId} in Supabase.", ticket.Id);
+            throw;
+        }
+    }
+
+    public async Task DeleteTicketAsync(int id)
+    {
+        try
+        {
+            await EnsureRealtimeSubscriptionAsync();
+            var client = await _clientProvider.GetClientAsync();
+            await client.From<SupportTicketRecord>()
+                .Filter(x => x.Id, PostgrestOperator.Equals, id)
+                .Delete();
+
+            var removed = false;
+            lock (_syncRoot)
+            {
+                removed = _cache.Remove(id);
+            }
+
+            if (removed)
+            {
+                TicketDeleted?.Invoke(id);
+                NotifyLiveTicketCount();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete support ticket {TicketId} from Supabase.", id);
+            throw;
+        }
+    }
+
+    private async Task EnsureRealtimeSubscriptionAsync()
+    {
+        if (_subscriptionInitialized)
+        {
+            return;
+        }
+
+        await _subscriptionLock.WaitAsync();
+        try
+        {
+            if (_subscriptionInitialized)
+            {
+                return;
+            }
+
+            var client = await _clientProvider.GetClientAsync();
+            _changeHandler ??= HandleRealtimeChange;
+            _realtimeChannel = await client.From<SupportTicketRecord>()
+                .On(RealtimeListenType.All, _changeHandler);
+
+            _subscriptionInitialized = true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to subscribe to Supabase support ticket realtime channel.");
+        }
+        finally
+        {
+            _subscriptionLock.Release();
+        }
+    }
+
+    private void HandleRealtimeChange(IRealtimeChannel sender, PostgresChangesResponse change)
+    {
+        try
+        {
+            var eventType = change.Payload?.Data?.Type;
+            if (eventType is null)
+            {
+                return;
+            }
+
+            switch (eventType.Value)
+            {
+                case RealtimeEventType.Insert:
+                case RealtimeEventType.Update:
+                    var record = change.Model<SupportTicketRecord>();
+                    if (record is null)
+                    {
+                        return;
+                    }
+
+                    var ticket = MapToTicket(record);
+                    StoreTicket(ticket);
+                    TicketUpserted?.Invoke(ticket);
+                    break;
+
+                case RealtimeEventType.Delete:
+                    HandleTicketDeleted(change);
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to process support ticket realtime payload.");
+        }
+    }
+
+    private void HandleTicketDeleted(PostgresChangesResponse change)
+    {
+        int? ticketId = change.OldModel<SupportTicketRecord>()?.Id;
+        if (ticketId is null)
+        {
+            var firstId = change.Payload?.Data?.Ids?.FirstOrDefault();
+            if (firstId.HasValue)
+            {
+                ticketId = firstId.Value;
+            }
+        }
+
+        if (ticketId is null)
+        {
+            return;
+        }
+
+        var removed = false;
+        lock (_syncRoot)
+        {
+            removed = _cache.Remove(ticketId.Value);
+        }
+
+        if (removed)
+        {
+            TicketDeleted?.Invoke(ticketId.Value);
+            NotifyLiveTicketCount();
+        }
+    }
+
+    private void StoreTicket(SupportTicket ticket)
+    {
+        lock (_syncRoot)
+        {
+            _cache[ticket.Id] = ticket;
+        }
+
+        NotifyLiveTicketCount();
+    }
+
+    private void NotifyLiveTicketCount()
+    {
+        int liveCount;
+        lock (_syncRoot)
+        {
+            liveCount = _cache.Values.Count(t =>
+                t.Status == TicketStatus.Open || t.Status == TicketStatus.InProgress);
+        }
+
+        LiveTicketCountChanged?.Invoke(liveCount);
+    }
+
+    private static SupportTicket MapToTicket(SupportTicketRecord record)
+    {
+        return new SupportTicket
+        {
+            Id = record.Id,
+            Subject = record.Subject,
+            Description = record.Description,
+            Status = ParseStatus(record.Status),
+            Priority = ParsePriority(record.Priority),
+            CustomerName = record.CustomerName,
+            AgentId = record.AgentId,
+            AgentName = record.AgentName,
+            CreatedAt = record.CreatedAt?.ToLocalTime() ?? DateTime.UtcNow,
+            Category = record.Category
+        };
+    }
+
+    private static TicketStatus ParseStatus(string? value)
+    {
+        if (Enum.TryParse<TicketStatus>(value, true, out var parsed))
+        {
+            return parsed;
+        }
+
+        return TicketStatus.Open;
+    }
+
+    private static TicketPriority ParsePriority(string? value)
+    {
+        if (Enum.TryParse<TicketPriority>(value, true, out var parsed))
+        {
+            return parsed;
+        }
+
+        return TicketPriority.Medium;
+    }
+
+    private static Guid? ParseGuid(string? value)
+    {
+        if (Guid.TryParse(value, out var guid))
+        {
+            return guid;
+        }
+
+        return null;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (_realtimeChannel is not null && _changeHandler is not null)
+        {
+            try
+            {
+                _realtimeChannel.RemovePostgresChangeHandler(RealtimeListenType.All, _changeHandler);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to remove support ticket realtime handler.");
+            }
+        }
+
+        _realtimeChannel = null;
+        _changeHandler = null;
+        _subscriptionInitialized = false;
+
+        return ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- refine the Supabase notification feed service to avoid duplicate unread count events and better handle realtime delete payloads
- harden the Supabase SMS service with sender sync safeguards, user scoping, and graceful handling when audit/log tables are unavailable
- add agent ID support to support tickets, wire the Supabase services into DI, and include the Supabase record models required by the new integrations

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68d40d9745c0832ca6a317b9144122bf