### PR TITLE
feat: integrate real-time actions and mobile interactions

### DIFF
--- a/src/Services/Admin.Core/Services/Interfaces/INotificationFeedService.cs
+++ b/src/Services/Admin.Core/Services/Interfaces/INotificationFeedService.cs
@@ -13,6 +13,7 @@ public interface INotificationFeedService
     Task AddAsync(NotificationFeedItem item);
 
     event Action<int>? UnreadCountChanged;
+    event Action<IReadOnlyList<NotificationFeedItem>>? FeedUpdated;
 }
 
 public sealed class NotificationFeedItem

--- a/src/Web/NexaCRM.WebClient/Components/UI/FloatingActionButton.razor
+++ b/src/Web/NexaCRM.WebClient/Components/UI/FloatingActionButton.razor
@@ -1,7 +1,6 @@
 @using Microsoft.Extensions.Localization
-@using Microsoft.JSInterop
 @inject IStringLocalizer<FloatingActionButton> Localizer
-@inject IJSRuntime JSRuntime
+@inject ActionInterop ActionInterop
 
 <div class="fab-container @(IsExpanded ? "expanded" : "") @CssClass">
     <!-- Main FAB Button -->
@@ -95,18 +94,7 @@
         StateHasChanged();
         
         // Add haptic feedback on mobile
-        try
-        {
-            await JSRuntime.InvokeVoidAsync("eval", @"
-                if ('vibrate' in navigator) {
-                    navigator.vibrate(50);
-                }
-            ");
-        }
-        catch
-        {
-            // Vibration not supported, ignore
-        }
+        await ActionInterop.VibrateAsync(50);
     }
 
     private async Task CollapseActions()
@@ -135,19 +123,7 @@
         if (firstRender)
         {
             // Add click outside handler to close FAB when clicking elsewhere
-            await JSRuntime.InvokeVoidAsync("eval", @"
-                document.addEventListener('click', function(e) {
-                    const fabContainer = e.target.closest('.fab-container');
-                    if (!fabContainer) {
-                        // Click was outside FAB, collapse it
-                        const fabElement = document.querySelector('.fab-container.expanded');
-                        if (fabElement) {
-                            const closeBtn = fabElement.querySelector('.fab-main');
-                            if (closeBtn) closeBtn.click();
-                        }
-                    }
-                });
-            ");
+            await ActionInterop.RegisterFabOutsideHandlerAsync();
         }
     }
 }

--- a/src/Web/NexaCRM.WebClient/Components/UI/QuickActionsComponent.razor
+++ b/src/Web/NexaCRM.WebClient/Components/UI/QuickActionsComponent.razor
@@ -1,9 +1,8 @@
 @using Microsoft.Extensions.Localization
-@using Microsoft.JSInterop
 @using System.Text.Json
 @using System.Linq
 @inject IStringLocalizer<QuickActionsComponent> Localizer
-@inject IJSRuntime JSRuntime
+@inject ActionInterop ActionInterop
 
 <div class="quick-actions-container @CssClass">
     <div class="quick-actions-wrapper">
@@ -130,7 +129,7 @@
         {
             if (await IsMobileViewportAsync())
             {
-                await JSRuntime.InvokeVoidAsync("eval", $"window.location.href = 'tel:{PhoneNumber}'");
+                await ActionInterop.OpenTelephoneAsync(PhoneNumber);
                 await AnnounceAndCompleteAsync("call", Localizer["QuickActionsCallLaunched", ResolveDisplayName(PhoneNumber)]);
             }
             else
@@ -161,7 +160,7 @@
 
             if (await IsMobileViewportAsync())
             {
-                await JSRuntime.InvokeVoidAsync("eval", $"window.location.href = '{mailtoUrl}'");
+                await ActionInterop.OpenMailtoAsync(mailtoUrl);
                 await AnnounceAndCompleteAsync("email", Localizer["QuickActionsEmailLaunched", displayName]);
             }
             else
@@ -196,17 +195,7 @@
         }
     }
 
-    private async Task<bool> IsMobileViewportAsync()
-    {
-        try
-        {
-            return await JSRuntime.InvokeAsync<bool>("eval", "window.matchMedia('(max-width: 767px)').matches");
-        }
-        catch
-        {
-            return false;
-        }
-    }
+    private Task<bool> IsMobileViewportAsync() => ActionInterop.IsMobileViewportAsync();
 
     private void PrepareCallActionSheet()
     {
@@ -309,32 +298,7 @@
         return string.IsNullOrWhiteSpace(fallback) ? Localizer["QuickActionsUnknownContact"] : fallback!;
     }
 
-    private async Task CopyToClipboardAsync(string value)
-    {
-        var encoded = JsonSerializer.Serialize(value);
-        var script = $@"
-            (async () => {{
-                const value = {encoded};
-                if (navigator.clipboard && navigator.clipboard.writeText) {{
-                    try {{
-                        await navigator.clipboard.writeText(value);
-                        return;
-                    }} catch (err) {{ }}
-                }}
-                const textarea = document.createElement('textarea');
-                textarea.value = value;
-                textarea.setAttribute('readonly', '');
-                textarea.style.position = 'absolute';
-                textarea.style.left = '-9999px';
-                document.body.appendChild(textarea);
-                textarea.select();
-                document.execCommand('copy');
-                document.body.removeChild(textarea);
-            }})();
-        ";
-
-        await JSRuntime.InvokeVoidAsync("eval", script);
-    }
+    private Task CopyToClipboardAsync(string value) => ActionInterop.CopyTextAsync(value);
 
     private string GetMeetingFileName()
     {
@@ -348,24 +312,9 @@
         return $"meeting-with-{sanitized}.ics";
     }
 
-    private async Task TriggerFileDownloadAsync(string fileName, string content)
+    private Task TriggerFileDownloadAsync(string fileName, string content)
     {
         var base64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(content));
-        var base64Json = JsonSerializer.Serialize(base64);
-        var fileNameJson = JsonSerializer.Serialize(fileName);
-        var script = $@"
-            (function() {{
-                const data = {base64Json};
-                const fileName = {fileNameJson};
-                const link = document.createElement('a');
-                link.href = 'data:text/calendar;base64,' + data;
-                link.download = fileName;
-                document.body.appendChild(link);
-                link.click();
-                document.body.removeChild(link);
-            }})();
-        ";
-
-        await JSRuntime.InvokeVoidAsync("eval", script);
+        return ActionInterop.TriggerDownloadAsync(base64, fileName, "text/calendar");
     }
 }

--- a/src/Web/NexaCRM.WebClient/Models/DealCreateRequest.cs
+++ b/src/Web/NexaCRM.WebClient/Models/DealCreateRequest.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace NexaCRM.WebClient.Models
+{
+    public sealed class DealCreateRequest
+    {
+        public string Name { get; set; } = string.Empty;
+        public int StageId { get; set; }
+        public decimal Amount { get; set; }
+        public string? Company { get; set; }
+        public string? ContactName { get; set; }
+        public string? Owner { get; set; }
+        public DateTime? ExpectedCloseDate { get; set; }
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Models/DealStage.cs
+++ b/src/Web/NexaCRM.WebClient/Models/DealStage.cs
@@ -1,0 +1,9 @@
+namespace NexaCRM.WebClient.Models
+{
+    public sealed class DealStage
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public int SortOrder { get; set; }
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/DemoContactsPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/DemoContactsPage.razor
@@ -1,8 +1,9 @@
 @page "/demo-contacts"
 @using Microsoft.Extensions.Localization
+@using NexaCRM.WebClient.Services.Interfaces
 @inject IStringLocalizer<ContactsPage> Localizer
-@inject IJSRuntime JSRuntime
 @inject NavigationManager NavigationManager
+@inject IGlobalActionService GlobalActionService
 
 <div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
     <div class="layout-container flex h-full grow flex-col">
@@ -165,20 +166,20 @@
 
     private async System.Threading.Tasks.Task HandleFloatingAction(string action)
     {
-        switch (action)
+        var request = action switch
         {
-            case "call":
-                await JSRuntime.InvokeVoidAsync("alert", "Select a contact to call from the list above");
-                break;
-            case "email":
-                await JSRuntime.InvokeVoidAsync("alert", "Select a contact to email from the list above");
-                break;
-            case "meeting":
-                await JSRuntime.InvokeVoidAsync("alert", "Schedule meeting functionality - would open calendar integration");
-                break;
-            case "add":
-                await JSRuntime.InvokeVoidAsync("alert", "Add new contact functionality - would open contact form");
-                break;
+            "call" => new GlobalActionRequest(GlobalActionType.Call),
+            "email" => new GlobalActionRequest(GlobalActionType.Email),
+            "meeting" => new GlobalActionRequest(GlobalActionType.ScheduleMeeting),
+            "add" => new GlobalActionRequest(GlobalActionType.AddContact),
+            _ => null
+        };
+
+        if (request is null)
+        {
+            return;
         }
+
+        await GlobalActionService.LaunchAsync(request);
     }
 }

--- a/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor
@@ -2,10 +2,14 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.Extensions.Localization
 @using NexaCRM.WebClient.Services.Interfaces
+@using System.Globalization
+@using System.Linq
 @inject IStringLocalizer<MainDashboard> Localizer
 @inject NavigationManager NavigationManager
-@inject IJSRuntime JSRuntime
 @inject INotificationFeedService NotificationFeed
+@inject IMobileInteractionService MobileInteractions
+@inject IGlobalActionService GlobalActionService
+@inject ActionInterop ActionInterop
 @attribute [Authorize(Roles = "Sales,Manager")]
 @implements IDisposable
 
@@ -46,7 +50,7 @@
         </div>
         
         <!-- Mobile Search Bar (collapsed by default) -->
-        <div class="mobile-search-bar @(showMobileSearch ? "expanded" : "collapsed")">
+        <div class="mobile-search-bar @(MobileInteractions.IsSearchOpen ? "expanded" : "collapsed")">
             <div class="mobile-search-input">
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 256 256">
                     <path d="M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z"></path>
@@ -104,7 +108,7 @@
     </div>
 
     <!-- Mobile Notifications Panel (collapsed by default) -->
-    <div class="mobile-notifications-panel @(showMobileNotifications ? "expanded" : "collapsed")">
+    <div class="mobile-notifications-panel @(MobileInteractions.AreNotificationsOpen ? "expanded" : "collapsed")">
         <div class="mobile-notifications-header">
             <h3>@Localizer["Notifications"]</h3>
             <button class="mobile-notifications-close" @onclick="ToggleMobileNotifications">
@@ -114,43 +118,28 @@
             </button>
         </div>
         <div class="mobile-notifications-content">
-            @foreach (var notification in mobileNotifications)
+            @if (mobileNotifications.Count == 0)
             {
-                <div class="notification-item">
-                    <div class="notification-icon">
-                        @switch (notification.Icon)
-                        {
-                            case NotificationIconType.Lead:
-                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256">
-                                    <path d="M256,136a8,8,0,0,1-8,8H232v16a8,8,0,0,1-16,0V144H200a8,8,0,0,1,0-16h16V112a8,8,0,0,1,16,0v16h16A8,8,0,0,1,256,136Z"></path>
-                                </svg>
-                                break;
-                            case NotificationIconType.Deal:
-                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256">
-                                    <path d="M173.66,98.34a8,8,0,0,1,0,11.32l-56,56a8,8,0,0,1-11.32,0l-24-24a8,8,0,0,1,11.32-11.32L112,148.69l50.34-50.35A8,8,0,0,1,173.66,98.34Z"></path>
-                                </svg>
-                                break;
-                            case NotificationIconType.Task:
-                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256">
-                                    <path d="M128,80a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Z"></path>
-                                </svg>
-                                break;
-                        }
-                    </div>
-                    <div class="notification-content">
-                        <div class="notification-title">@Localizer[notification.TitleKey]</div>
-                        <div class="notification-time">
-                            @if (!string.IsNullOrWhiteSpace(notification.TimeValue))
+                <div class="notification-empty">@ResolveString("NotificationEmpty", "새 알림이 없습니다.")</div>
+            }
+            else
+            {
+                @foreach (var notification in mobileNotifications)
+                {
+                    <div class="notification-item @(notification.IsRead ? string.Empty : "notification-item--unread")">
+                        <div class="notification-icon">
+                            <i class="@ResolveNotificationIcon(notification)" aria-hidden="true"></i>
+                        </div>
+                        <div class="notification-content">
+                            <div class="notification-title">@notification.Title</div>
+                            @if (!string.IsNullOrWhiteSpace(notification.Message))
                             {
-                                <span>@notification.TimeValue @Localizer[notification.TimeKey]</span>
+                                <div class="notification-message">@notification.Message</div>
                             }
-                            else
-                            {
-                                <span>@Localizer[notification.TimeKey]</span>
-                            }
+                            <div class="notification-time">@FormatRelativeTime(notification.TimestampUtc)</div>
                         </div>
                     </div>
-                </div>
+                }
             }
         </div>
     </div>
@@ -568,33 +557,47 @@
 </div>
 
 @code {
+    private const int MobileNotificationLimit = 12;
     private int unreadNotificationsCount;
+    private List<NotificationFeedItem> mobileNotifications = new();
+    private string mobileSearchQuery = string.Empty;
+    private int UnreadMobileNotificationsCount => mobileNotifications.Count(item => !item.IsRead);
 
     protected override async Task OnInitializedAsync()
     {
         NotificationFeed.UnreadCountChanged += HandleUnreadCountChanged;
+        NotificationFeed.FeedUpdated += HandleFeedUpdated;
+        MobileInteractions.StateChanged += HandleMobileStateChanged;
+
         unreadNotificationsCount = Math.Max(0, await NotificationFeed.GetUnreadCountAsync());
+        await LoadInitialNotificationsAsync();
     }
 
-    private static readonly MobileNotification[] mobileNotifications =
-    [
-        new(NotificationIconType.Lead, "NewLead", "2", "MinutesAgo"),
-        new(NotificationIconType.Deal, "DealClosed", "15", "MinutesAgo"),
-        new(NotificationIconType.Task, "TaskReminder", "1", "HourAgo")
-    ];
-
-    private bool showMobileSearch = false;
-    private bool showMobileNotifications = false;
-    private string mobileSearchQuery = "";
-    private int UnreadMobileNotificationsCount => mobileNotifications.Length;
-
-    private sealed record MobileNotification(NotificationIconType Icon, string TitleKey, string TimeValue, string TimeKey);
-
-    private enum NotificationIconType
+    private async Task LoadInitialNotificationsAsync()
     {
-        Lead,
-        Deal,
-        Task
+        try
+        {
+            var items = await NotificationFeed.GetAsync();
+            UpdateMobileNotifications(items);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Failed to load notifications: {ex.Message}");
+        }
+    }
+
+    private void HandleFeedUpdated(IReadOnlyList<NotificationFeedItem> items)
+    {
+        _ = InvokeAsync(() =>
+        {
+            UpdateMobileNotifications(items);
+            StateHasChanged();
+        });
+    }
+
+    private void HandleMobileStateChanged()
+    {
+        _ = InvokeAsync(StateHasChanged);
     }
 
     private async Task NavigateToPage(string url)
@@ -616,87 +619,22 @@
     {
         // Close any open mobile panels first
         await CloseMobilePanels();
-        
-        // Use JavaScript to smooth scroll to section
-        await JSRuntime.InvokeVoidAsync("eval", $@"
-            const element = document.getElementById('{sectionId}');
-            if (element) {{
-                element.scrollIntoView({{ behavior: 'smooth', block: 'start' }});
-            }}
-        ");
+
+        await MobileInteractions.ScrollToAsync(sectionId);
     }
 
-    private async Task ToggleMobileMenu()
-    {
-        // Close other mobile panels first
-        showMobileSearch = false;
-        showMobileNotifications = false;
-        StateHasChanged();
-        
-        // Toggle the main navigation menu - with error handling
-        try
-        {
-            await JSRuntime.InvokeVoidAsync("eval", @"
-                if (window.navigationHelper && window.navigationHelper.toggleMenu) {
-                    window.navigationHelper.toggleMenu(false);
-                }
-            ");
-        }
-        catch (Exception ex)
-        {
-            // Log error but don't break functionality
-            Console.WriteLine($"Navigation helper error: {ex.Message}");
-        }
-    }
+    private Task ToggleMobileMenu() => MobileInteractions.ToggleMenuAsync();
 
-    private async Task ToggleMobileSearch()
-    {
-        showMobileSearch = !showMobileSearch;
-        
-        // Close notifications if search is opening
-        if (showMobileSearch)
-        {
-            showMobileNotifications = false;
-        }
-        
-        StateHasChanged();
-        
-        // Focus on search input if opening - with error handling
-        if (showMobileSearch)
-        {
-            await Task.Delay(100); // Wait for animation
-            try
-            {
-                await JSRuntime.InvokeVoidAsync("eval", @"
-                    try {
-                        const searchInput = document.querySelector('.mobile-search-input input');
-                        if (searchInput) {
-                            searchInput.focus();
-                        }
-                    } catch (e) {
-                        console.warn('Search input focus failed:', e);
-                    }
-                ");
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Search input focus error: {ex.Message}");
-            }
-        }
-    }
+    private Task ToggleMobileSearch() => MobileInteractions.ToggleSearchAsync();
 
     private async Task ToggleMobileNotifications()
     {
-        showMobileNotifications = !showMobileNotifications;
-
-        // Close search if notifications is opening
-        if (showMobileNotifications)
+        await MobileInteractions.ToggleNotificationsAsync();
+        if (MobileInteractions.AreNotificationsOpen && mobileNotifications.Any(item => !item.IsRead))
         {
-            showMobileSearch = false;
+            await NotificationFeed.MarkAllReadAsync();
+            MarkLocalNotificationsRead();
         }
-
-        StateHasChanged();
-        await Task.Delay(50); // Small delay for smooth animation
     }
 
     private void HandleUnreadCountChanged(int count)
@@ -705,16 +643,105 @@
         _ = InvokeAsync(StateHasChanged);
     }
 
-    private async Task CloseMobilePanels()
+    private void UpdateMobileNotifications(IReadOnlyList<NotificationFeedItem> items)
     {
-        if (showMobileSearch || showMobileNotifications)
+        if (items is null)
         {
-            showMobileSearch = false;
-            showMobileNotifications = false;
-            StateHasChanged();
-            await Task.Delay(50);
+            return;
         }
+
+        mobileNotifications = items
+            .OrderByDescending(item => item.TimestampUtc)
+            .Take(MobileNotificationLimit)
+            .Select(CloneNotification)
+            .ToList();
     }
+
+    private static NotificationFeedItem CloneNotification(NotificationFeedItem item)
+    {
+        return new NotificationFeedItem
+        {
+            Id = item.Id,
+            Title = item.Title,
+            Message = item.Message,
+            TimestampUtc = item.TimestampUtc,
+            IsRead = item.IsRead,
+            Type = item.Type
+        };
+    }
+
+    private void MarkLocalNotificationsRead()
+    {
+        if (mobileNotifications.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var notification in mobileNotifications)
+        {
+            notification.IsRead = true;
+        }
+
+        StateHasChanged();
+    }
+
+    private string ResolveNotificationIcon(NotificationFeedItem notification)
+    {
+        var type = notification.Type?.ToLowerInvariant();
+
+        return type switch
+        {
+            "deal" or "pipeline" or "opportunity" => "bi bi-kanban",
+            "task" or "todo" => "bi bi-check2-circle",
+            "meeting" or "event" or "calendar" => "bi bi-calendar-event",
+            "lead" or "contact" => "bi bi-person-plus",
+            "warning" or "alert" => "bi bi-exclamation-triangle",
+            "message" or "communication" or "chat" => "bi bi-chat-dots",
+            _ => "bi bi-bell"
+        };
+    }
+
+    private string FormatRelativeTime(DateTime timestampUtc)
+    {
+        var difference = DateTime.UtcNow - timestampUtc;
+        if (difference < TimeSpan.Zero)
+        {
+            difference = TimeSpan.Zero;
+        }
+
+        if (difference < TimeSpan.FromMinutes(1))
+        {
+            return ResolveString("NotificationJustNow", "방금 전");
+        }
+
+        if (difference < TimeSpan.FromHours(1))
+        {
+            var minutes = Math.Max(1, (int)Math.Floor(difference.TotalMinutes));
+            return string.Format(CultureInfo.CurrentCulture, ResolveString("NotificationMinutesAgo", "{0}분 전"), minutes);
+        }
+
+        if (difference < TimeSpan.FromDays(1))
+        {
+            var hours = Math.Max(1, (int)Math.Floor(difference.TotalHours));
+            return string.Format(CultureInfo.CurrentCulture, ResolveString("NotificationHoursAgo", "{0}시간 전"), hours);
+        }
+
+        if (difference < TimeSpan.FromDays(7))
+        {
+            var days = Math.Max(1, (int)Math.Floor(difference.TotalDays));
+            return string.Format(CultureInfo.CurrentCulture, ResolveString("NotificationDaysAgo", "{0}일 전"), days);
+        }
+
+        return timestampUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm", CultureInfo.CurrentCulture);
+    }
+
+    private string ResolveString(string key, string fallback)
+    {
+        var localized = Localizer[key];
+        return localized.ResourceNotFound ? fallback : localized.Value;
+    }
+
+    private Task CloseMobilePanels() => MobileInteractions.CloseAllAsync();
 
     private async Task HandleMobileSearch(KeyboardEventArgs e)
     {
@@ -728,9 +755,8 @@
     private async Task PerformMobileSearch()
     {
         // Close search panel
-        showMobileSearch = false;
-        StateHasChanged();
-        
+        await MobileInteractions.CloseAllAsync();
+
         // Perform search navigation
         var searchUrl = $"/search?q={Uri.EscapeDataString(mobileSearchQuery)}";
         NavigationManager.NavigateTo(searchUrl);
@@ -746,85 +772,9 @@
     {
         if (firstRender)
         {
-            // Initialize mobile dashboard navigation after render - with error handling
             try
             {
-                await JSRuntime.InvokeVoidAsync("eval", @"
-                    try {
-                        if (window.navigationHelper && window.navigationHelper.setupMobileDashboardNavigation) {
-                            window.navigationHelper.setupMobileDashboardNavigation();
-                        }
-                    } catch (e) {
-                        console.warn('Navigation helper setup failed:', e);
-                    }
-                ");
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Navigation helper setup error: {ex.Message}");
-            }
-            
-            // Setup mobile dashboard specific functionality - with error handling
-            try
-            {
-                await JSRuntime.InvokeVoidAsync("eval", @"
-                    try {
-                        const mobileHeader = document.querySelector('.mobile-header');
-                        if (mobileHeader) {
-                            mobileHeader.classList.add('mobile-header--active');
-                        }
-
-                        const handleBackdropClick = (event) => {
-                            if (!event.target || !event.target.classList) {
-                                return;
-                            }
-
-                            if (event.target.classList.contains('mobile-search-bar') && event.target.classList.contains('expanded')) {
-                                const closeSearch = document.querySelector('.mobile-search-close');
-                                if (closeSearch) {
-                                    closeSearch.click();
-                                }
-                            }
-
-                            if (event.target.classList.contains('mobile-notifications-panel') && event.target.classList.contains('expanded')) {
-                                const closeNotifications = document.querySelector('.mobile-notifications-close');
-                                if (closeNotifications) {
-                                    closeNotifications.click();
-                                }
-                            }
-                        };
-
-                        document.addEventListener('click', handleBackdropClick);
-
-                        let touchStartY = 0;
-                        document.addEventListener('touchstart', (event) => {
-                            if (event.touches && event.touches[0]) {
-                                touchStartY = event.touches[0].clientY;
-                            }
-                        }, { passive: true });
-
-                        document.addEventListener('touchend', (event) => {
-                            if (!event.changedTouches || !event.changedTouches[0]) {
-                                return;
-                            }
-
-                            const touchEndY = event.changedTouches[0].clientY;
-                            const diff = touchStartY - touchEndY;
-
-                            if (diff > 50) {
-                                const expandedPanels = document.querySelectorAll('.mobile-search-bar.expanded, .mobile-notifications-panel.expanded');
-                                expandedPanels.forEach((panel) => {
-                                    const closeBtn = panel.querySelector('.mobile-search-close, .mobile-notifications-close');
-                                    if (closeBtn) {
-                                        closeBtn.click();
-                                    }
-                                });
-                            }
-                        }, { passive: true });
-                    } catch (setupError) {
-                        console.warn('Mobile dashboard setup failed:', setupError);
-                    }
-                ");
+                await ActionInterop.SetupMobileDashboardAsync();
             }
             catch (Exception ex)
             {
@@ -835,28 +785,21 @@
 
     private async Task HandleFloatingAction(string action)
     {
-        switch (action)
+        var request = action switch
         {
-            case "call":
-                // Navigate to contacts page to select a contact to call
-                NavigationManager.NavigateTo("/contacts");
-                break;
-            case "email":
-                // Navigate to contacts page to select a contact to email
-                NavigationManager.NavigateTo("/contacts");
-                break;
-            case "meeting":
-                // Navigate to calendar/meeting scheduling
-                NavigationManager.NavigateTo("/sales-calendar");
-                break;
-            case "add":
-                // Navigate to add new contact/lead page
-                NavigationManager.NavigateTo("/contacts");
-                break;
+            "call" => new GlobalActionRequest(GlobalActionType.Call),
+            "email" => new GlobalActionRequest(GlobalActionType.Email),
+            "meeting" => new GlobalActionRequest(GlobalActionType.ScheduleMeeting),
+            "add" => new GlobalActionRequest(GlobalActionType.AddContact),
+            _ => null
+        };
+
+        if (request is null)
+        {
+            return;
         }
-        
-        // Add a small delay to ensure navigation is processed
-        await Task.Delay(10);
+
+        await GlobalActionService.LaunchAsync(request);
     }
 
     public void Dispose()
@@ -864,6 +807,9 @@
         if (NotificationFeed is not null)
         {
             NotificationFeed.UnreadCountChanged -= HandleUnreadCountChanged;
+            NotificationFeed.FeedUpdated -= HandleFeedUpdated;
         }
+
+        MobileInteractions.StateChanged -= HandleMobileStateChanged;
     }
 }

--- a/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor.css
+++ b/src/Web/NexaCRM.WebClient/Pages/MainDashboard.razor.css
@@ -378,6 +378,41 @@
     color: #f8fafc !important;
 }
 
+[data-theme="dark"] .group\/design-root .notification-item {
+    background: rgba(30, 41, 59, 0.7);
+    border-color: #334155;
+}
+
+[data-theme="dark"] .group\/design-root .notification-item--unread {
+    background: rgba(99, 102, 241, 0.25);
+    border-color: #818cf8;
+}
+
+[data-theme="dark"] .group\/design-root .notification-icon {
+    background: rgba(148, 163, 184, 0.25);
+    color: #e2e8f0;
+}
+
+[data-theme="dark"] .group\/design-root .notification-item--unread .notification-icon {
+    background: rgba(129, 140, 248, 0.25);
+    color: #c7d2fe;
+}
+
+[data-theme="dark"] .group\/design-root .notification-title {
+    color: #f8fafc;
+}
+
+[data-theme="dark"] .group\/design-root .notification-message,
+[data-theme="dark"] .group\/design-root .notification-time {
+    color: #cbd5f5;
+}
+
+[data-theme="dark"] .group\/design-root .notification-empty {
+    background: rgba(15, 23, 42, 0.7);
+    border-color: rgba(148, 163, 184, 0.4);
+    color: #e2e8f0;
+}
+
 /* 모바일 헤더 기본 스타일 */
 .mobile-header {
     display: none;
@@ -411,6 +446,78 @@
     min-width: 1.25rem;
     text-align: center;
     pointer-events: none;
+}
+
+.mobile-notifications-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.notification-item {
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.75rem 0.85rem;
+    border-radius: 0.85rem;
+    background: #f8fafc;
+    border: 1px solid rgba(208, 217, 231, 0.6);
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.notification-item--unread {
+    background: #eef2ff;
+    border-color: #6366f1;
+}
+
+.notification-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 0.75rem;
+    background: #e2e8f0;
+    color: #1e293b;
+    font-size: 1rem;
+}
+
+.notification-item--unread .notification-icon {
+    background: rgba(99, 102, 241, 0.15);
+    color: #4338ca;
+}
+
+.notification-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.notification-title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #0f172a;
+    margin: 0;
+}
+
+.notification-message {
+    font-size: 0.85rem;
+    color: #475569;
+    margin: 0;
+}
+
+.notification-time {
+    font-size: 0.75rem;
+    color: #64748b;
+}
+
+.notification-empty {
+    padding: 1.25rem;
+    border-radius: 0.85rem;
+    background: #f8fafc;
+    border: 1px dashed rgba(148, 163, 184, 0.6);
+    color: #475569;
+    text-align: center;
+    font-size: 0.9rem;
 }
 
 @media (max-width: 768px) {

--- a/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/SalesPipelinePage.razor
@@ -5,8 +5,8 @@
 @using NexaCRM.WebClient.Models
 @using NexaCRM.WebClient.Services.Interfaces
 @inject IDealService DealService
-@inject IJSRuntime JSRuntime
 @inject NavigationManager NavigationManager
+@inject IGlobalActionService GlobalActionService
 
 <div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
     <div class="layout-container flex h-full grow flex-col">
@@ -445,24 +445,20 @@
 
     private async System.Threading.Tasks.Task HandleFloatingAction(string action)
     {
-        switch (action)
+        var request = action switch
         {
-            case "call":
-                // Navigate to contacts page to select a contact to call
-                NavigationManager.NavigateTo("/contacts");
-                break;
-            case "email":
-                // Navigate to contacts page to select a contact to email
-                NavigationManager.NavigateTo("/contacts");
-                break;
-            case "meeting":
-                // Navigate to calendar/meeting scheduling
-                NavigationManager.NavigateTo("/sales-calendar");
-                break;
-            case "add":
-                // Show add deal functionality
-                await JSRuntime.InvokeVoidAsync("alert", "Add new deal functionality - to be implemented");
-                break;
+            "call" => new GlobalActionRequest(GlobalActionType.Call),
+            "email" => new GlobalActionRequest(GlobalActionType.Email),
+            "meeting" => new GlobalActionRequest(GlobalActionType.ScheduleMeeting),
+            "add" => new GlobalActionRequest(GlobalActionType.AddDeal),
+            _ => null
+        };
+
+        if (request is null)
+        {
+            return;
         }
+
+        await GlobalActionService.LaunchAsync(request);
     }
 }

--- a/src/Web/NexaCRM.WebClient/Pages/TestDashboard.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/TestDashboard.razor
@@ -1,8 +1,13 @@
 @page "/test-dashboard"
+@using Microsoft.AspNetCore.Components.Web
 @using Microsoft.Extensions.Localization
+@using NexaCRM.WebClient.Services.Interfaces
 @inject IStringLocalizer<MainDashboard> Localizer
 @inject NavigationManager NavigationManager
-@inject IJSRuntime JSRuntime
+@inject IMobileInteractionService MobileInteractions
+@inject ActionInterop ActionInterop
+@inject IGlobalActionService GlobalActionService
+@implements IDisposable
 
 <div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;' data-page="main-dashboard">
     <!-- Mobile Header Bar -->
@@ -28,13 +33,16 @@
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 256 256">
                         <path d="M221.8,175.94C216.25,166.38,208,139.33,208,104a80,80,0,1,0-160,0c0,35.34-8.26,62.38-13.81,71.94A16,16,0,0,0,48,200H88.81a40,40,0,0,0,78.38,0H208a16,16,0,0,0,13.8-24.06ZM128,216a24,24,0,0,1-22.62-16h45.24A24,24,0,0,1,128,216ZM48,184c7.7-13.24,16-43.92,16-80a64,64,0,1,1,128,0c0,36.05,8.28,66.73,16,80Z"></path>
                     </svg>
-                    <span class="notification-badge">3</span>
+                    @if (demoUnreadCount > 0)
+                    {
+                        <span class="notification-badge">@demoUnreadCount</span>
+                    }
                 </button>
             </div>
         </div>
         
         <!-- Mobile Search Bar (collapsed by default) -->
-        <div class="mobile-search-bar @(showMobileSearch ? "expanded" : "collapsed")">
+        <div class="mobile-search-bar @(MobileInteractions.IsSearchOpen ? "expanded" : "collapsed")">
             <div class="mobile-search-input">
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 256 256">
                     <path d="M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z"></path>
@@ -81,7 +89,7 @@
     </div>
 
     <!-- Mobile Notifications Panel (collapsed by default) -->
-    <div class="mobile-notifications-panel @(showMobileNotifications ? "expanded" : "collapsed")">
+    <div class="mobile-notifications-panel @(MobileInteractions.AreNotificationsOpen ? "expanded" : "collapsed")">
         <div class="mobile-notifications-header">
             <h3>@Localizer["Notifications"]</h3>
             <button class="mobile-notifications-close" @onclick="ToggleMobileNotifications">
@@ -200,98 +208,50 @@
 </div>
 
 @code {
-    private bool showMobileSearch = false;
-    private bool showMobileNotifications = false;
-    private string mobileSearchQuery = "";
+    private string mobileSearchQuery = string.Empty;
+    private int demoUnreadCount = 3;
+
+    protected override void OnInitialized()
+    {
+        MobileInteractions.StateChanged += HandleMobileStateChanged;
+    }
+
+    private void HandleMobileStateChanged()
+    {
+        _ = InvokeAsync(StateHasChanged);
+    }
 
     private async Task NavigateToPage(string url)
     {
-        // Close any open mobile panels first
         await CloseMobilePanels();
-        
-        // Add visual feedback before navigation
         await Task.Delay(150);
         NavigationManager.NavigateTo(url);
     }
 
     private async Task ScrollToSection(string sectionId)
     {
-        // Close any open mobile panels first
         await CloseMobilePanels();
-        
-        // Use JavaScript to smooth scroll to section
-        await JSRuntime.InvokeVoidAsync("eval", $@"
-            const element = document.getElementById('{sectionId}');
-            if (element) {{
-                element.scrollIntoView({{ behavior: 'smooth', block: 'start' }});
-            }}
-        ");
+        await MobileInteractions.ScrollToAsync(sectionId);
     }
 
-    private async Task ToggleMobileMenu()
-    {
-        // Close other mobile panels first
-        showMobileSearch = false;
-        showMobileNotifications = false;
-        StateHasChanged();
-        
-        // For demo purposes, show an alert
-        await JSRuntime.InvokeVoidAsync("alert", "Mobile menu would open the sidebar navigation here");
-    }
+    private Task ToggleMobileMenu() => MobileInteractions.ToggleMenuAsync();
 
-    private async Task ToggleMobileSearch()
-    {
-        showMobileSearch = !showMobileSearch;
-        
-        // Close notifications if search is opening
-        if (showMobileSearch)
-        {
-            showMobileNotifications = false;
-        }
-        
-        StateHasChanged();
-        
-        // Focus on search input if opening
-        if (showMobileSearch)
-        {
-            await Task.Delay(100); // Wait for animation
-            await JSRuntime.InvokeVoidAsync("eval", @"
-                const searchInput = document.querySelector('.mobile-search-input input');
-                if (searchInput) {
-                    searchInput.focus();
-                }
-            ");
-        }
-    }
+    private Task ToggleMobileSearch() => MobileInteractions.ToggleSearchAsync();
 
     private async Task ToggleMobileNotifications()
     {
-        showMobileNotifications = !showMobileNotifications;
-        
-        // Close search if notifications is opening
-        if (showMobileNotifications)
+        await MobileInteractions.ToggleNotificationsAsync();
+        if (MobileInteractions.AreNotificationsOpen)
         {
-            showMobileSearch = false;
+            demoUnreadCount = 0;
+            _ = InvokeAsync(StateHasChanged);
         }
-        
-        StateHasChanged();
-        await Task.Delay(50); // Small delay for smooth animation
     }
 
-    private async Task CloseMobilePanels()
-    {
-        if (showMobileSearch || showMobileNotifications)
-        {
-            showMobileSearch = false;
-            showMobileNotifications = false;
-            StateHasChanged();
-            await Task.Delay(50);
-        }
-    }
+    private Task CloseMobilePanels() => MobileInteractions.CloseAllAsync();
 
     private async Task HandleMobileSearch(KeyboardEventArgs e)
     {
-        // Handle search on Enter key
         if (e.Key == "Enter" && !string.IsNullOrWhiteSpace(mobileSearchQuery))
         {
             await PerformMobileSearch();
@@ -300,43 +260,49 @@
 
     private async Task PerformMobileSearch()
     {
-        // Close search panel
-        showMobileSearch = false;
-        StateHasChanged();
-        
-        // Perform search navigation
+        await MobileInteractions.CloseAllAsync();
         var searchUrl = $"/search?q={Uri.EscapeDataString(mobileSearchQuery)}";
         NavigationManager.NavigateTo(searchUrl);
-        
-        // Clear search query
-        mobileSearchQuery = "";
+        mobileSearchQuery = string.Empty;
+        await Task.Delay(10);
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
-            // Initialize mobile dashboard navigation after render
-            await JSRuntime.InvokeVoidAsync("window.navigationHelper.setupMobileDashboardNavigation");
+            try
+            {
+                await ActionInterop.SetupMobileDashboardAsync();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Mobile dashboard setup error: {ex.Message}");
+            }
         }
     }
 
-    private async System.Threading.Tasks.Task HandleFloatingAction(string action)
+    private async Task HandleFloatingAction(string action)
     {
-        switch (action)
+        var request = action switch
         {
-            case "call":
-                await JSRuntime.InvokeVoidAsync("alert", $"Call action selected! On mobile, this would open the phone app.");
-                break;
-            case "email":
-                await JSRuntime.InvokeVoidAsync("alert", $"Email action selected! On mobile, this would open the email app.");
-                break;
-            case "meeting":
-                await JSRuntime.InvokeVoidAsync("alert", $"Meeting action selected! This would open calendar integration.");
-                break;
-            case "add":
-                await JSRuntime.InvokeVoidAsync("alert", $"Add new action selected! This would open a form to add new customer/lead.");
-                break;
+            "call" => new GlobalActionRequest(GlobalActionType.Call),
+            "email" => new GlobalActionRequest(GlobalActionType.Email),
+            "meeting" => new GlobalActionRequest(GlobalActionType.ScheduleMeeting),
+            "add" => new GlobalActionRequest(GlobalActionType.AddContact),
+            _ => null
+        };
+
+        if (request is null)
+        {
+            return;
         }
+
+        await GlobalActionService.LaunchAsync(request);
+    }
+
+    public void Dispose()
+    {
+        MobileInteractions.StateChanged -= HandleMobileStateChanged;
     }
 }

--- a/src/Web/NexaCRM.WebClient/Program.cs
+++ b/src/Web/NexaCRM.WebClient/Program.cs
@@ -54,6 +54,9 @@ builder.Services.AddScoped<Supabase.Client>(provider =>
 builder.Services.AddScoped<SupabaseClientProvider>();
 builder.Services.AddScoped<CustomAuthStateProvider>();
 builder.Services.AddScoped<AuthenticationStateProvider>(provider => provider.GetRequiredService<CustomAuthStateProvider>());
+builder.Services.AddScoped<ActionInterop>();
+builder.Services.AddScoped<IMobileInteractionService, MobileInteractionService>();
+builder.Services.AddScoped<IGlobalActionService, GlobalActionService>();
 builder.Services.AddScoped<IContactService, SupabaseContactService>();
 builder.Services.AddScoped<IDealService, SupabaseDealService>();
 builder.Services.AddScoped<ITaskService, SupabaseTaskService>();

--- a/src/Web/NexaCRM.WebClient/Services/ActionInterop.cs
+++ b/src/Web/NexaCRM.WebClient/Services/ActionInterop.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.JSInterop;
+
+namespace NexaCRM.WebClient.Services;
+
+public sealed class ActionInterop : IAsyncDisposable
+{
+    private readonly Lazy<Task<IJSObjectReference>> _moduleTask;
+
+    public ActionInterop(IJSRuntime jsRuntime)
+    {
+        if (jsRuntime is null)
+        {
+            throw new ArgumentNullException(nameof(jsRuntime));
+        }
+
+        _moduleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>("import", "./js/actions.js").AsTask());
+    }
+
+    public async Task VibrateAsync(int duration)
+    {
+        if (duration <= 0)
+        {
+            return;
+        }
+
+        var module = await _moduleTask.Value.ConfigureAwait(false);
+        await module.InvokeVoidAsync("vibrate", duration).ConfigureAwait(false);
+    }
+
+    public async Task OpenTelephoneAsync(string? phoneNumber)
+    {
+        if (string.IsNullOrWhiteSpace(phoneNumber))
+        {
+            return;
+        }
+
+        var module = await _moduleTask.Value.ConfigureAwait(false);
+        await module.InvokeVoidAsync("openTel", phoneNumber).ConfigureAwait(false);
+    }
+
+    public async Task OpenMailtoAsync(string? mailtoUrl)
+    {
+        if (string.IsNullOrWhiteSpace(mailtoUrl))
+        {
+            return;
+        }
+
+        var module = await _moduleTask.Value.ConfigureAwait(false);
+        await module.InvokeVoidAsync("openMailto", mailtoUrl).ConfigureAwait(false);
+    }
+
+    public async Task<bool> CopyTextAsync(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return false;
+        }
+
+        var module = await _moduleTask.Value.ConfigureAwait(false);
+        return await module.InvokeAsync<bool>("copyText", value).ConfigureAwait(false);
+    }
+
+    public async Task TriggerDownloadAsync(string base64Data, string fileName, string? contentType = null)
+    {
+        if (string.IsNullOrEmpty(base64Data) || string.IsNullOrEmpty(fileName))
+        {
+            return;
+        }
+
+        var module = await _moduleTask.Value.ConfigureAwait(false);
+        await module.InvokeVoidAsync("triggerDownload", base64Data, fileName, contentType).ConfigureAwait(false);
+    }
+
+    public async Task SmoothScrollToAsync(string elementId)
+    {
+        if (string.IsNullOrWhiteSpace(elementId))
+        {
+            return;
+        }
+
+        var module = await _moduleTask.Value.ConfigureAwait(false);
+        await module.InvokeVoidAsync("smoothScrollToId", elementId).ConfigureAwait(false);
+    }
+
+    public async Task FocusSelectorAsync(string selector)
+    {
+        if (string.IsNullOrWhiteSpace(selector))
+        {
+            return;
+        }
+
+        var module = await _moduleTask.Value.ConfigureAwait(false);
+        await module.InvokeVoidAsync("focusSelector", selector).ConfigureAwait(false);
+    }
+
+    public async Task<bool> IsMobileViewportAsync()
+    {
+        var module = await _moduleTask.Value.ConfigureAwait(false);
+        return await module.InvokeAsync<bool>("isMobileViewport").ConfigureAwait(false);
+    }
+
+    public async Task RegisterFabOutsideHandlerAsync()
+    {
+        var module = await _moduleTask.Value.ConfigureAwait(false);
+        await module.InvokeVoidAsync("registerFabOutsideHandler").ConfigureAwait(false);
+    }
+
+    public async Task SetupMobileDashboardAsync()
+    {
+        var module = await _moduleTask.Value.ConfigureAwait(false);
+        await module.InvokeVoidAsync("setupMobileDashboard").ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_moduleTask.IsValueCreated)
+        {
+            try
+            {
+                var module = await _moduleTask.Value.ConfigureAwait(false);
+                await module.DisposeAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+                // ignore disposal failures
+            }
+        }
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Services/GlobalActionService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/GlobalActionService.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NexaCRM.WebClient.Services.Interfaces;
+
+namespace NexaCRM.WebClient.Services;
+
+public sealed class GlobalActionService : IGlobalActionService
+{
+    public event Func<GlobalActionContext, Task>? ActionRequested;
+
+    public async Task<GlobalActionResult> LaunchAsync(GlobalActionRequest request, CancellationToken cancellationToken = default)
+    {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var handler = ActionRequested;
+        if (handler is null)
+        {
+            return GlobalActionResult.NotHandled;
+        }
+
+        var context = new GlobalActionContext(request);
+        var invocation = handler(context);
+
+        using (cancellationToken.Register(context.Cancel))
+        {
+            await invocation.ConfigureAwait(false);
+            return await context.Completion.ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IContactService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IContactService.cs
@@ -1,11 +1,13 @@
-using NexaCRM.WebClient.Models;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using NexaCRM.WebClient.Models;
 
 namespace NexaCRM.WebClient.Services.Interfaces
 {
     public interface IContactService
     {
         Task<IEnumerable<Contact>> GetContactsAsync();
+        Task<Contact> CreateContactAsync(Contact contact, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IDealService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IDealService.cs
@@ -1,11 +1,14 @@
-using NexaCRM.WebClient.Models;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using NexaCRM.WebClient.Models;
 
 namespace NexaCRM.WebClient.Services.Interfaces
 {
     public interface IDealService
     {
         Task<IEnumerable<Deal>> GetDealsAsync();
+        Task<IReadOnlyList<DealStage>> GetDealStagesAsync(CancellationToken cancellationToken = default);
+        Task<Deal> CreateDealAsync(DealCreateRequest request, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IGlobalActionService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IGlobalActionService.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+public enum GlobalActionType
+{
+    Call,
+    Email,
+    ScheduleMeeting,
+    AddContact,
+    AddDeal
+}
+
+public sealed record GlobalActionRequest(
+    GlobalActionType Type,
+    string? TargetId = null,
+    string? TargetName = null,
+    string? PhoneNumber = null,
+    string? Email = null,
+    IReadOnlyDictionary<string, string>? Metadata = null);
+
+public enum GlobalActionResult
+{
+    Completed,
+    Cancelled,
+    NotHandled,
+    Failed
+}
+
+public sealed class GlobalActionContext
+{
+    private readonly TaskCompletionSource<GlobalActionResult> _completionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public GlobalActionContext(GlobalActionRequest request)
+    {
+        Request = request ?? throw new ArgumentNullException(nameof(request));
+    }
+
+    public GlobalActionRequest Request { get; }
+
+    public Task<GlobalActionResult> Completion => _completionSource.Task;
+
+    public void Complete(GlobalActionResult result) => _completionSource.TrySetResult(result);
+
+    public void Fail() => _completionSource.TrySetResult(GlobalActionResult.Failed);
+
+    public void Cancel() => _completionSource.TrySetResult(GlobalActionResult.Cancelled);
+}
+
+public interface IGlobalActionService
+{
+    event Func<GlobalActionContext, Task>? ActionRequested;
+
+    Task<GlobalActionResult> LaunchAsync(GlobalActionRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IMobileInteractionService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IMobileInteractionService.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+public interface IMobileInteractionService
+{
+    bool IsSearchOpen { get; }
+    bool AreNotificationsOpen { get; }
+
+    event Action? StateChanged;
+
+    Task ToggleMenuAsync();
+    Task ToggleSearchAsync();
+    Task ToggleNotificationsAsync();
+    Task CloseAllAsync();
+    Task ScrollToAsync(string elementId);
+}

--- a/src/Web/NexaCRM.WebClient/Services/MobileInteractionService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/MobileInteractionService.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.JSInterop;
+using NexaCRM.WebClient.Services.Interfaces;
+
+namespace NexaCRM.WebClient.Services;
+
+public sealed class MobileInteractionService : IMobileInteractionService
+{
+    private readonly IJSRuntime _jsRuntime;
+    private readonly ActionInterop _actionInterop;
+    private bool _searchOpen;
+    private bool _notificationsOpen;
+
+    public MobileInteractionService(IJSRuntime jsRuntime, ActionInterop actionInterop)
+    {
+        _jsRuntime = jsRuntime ?? throw new ArgumentNullException(nameof(jsRuntime));
+        _actionInterop = actionInterop ?? throw new ArgumentNullException(nameof(actionInterop));
+    }
+
+    public bool IsSearchOpen => _searchOpen;
+    public bool AreNotificationsOpen => _notificationsOpen;
+
+    public event Action? StateChanged;
+
+    public async Task ToggleMenuAsync()
+    {
+        await ClosePanelsInternalAsync(closeSearch: true, closeNotifications: true).ConfigureAwait(false);
+        try
+        {
+            await _jsRuntime.InvokeVoidAsync("layoutInterop.toggleMenu", false).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Swallow invocation exceptions to keep UX responsive in environments without the helper script.
+        }
+    }
+
+    public async Task ToggleSearchAsync()
+    {
+        _searchOpen = !_searchOpen;
+        if (_searchOpen)
+        {
+            _notificationsOpen = false;
+        }
+
+        OnStateChanged();
+
+        if (_searchOpen)
+        {
+            await Task.Delay(120).ConfigureAwait(false);
+            await _actionInterop.FocusSelectorAsync(".mobile-search-input input").ConfigureAwait(false);
+        }
+    }
+
+    public Task ToggleNotificationsAsync()
+    {
+        _notificationsOpen = !_notificationsOpen;
+        if (_notificationsOpen)
+        {
+            _searchOpen = false;
+        }
+
+        OnStateChanged();
+        return Task.CompletedTask;
+    }
+
+    public async Task CloseAllAsync()
+    {
+        await ClosePanelsInternalAsync(closeSearch: true, closeNotifications: true).ConfigureAwait(false);
+    }
+
+    public Task ScrollToAsync(string elementId)
+    {
+        return _actionInterop.SmoothScrollToAsync(elementId);
+    }
+
+    private async Task ClosePanelsInternalAsync(bool closeSearch, bool closeNotifications)
+    {
+        var changed = false;
+
+        if (closeSearch && _searchOpen)
+        {
+            _searchOpen = false;
+            changed = true;
+        }
+
+        if (closeNotifications && _notificationsOpen)
+        {
+            _notificationsOpen = false;
+            changed = true;
+        }
+
+        if (changed)
+        {
+            OnStateChanged();
+            await Task.Yield();
+        }
+    }
+
+    private void OnStateChanged() => StateChanged?.Invoke();
+}

--- a/src/Web/NexaCRM.WebClient/Services/Mock/MockContactService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Mock/MockContactService.cs
@@ -1,27 +1,53 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using NexaCRM.WebClient.Models;
 using NexaCRM.WebClient.Services.Interfaces;
-using System.Collections.Generic;
 
 namespace NexaCRM.WebClient.Services.Mock
 {
     public class MockContactService : IContactService
     {
+        private static readonly List<Contact> Contacts = new()
+        {
+            new Contact { Id = 1, FirstName = "John", LastName = "Doe", Email = "john.doe@example.com", PhoneNumber = "123-456-7890" },
+            new Contact { Id = 2, FirstName = "Jane", LastName = "Smith", Email = "jane.smith@example.com", PhoneNumber = "098-765-4321" },
+            new Contact { Id = 3, FirstName = "Peter", LastName = "Jones", Email = "peter.jones@example.com", PhoneNumber = "111-222-3333" },
+            new Contact { Id = 4, FirstName = "Mary", LastName = "Brown", Email = "mary.brown@example.com", PhoneNumber = "444-555-6666" },
+            new Contact { Id = 5, FirstName = "David", LastName = "Wilson", Email = "david.wilson@example.com", PhoneNumber = "777-888-9999" },
+            new Contact { Id = 6, FirstName = "Susan", LastName = "Taylor", Email = "susan.taylor@example.com", PhoneNumber = "123-123-1234" },
+            new Contact { Id = 7, FirstName = "Michael", LastName = "Clark", Email = "michael.clark@example.com", PhoneNumber = "456-456-4567" },
+            new Contact { Id = 8, FirstName = "Linda", LastName = "Harris", Email = "linda.harris@example.com", PhoneNumber = "789-789-7890" },
+            new Contact { Id = 9, FirstName = "Robert", LastName = "Lee", Email = "robert.lee@example.com", PhoneNumber = "112-233-4455" },
+            new Contact { Id = 10, FirstName = "Patricia", LastName = "Walker", Email = "patricia.walker@example.com", PhoneNumber = "667-788-9900" }
+        };
+
         public System.Threading.Tasks.Task<IEnumerable<Contact>> GetContactsAsync()
         {
-            var contacts = new List<Contact>
+            return System.Threading.Tasks.Task.FromResult<IEnumerable<Contact>>(Contacts.ToList());
+        }
+
+        public System.Threading.Tasks.Task<Contact> CreateContactAsync(Contact contact, CancellationToken cancellationToken = default)
+        {
+            if (contact is null)
             {
-                new Contact { Id = 1, FirstName = "John", LastName = "Doe", Email = "john.doe@example.com", PhoneNumber = "123-456-7890" },
-                new Contact { Id = 2, FirstName = "Jane", LastName = "Smith", Email = "jane.smith@example.com", PhoneNumber = "098-765-4321" },
-                new Contact { Id = 3, FirstName = "Peter", LastName = "Jones", Email = "peter.jones@example.com", PhoneNumber = "111-222-3333" },
-                new Contact { Id = 4, FirstName = "Mary", LastName = "Brown", Email = "mary.brown@example.com", PhoneNumber = "444-555-6666" },
-                new Contact { Id = 5, FirstName = "David", LastName = "Wilson", Email = "david.wilson@example.com", PhoneNumber = "777-888-9999" },
-                new Contact { Id = 6, FirstName = "Susan", LastName = "Taylor", Email = "susan.taylor@example.com", PhoneNumber = "123-123-1234" },
-                new Contact { Id = 7, FirstName = "Michael", LastName = "Clark", Email = "michael.clark@example.com", PhoneNumber = "456-456-4567" },
-                new Contact { Id = 8, FirstName = "Linda", LastName = "Harris", Email = "linda.harris@example.com", PhoneNumber = "789-789-7890" },
-                new Contact { Id = 9, FirstName = "Robert", LastName = "Lee", Email = "robert.lee@example.com", PhoneNumber = "112-233-4455" },
-                new Contact { Id = 10, FirstName = "Patricia", LastName = "Walker", Email = "patricia.walker@example.com", PhoneNumber = "667-788-9900" }
+                throw new ArgumentNullException(nameof(contact));
+            }
+
+            var nextId = Contacts.Count == 0 ? 1 : Contacts.Max(c => c.Id) + 1;
+            var created = new Contact
+            {
+                Id = nextId,
+                FirstName = contact.FirstName,
+                LastName = contact.LastName,
+                Email = contact.Email,
+                PhoneNumber = contact.PhoneNumber,
+                Company = contact.Company,
+                Title = contact.Title
             };
-            return System.Threading.Tasks.Task.FromResult<IEnumerable<Contact>>(contacts);
+
+            Contacts.Add(created);
+            return System.Threading.Tasks.Task.FromResult(created);
         }
     }
 }

--- a/src/Web/NexaCRM.WebClient/Services/Mock/MockDealService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Mock/MockDealService.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using NexaCRM.WebClient.Models;
 using NexaCRM.WebClient.Services.Interfaces;
 
@@ -7,17 +9,74 @@ namespace NexaCRM.WebClient.Services.Mock
 {
     public class MockDealService : IDealService
     {
+        private static readonly List<DealStage> DealStages = new()
+        {
+            new DealStage { Id = 1, Name = "Prospecting", SortOrder = 1 },
+            new DealStage { Id = 2, Name = "Qualification", SortOrder = 2 },
+            new DealStage { Id = 3, Name = "Proposal", SortOrder = 3 },
+            new DealStage { Id = 4, Name = "Negotiation", SortOrder = 4 },
+            new DealStage { Id = 5, Name = "Closed (Won)", SortOrder = 5 },
+            new DealStage { Id = 6, Name = "Closed (Lost)", SortOrder = 6 }
+        };
+
+        private static readonly List<Deal> Deals = new()
+        {
+            new Deal { Id = 1, Name = "Deal 1", Stage = "Prospecting", Amount = 50000, Company = "Company A", ContactPerson = "John Doe", Owner = "Alex Kim", CreatedDate = DateTime.Today.AddDays(-3) },
+            new Deal { Id = 2, Name = "Deal 2", Stage = "Qualification", Amount = 30000, Company = "Company B", ContactPerson = "Jane Smith", Owner = "Alex Kim", CreatedDate = DateTime.Today.AddDays(-18) },
+            new Deal { Id = 3, Name = "Deal 3", Stage = "Proposal", Amount = 20000, Company = "Company C", ContactPerson = "Peter Jones", Owner = "Morgan Lee", CreatedDate = DateTime.Today.AddDays(-33) },
+            new Deal { Id = 4, Name = "Deal 4", Stage = "Negotiation", Amount = 15000, Company = "Company D", ContactPerson = "Mary Johnson", Owner = "Jordan Park", CreatedDate = DateTime.Today.AddDays(-8) },
+            new Deal { Id = 5, Name = "Deal 5", Stage = "Closed (Won)", Amount = 100000, Company = "Company E", ContactPerson = "David Williams", Owner = "Morgan Lee", CreatedDate = DateTime.Today.AddDays(-65) }
+        };
+
         public System.Threading.Tasks.Task<IEnumerable<Deal>> GetDealsAsync()
         {
-            var deals = new List<Deal>
+            return System.Threading.Tasks.Task.FromResult<IEnumerable<Deal>>(Deals.ToList());
+        }
+
+        public System.Threading.Tasks.Task<IReadOnlyList<DealStage>> GetDealStagesAsync(CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<DealStage> ordered = DealStages
+                .OrderBy(stage => stage.SortOrder)
+                .ThenBy(stage => stage.Name)
+                .Select(stage => new DealStage
+                {
+                    Id = stage.Id,
+                    Name = stage.Name,
+                    SortOrder = stage.SortOrder
+                })
+                .ToList();
+
+            return System.Threading.Tasks.Task.FromResult(ordered);
+        }
+
+        public System.Threading.Tasks.Task<Deal> CreateDealAsync(DealCreateRequest request, CancellationToken cancellationToken = default)
+        {
+            if (request is null)
             {
-                new Deal { Id = 1, Name = "Deal 1", Stage = "Prospecting", Amount = 50000, Company = "Company A", ContactPerson = "John Doe", Owner = "Alex Kim", CreatedDate = DateTime.Today.AddDays(-3) },
-                new Deal { Id = 2, Name = "Deal 2", Stage = "Qualification", Amount = 30000, Company = "Company B", ContactPerson = "Jane Smith", Owner = "Alex Kim", CreatedDate = DateTime.Today.AddDays(-18) },
-                new Deal { Id = 3, Name = "Deal 3", Stage = "Proposal", Amount = 20000, Company = "Company C", ContactPerson = "Peter Jones", Owner = "Morgan Lee", CreatedDate = DateTime.Today.AddDays(-33) },
-                new Deal { Id = 4, Name = "Deal 4", Stage = "Negotiation", Amount = 15000, Company = "Company D", ContactPerson = "Mary Johnson", Owner = "Jordan Park", CreatedDate = DateTime.Today.AddDays(-8) },
-                new Deal { Id = 5, Name = "Deal 5", Stage = "Closed (Won)", Amount = 100000, Company = "Company E", ContactPerson = "David Williams", Owner = "Morgan Lee", CreatedDate = DateTime.Today.AddDays(-65) }
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            var stage = DealStages.FirstOrDefault(s => s.Id == request.StageId);
+            if (stage is null)
+            {
+                throw new InvalidOperationException($"Unknown stage id {request.StageId}.");
+            }
+
+            var nextId = Deals.Count == 0 ? 1 : Deals.Max(d => d.Id) + 1;
+            var deal = new Deal
+            {
+                Id = nextId,
+                Name = request.Name,
+                Stage = stage.Name,
+                Amount = request.Amount,
+                Company = request.Company,
+                ContactPerson = request.ContactName,
+                Owner = request.Owner,
+                CreatedDate = DateTime.UtcNow
             };
-            return System.Threading.Tasks.Task.FromResult<IEnumerable<Deal>>(deals);
+
+            Deals.Add(deal);
+            return System.Threading.Tasks.Task.FromResult(deal);
         }
     }
 }

--- a/src/Web/NexaCRM.WebClient/Services/SupabaseSmsService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SupabaseSmsService.cs
@@ -408,9 +408,16 @@ public sealed class SupabaseSmsService : ISmsService
 
     private static SmsHistoryItem MapToHistoryItem(SmsHistoryRecord record)
     {
-        var attachments = string.IsNullOrWhiteSpace(record.AttachmentsJson)
-            ? Array.Empty<SmsAttachment>()
-            : JsonConvert.DeserializeObject<List<SmsAttachment>>(record.AttachmentsJson!) ?? new List<SmsAttachment>();
+        IReadOnlyList<SmsAttachment> attachments;
+        if (string.IsNullOrWhiteSpace(record.AttachmentsJson))
+        {
+            attachments = Array.Empty<SmsAttachment>();
+        }
+        else
+        {
+            attachments = JsonConvert.DeserializeObject<List<SmsAttachment>>(record.AttachmentsJson!)
+                ?? new List<SmsAttachment>();
+        }
 
         return new SmsHistoryItem(
             record.Recipient,

--- a/src/Web/NexaCRM.WebClient/Services/SupabaseSupportTicketService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SupabaseSupportTicketService.cs
@@ -327,15 +327,6 @@ public sealed class SupabaseSupportTicketService : ISupportTicketService, IAsync
         int? ticketId = change.OldModel<SupportTicketRecord>()?.Id;
         if (ticketId is null)
         {
-            var firstId = change.Payload?.Data?.Ids?.FirstOrDefault();
-            if (firstId.HasValue)
-            {
-                ticketId = firstId.Value;
-            }
-        }
-
-        if (ticketId is null)
-        {
             return;
         }
 

--- a/src/Web/NexaCRM.WebClient/Services/SupabaseTaskService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SupabaseTaskService.cs
@@ -297,15 +297,6 @@ public sealed class SupabaseTaskService : ITaskService, IAsyncDisposable
 
         if (taskId is null)
         {
-            var firstId = change.Payload?.Data?.Ids?.FirstOrDefault();
-            if (firstId.HasValue)
-            {
-                taskId = firstId.Value;
-            }
-        }
-
-        if (taskId is null)
-        {
             return;
         }
 

--- a/src/Web/NexaCRM.WebClient/Shared/GlobalActionHost.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/GlobalActionHost.razor
@@ -1,0 +1,683 @@
+@using System.ComponentModel.DataAnnotations
+@using NexaCRM.WebClient.Models
+@using NexaCRM.WebClient.Services.Interfaces
+@inject IGlobalActionService ActionService
+@inject IContactService ContactService
+@inject IDealService DealService
+@inject ActionInterop ActionInterop
+@inject IMobileInteractionService MobileInteractionService
+@implements IDisposable
+
+@if (activeContext is not null)
+{
+    <div class="global-action-overlay" role="presentation">
+        <div class="global-action-dialog" role="dialog" aria-modal="true" aria-live="polite">
+            <header class="global-action-dialog__header">
+                <h2>@GetDialogTitle(activeContext.Request.Type)</h2>
+                <button type="button" class="global-action-dialog__close" @onclick="CancelAction" aria-label="Close">×</button>
+            </header>
+
+            <div class="global-action-dialog__body">
+                @if (!string.IsNullOrWhiteSpace(errorMessage))
+                {
+                    <div class="global-action-alert global-action-alert--error">@errorMessage</div>
+                }
+                @if (!string.IsNullOrWhiteSpace(successMessage))
+                {
+                    <div class="global-action-alert global-action-alert--success">@successMessage</div>
+                }
+
+                @if (activeContext.Request.Type == GlobalActionType.Call)
+                {
+                    <section class="global-action-section">
+                        <label class="global-action-field">
+                            <span>@Localize("SelectContact")</span>
+                            <input type="search"
+                                   class="global-action-input"
+                                   placeholder="@Localize("SearchContacts")"
+                                   @bind="callSearchTerm"
+                                   @bind:event="oninput" />
+                        </label>
+
+                        <ul class="global-action-contact-list">
+                            @foreach (var contact in FilteredContacts)
+                            {
+                                var isActive = selectedContact?.Id == contact.Id;
+                                <li class="global-action-contact-item @(isActive ? "is-active" : null)" @onclick="() => SelectContact(contact)" role="button">
+                                    <div class="global-action-contact-name">@(!string.IsNullOrWhiteSpace(contact.DisplayName) ? contact.DisplayName : Localize("UnknownContact"))</div>
+                                    <div class="global-action-contact-meta">@FormatContactMeta(contact)</div>
+                                </li>
+                            }
+                        </ul>
+
+                        @if (selectedContact is not null)
+                        {
+                            <div class="global-action-actions">
+                                <button class="global-action-primary" @onclick="LaunchCallAsync">@Localize("StartCall")</button>
+                                @if (!string.IsNullOrWhiteSpace(selectedContact.PhoneNumber))
+                                {
+                                    <button class="global-action-secondary" @onclick="CopySelectedPhoneAsync">@Localize("CopyNumber")</button>
+                                }
+                            </div>
+                        }
+                    </section>
+                }
+                else if (activeContext.Request.Type == GlobalActionType.Email)
+                {
+                    <section class="global-action-section">
+                        @if (selectedContact is not null)
+                        {
+                            <p class="global-action-context">@string.Format(Localize("EmailingContactFormat"), selectedContact.DisplayName)</p>
+                        }
+                        <EditForm Model="emailForm" OnValidSubmit="LaunchEmailAsync">
+                            <DataAnnotationsValidator />
+                            <ValidationSummary />
+
+                            <label class="global-action-field">
+                                <span>@Localize("EmailSubject")</span>
+                                <InputText class="global-action-input" @bind-Value="emailForm.Subject" />
+                            </label>
+
+                            <label class="global-action-field">
+                                <span>@Localize("EmailBody")</span>
+                                <InputTextArea class="global-action-textarea" Rows="6" @bind-Value="emailForm.Body" />
+                            </label>
+
+                            <div class="global-action-actions">
+                                <button type="submit" class="global-action-primary">@Localize("SendEmail")</button>
+                            </div>
+                        </EditForm>
+                    </section>
+                }
+                else if (activeContext.Request.Type == GlobalActionType.ScheduleMeeting)
+                {
+                    <section class="global-action-section">
+                        @if (selectedContact is not null)
+                        {
+                            <p class="global-action-context">@string.Format(Localize("MeetingWithContactFormat"), selectedContact.DisplayName)</p>
+                        }
+                        <EditForm Model="meetingForm" OnValidSubmit="ScheduleMeetingAsync">
+                            <DataAnnotationsValidator />
+                            <ValidationSummary />
+
+                            <label class="global-action-field">
+                                <span>@Localize("MeetingTitle")</span>
+                                <InputText class="global-action-input" @bind-Value="meetingForm.Title" />
+                            </label>
+
+                            <div class="global-action-date-grid">
+                                <label>
+                                    <span>@Localize("MeetingStart")</span>
+                                    <InputDate class="global-action-input" @bind-Value="meetingForm.Start" />
+                                </label>
+                                <label>
+                                    <span>@Localize("MeetingEnd")</span>
+                                    <InputDate class="global-action-input" @bind-Value="meetingForm.End" />
+                                </label>
+                            </div>
+
+                            <label class="global-action-field">
+                                <span>@Localize("MeetingNotes")</span>
+                                <InputTextArea class="global-action-textarea" Rows="4" @bind-Value="meetingForm.Description" />
+                            </label>
+
+                            <div class="global-action-actions">
+                                <button type="submit" class="global-action-primary">@Localize("CreateInvite")</button>
+                            </div>
+                        </EditForm>
+                    </section>
+                }
+                else if (activeContext.Request.Type == GlobalActionType.AddContact)
+                {
+                    <section class="global-action-section">
+                        <EditForm Model="contactForm" OnValidSubmit="SaveContactAsync">
+                            <DataAnnotationsValidator />
+                            <ValidationSummary />
+
+                            <label class="global-action-field">
+                                <span>@Localize("FirstName")</span>
+                                <InputText class="global-action-input" @bind-Value="contactForm.FirstName" />
+                            </label>
+                            <label class="global-action-field">
+                                <span>@Localize("LastName")</span>
+                                <InputText class="global-action-input" @bind-Value="contactForm.LastName" />
+                            </label>
+                            <label class="global-action-field">
+                                <span>@Localize("Email")</span>
+                                <InputText class="global-action-input" type="email" @bind-Value="contactForm.Email" />
+                            </label>
+                            <label class="global-action-field">
+                                <span>@Localize("PhoneNumber")</span>
+                                <InputText class="global-action-input" type="tel" @bind-Value="contactForm.PhoneNumber" />
+                            </label>
+                            <label class="global-action-field">
+                                <span>@Localize("Company")</span>
+                                <InputText class="global-action-input" @bind-Value="contactForm.Company" />
+                            </label>
+                            <label class="global-action-field">
+                                <span>@Localize("Title")</span>
+                                <InputText class="global-action-input" @bind-Value="contactForm.Title" />
+                            </label>
+
+                            <div class="global-action-actions">
+                                <button type="submit" class="global-action-primary">@Localize("SaveContact")</button>
+                            </div>
+                        </EditForm>
+                    </section>
+                }
+                else if (activeContext.Request.Type == GlobalActionType.AddDeal)
+                {
+                    <section class="global-action-section">
+                        <EditForm Model="dealForm" OnValidSubmit="SaveDealAsync">
+                            <DataAnnotationsValidator />
+                            <ValidationSummary />
+
+                            <label class="global-action-field">
+                                <span>@Localize("DealName")</span>
+                                <InputText class="global-action-input" @bind-Value="dealForm.Name" />
+                            </label>
+
+                            <label class="global-action-field">
+                                <span>@Localize("DealStage")</span>
+                                <InputSelect class="global-action-input" @bind-Value="dealForm.StageId">
+                                    <option value="">@Localize("SelectOption")</option>
+                                    @foreach (var stage in dealStages)
+                                    {
+                                        <option value="@stage.Id">@stage.Name</option>
+                                    }
+                                </InputSelect>
+                            </label>
+
+                            <label class="global-action-field">
+                                <span>@Localize("DealAmount")</span>
+                                <InputNumber class="global-action-input" @bind-Value="dealForm.Amount" />
+                            </label>
+
+                            <label class="global-action-field">
+                                <span>@Localize("Company")</span>
+                                <InputText class="global-action-input" @bind-Value="dealForm.Company" />
+                            </label>
+                            <label class="global-action-field">
+                                <span>@Localize("PrimaryContact")</span>
+                                <InputText class="global-action-input" @bind-Value="dealForm.ContactName" />
+                            </label>
+                            <label class="global-action-field">
+                                <span>@Localize("Owner")</span>
+                                <InputText class="global-action-input" @bind-Value="dealForm.Owner" />
+                            </label>
+                            <label class="global-action-field">
+                                <span>@Localize("ExpectedCloseDate")</span>
+                                <InputDate class="global-action-input" @bind-Value="dealForm.ExpectedCloseDate" />
+                            </label>
+
+                            <div class="global-action-actions">
+                                <button type="submit" class="global-action-primary">@Localize("CreateDeal")</button>
+                            </div>
+                        </EditForm>
+                    </section>
+                }
+            </div>
+
+            <footer class="global-action-dialog__footer">
+                <button type="button" class="global-action-secondary" @onclick="CancelAction">@Localize("Cancel")</button>
+            </footer>
+        </div>
+    </div>
+}
+
+@code {
+    private GlobalActionContext? activeContext;
+    private List<ContactOption> contacts = new();
+    private ContactOption? selectedContact;
+    private string callSearchTerm = string.Empty;
+    private EmailFormModel emailForm = new();
+    private MeetingFormModel meetingForm = new();
+    private ContactFormModel contactForm = new();
+    private DealFormModel dealForm = new();
+    private IReadOnlyList<DealStage> dealStages = Array.Empty<DealStage>();
+    private string? errorMessage;
+    private string? successMessage;
+
+    private IEnumerable<ContactOption> FilteredContacts => string.IsNullOrWhiteSpace(callSearchTerm)
+        ? contacts.Take(12)
+        : contacts
+            .Where(c =>
+                (!string.IsNullOrWhiteSpace(c.DisplayName) && c.DisplayName.Contains(callSearchTerm, StringComparison.OrdinalIgnoreCase)) ||
+                (!string.IsNullOrWhiteSpace(c.Email) && c.Email.Contains(callSearchTerm, StringComparison.OrdinalIgnoreCase)) ||
+                (!string.IsNullOrWhiteSpace(c.PhoneNumber) && c.PhoneNumber.Contains(callSearchTerm, StringComparison.OrdinalIgnoreCase)) ||
+                (!string.IsNullOrWhiteSpace(c.Company) && c.Company.Contains(callSearchTerm, StringComparison.OrdinalIgnoreCase)))
+            .Take(12);
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        ActionService.ActionRequested += HandleActionRequested;
+    }
+
+    private Task HandleActionRequested(GlobalActionContext context)
+    {
+        return InvokeAsync(async () =>
+        {
+            await MobileInteractionService.CloseAllAsync().ConfigureAwait(false);
+            activeContext = context;
+            ResetForms();
+            await LoadContextDataAsync(context.Request).ConfigureAwait(false);
+            StateHasChanged();
+            _ = ObserveCompletionAsync(context);
+        });
+    }
+
+    private async Task ObserveCompletionAsync(GlobalActionContext context)
+    {
+        try
+        {
+            await context.Completion.ConfigureAwait(false);
+        }
+        finally
+        {
+            await InvokeAsync(() =>
+            {
+                if (ReferenceEquals(activeContext, context))
+                {
+                    activeContext = null;
+                }
+
+                ResetForms();
+                StateHasChanged();
+            });
+        }
+    }
+
+    private async Task LoadContextDataAsync(GlobalActionRequest request)
+    {
+        errorMessage = null;
+        successMessage = null;
+
+        if (request.Type is GlobalActionType.Call or GlobalActionType.Email or GlobalActionType.ScheduleMeeting or GlobalActionType.AddDeal)
+        {
+            await EnsureContactsLoadedAsync().ConfigureAwait(false);
+
+            if (!string.IsNullOrWhiteSpace(request.TargetId) && int.TryParse(request.TargetId, out var id))
+            {
+                selectedContact = contacts.FirstOrDefault(c => c.Id == id);
+            }
+
+            if (selectedContact is null && !string.IsNullOrWhiteSpace(request.PhoneNumber))
+            {
+                selectedContact = contacts.FirstOrDefault(c => string.Equals(c.PhoneNumber, request.PhoneNumber, StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (selectedContact is null && !string.IsNullOrWhiteSpace(request.Email))
+            {
+                selectedContact = contacts.FirstOrDefault(c => string.Equals(c.Email, request.Email, StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (selectedContact is null && !string.IsNullOrWhiteSpace(request.TargetName))
+            {
+                selectedContact = contacts.FirstOrDefault(c => string.Equals(c.DisplayName, request.TargetName, StringComparison.OrdinalIgnoreCase));
+            }
+        }
+
+        if (request.Type == GlobalActionType.Email)
+        {
+            emailForm = new EmailFormModel
+            {
+                Subject = request.Metadata?.TryGetValue("subject", out var subject) == true ? subject : Localize("DefaultEmailSubject"),
+                Body = request.Metadata?.TryGetValue("body", out var body) == true ? body : string.Empty
+            };
+        }
+        else if (request.Type == GlobalActionType.ScheduleMeeting)
+        {
+            meetingForm = new MeetingFormModel
+            {
+                Title = string.IsNullOrWhiteSpace(request.TargetName) ? Localize("DefaultMeetingTitle") : string.Format(Localize("MeetingWithContactFormat"), request.TargetName),
+                Start = DateTimeOffset.Now.AddMinutes(30),
+                End = DateTimeOffset.Now.AddMinutes(60)
+            };
+        }
+        else if (request.Type == GlobalActionType.AddDeal)
+        {
+            dealStages = await DealService.GetDealStagesAsync().ConfigureAwait(false);
+            if (selectedContact is not null)
+            {
+                dealForm.ContactName = selectedContact.DisplayName;
+                dealForm.Company ??= selectedContact.Company;
+            }
+        }
+    }
+
+    private async Task EnsureContactsLoadedAsync()
+    {
+        if (contacts.Count > 0)
+        {
+            return;
+        }
+
+        var list = await ContactService.GetContactsAsync().ConfigureAwait(false);
+        contacts = list
+            .Select(c => new ContactOption(
+                c.Id,
+                string.Join(" ", new[] { c.FirstName, c.LastName }.Where(part => !string.IsNullOrWhiteSpace(part))).Trim(),
+                c.Email ?? string.Empty,
+                c.PhoneNumber ?? string.Empty,
+                c.Company ?? string.Empty))
+            .OrderBy(c => c.DisplayName)
+            .ToList();
+    }
+
+    private void ResetForms()
+    {
+        callSearchTerm = string.Empty;
+        emailForm = new EmailFormModel();
+        meetingForm = new MeetingFormModel();
+        contactForm = new ContactFormModel();
+        dealForm = new DealFormModel { ExpectedCloseDate = DateTime.Today.AddDays(14) };
+        errorMessage = null;
+        successMessage = null;
+        selectedContact = null;
+    }
+
+    private void SelectContact(ContactOption contact)
+    {
+        selectedContact = contact;
+        successMessage = null;
+    }
+
+    private string FormatContactMeta(ContactOption option)
+    {
+        var parts = new List<string>();
+        if (!string.IsNullOrWhiteSpace(option.Email))
+        {
+            parts.Add(option.Email);
+        }
+        if (!string.IsNullOrWhiteSpace(option.PhoneNumber))
+        {
+            parts.Add(option.PhoneNumber);
+        }
+        if (!string.IsNullOrWhiteSpace(option.Company))
+        {
+            parts.Add(option.Company);
+        }
+        return parts.Count == 0 ? Localize("NoContactDetails") : string.Join(" · ", parts);
+    }
+
+    private async Task LaunchCallAsync()
+    {
+        if (selectedContact is null || string.IsNullOrWhiteSpace(selectedContact.PhoneNumber))
+        {
+            errorMessage = Localize("SelectContactForCall");
+            return;
+        }
+
+        await ActionInterop.OpenTelephoneAsync(selectedContact.PhoneNumber).ConfigureAwait(false);
+        successMessage = Localize("CallLaunched");
+        activeContext?.Complete(GlobalActionResult.Completed);
+    }
+
+    private async Task CopySelectedPhoneAsync()
+    {
+        if (selectedContact is null || string.IsNullOrWhiteSpace(selectedContact.PhoneNumber))
+        {
+            return;
+        }
+
+        await ActionInterop.CopyTextAsync(selectedContact.PhoneNumber).ConfigureAwait(false);
+        successMessage = Localize("CopiedToClipboard");
+    }
+
+    private async Task LaunchEmailAsync()
+    {
+        if (selectedContact is null || string.IsNullOrWhiteSpace(selectedContact.Email))
+        {
+            errorMessage = Localize("SelectContactForEmail");
+            return;
+        }
+
+        var subject = Uri.EscapeDataString(emailForm.Subject ?? string.Empty);
+        var body = Uri.EscapeDataString(emailForm.Body ?? string.Empty);
+        var mailto = $"mailto:{selectedContact.Email}?subject={subject}&body={body}";
+        await ActionInterop.OpenMailtoAsync(mailto).ConfigureAwait(false);
+        successMessage = Localize("EmailClientOpened");
+        activeContext?.Complete(GlobalActionResult.Completed);
+    }
+
+    private async Task ScheduleMeetingAsync()
+    {
+        if (meetingForm.End <= meetingForm.Start)
+        {
+            errorMessage = Localize("MeetingEndAfterStart");
+            return;
+        }
+
+        var summary = meetingForm.Title ?? Localize("DefaultMeetingTitle");
+        if (selectedContact is not null)
+        {
+            summary = string.Format(Localize("MeetingWithContactFormat"), selectedContact.DisplayName);
+        }
+
+        var description = meetingForm.Description ?? string.Empty;
+        if (selectedContact is not null && !string.IsNullOrWhiteSpace(selectedContact.Email))
+        {
+            description += $"\nAttendee: {selectedContact.Email}";
+        }
+
+        var ics = BuildIcs(summary, description, meetingForm.Start.UtcDateTime, meetingForm.End.UtcDateTime);
+        var base64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(ics));
+        var fileName = selectedContact is null ? "meeting.ics" : $"meeting-{Sanitize(selectedContact.DisplayName)}.ics";
+        await ActionInterop.TriggerDownloadAsync(base64, fileName, "text/calendar").ConfigureAwait(false);
+        successMessage = Localize("MeetingInviteCreated");
+        activeContext?.Complete(GlobalActionResult.Completed);
+    }
+
+    private async Task SaveContactAsync()
+    {
+        try
+        {
+            var contact = new Contact
+            {
+                FirstName = contactForm.FirstName,
+                LastName = contactForm.LastName,
+                Email = contactForm.Email,
+                PhoneNumber = contactForm.PhoneNumber,
+                Company = contactForm.Company,
+                Title = contactForm.Title
+            };
+
+            var created = await ContactService.CreateContactAsync(contact).ConfigureAwait(false);
+            successMessage = Localize("ContactCreated");
+            contacts.Add(new ContactOption(
+                created.Id,
+                string.Join(" ", new[] { created.FirstName, created.LastName }.Where(part => !string.IsNullOrWhiteSpace(part))).Trim(),
+                created.Email ?? string.Empty,
+                created.PhoneNumber ?? string.Empty,
+                created.Company ?? string.Empty));
+            contacts = contacts.OrderBy(c => c.DisplayName).ToList();
+            activeContext?.Complete(GlobalActionResult.Completed);
+        }
+        catch (Exception ex)
+        {
+            errorMessage = string.Format(Localize("ContactCreationFailed"), ex.Message);
+        }
+    }
+
+    private async Task SaveDealAsync()
+    {
+        try
+        {
+            if (!dealForm.StageId.HasValue)
+            {
+                errorMessage = Localize("SelectDealStage");
+                return;
+            }
+
+            var request = new DealCreateRequest
+            {
+                Name = dealForm.Name!,
+                StageId = dealForm.StageId.Value,
+                Amount = dealForm.Amount ?? 0,
+                Company = dealForm.Company,
+                ContactName = dealForm.ContactName,
+                Owner = dealForm.Owner,
+                ExpectedCloseDate = dealForm.ExpectedCloseDate
+            };
+
+            await DealService.CreateDealAsync(request).ConfigureAwait(false);
+            successMessage = Localize("DealCreated");
+            activeContext?.Complete(GlobalActionResult.Completed);
+        }
+        catch (Exception ex)
+        {
+            errorMessage = string.Format(Localize("DealCreationFailed"), ex.Message);
+        }
+    }
+
+    private static string BuildIcs(string summary, string description, DateTime startUtc, DateTime endUtc)
+    {
+        return $"BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//NexaCRM//EN\nBEGIN:VEVENT\nUID:{Guid.NewGuid()}\nDTSTAMP:{DateTime.UtcNow:yyyyMMddTHHmmssZ}\nDTSTART:{startUtc:yyyyMMddTHHmmssZ}\nDTEND:{endUtc:yyyyMMddTHHmmssZ}\nSUMMARY:{Escape(summary)}\nDESCRIPTION:{Escape(description)}\nEND:VEVENT\nEND:VCALENDAR";
+    }
+
+    private static string Escape(string value) => value.Replace("\\", "\\\\").Replace("\n", "\\n").Replace(",", "\\,");
+
+    private static string Sanitize(string value)
+    {
+        var chars = value.Where(c => char.IsLetterOrDigit(c) || c == '-').ToArray();
+        return chars.Length == 0 ? "meeting" : new string(chars).ToLowerInvariant();
+    }
+
+    private string Localize(string key) => key switch
+    {
+        "Cancel" => "취소",
+        "SelectContact" => "연락처 선택",
+        "SearchContacts" => "연락처 검색",
+        "UnknownContact" => "알 수 없음",
+        "NoContactDetails" => "연락처 정보 없음",
+        "StartCall" => "전화하기",
+        "CopyNumber" => "번호 복사",
+        "CallLaunched" => "전화 앱을 열었습니다.",
+        "CopiedToClipboard" => "클립보드에 복사되었습니다.",
+        "SelectContactForCall" => "전화를 걸 연락처를 선택하세요.",
+        "EmailSubject" => "제목",
+        "EmailBody" => "본문",
+        "EmailingContactFormat" => "{0}에게 이메일을 보냅니다.",
+        "SendEmail" => "이메일 열기",
+        "SelectContactForEmail" => "이메일을 보낼 연락처를 선택하세요.",
+        "EmailClientOpened" => "기본 이메일 앱을 열었습니다.",
+        "DefaultEmailSubject" => "안녕하세요",
+        "MeetingTitle" => "회의 제목",
+        "MeetingStart" => "시작 시간",
+        "MeetingEnd" => "종료 시간",
+        "MeetingNotes" => "메모",
+        "DefaultMeetingTitle" => "고객 미팅",
+        "MeetingWithContactFormat" => "{0}와(과)의 미팅",
+        "CreateInvite" => "초대장 생성",
+        "MeetingEndAfterStart" => "종료 시간은 시작 시간보다 이후여야 합니다.",
+        "MeetingInviteCreated" => "캘린더 초대장을 다운로드했습니다.",
+        "FirstName" => "이름",
+        "LastName" => "성",
+        "Email" => "이메일",
+        "PhoneNumber" => "전화",
+        "Company" => "회사",
+        "Title" => "직함",
+        "SaveContact" => "연락처 저장",
+        "ContactCreated" => "새 연락처가 저장되었습니다.",
+        "ContactCreationFailed" => "연락처 저장 실패: {0}",
+        "DealName" => "딜 이름",
+        "DealStage" => "영업 단계",
+        "DealAmount" => "금액",
+        "PrimaryContact" => "주 연락처",
+        "Owner" => "담당자",
+        "ExpectedCloseDate" => "예상 마감일",
+        "CreateDeal" => "딜 생성",
+        "SelectDealStage" => "딜 단계를 선택하세요.",
+        "DealCreated" => "새로운 딜이 생성되었습니다.",
+        "DealCreationFailed" => "딜 생성 실패: {0}",
+        _ => key
+    };
+
+    private string GetDialogTitle(GlobalActionType type) => type switch
+    {
+        GlobalActionType.Call => Localize("StartCall"),
+        GlobalActionType.Email => Localize("SendEmail"),
+        GlobalActionType.ScheduleMeeting => Localize("CreateInvite"),
+        GlobalActionType.AddContact => Localize("SaveContact"),
+        GlobalActionType.AddDeal => Localize("CreateDeal"),
+        _ => "Action"
+    };
+
+    private void CancelAction()
+    {
+        activeContext?.Cancel();
+        activeContext = null;
+        ResetForms();
+    }
+
+    public void Dispose()
+    {
+        ActionService.ActionRequested -= HandleActionRequested;
+    }
+
+    private sealed record ContactOption(int Id, string DisplayName, string Email, string PhoneNumber, string Company);
+
+    private sealed class EmailFormModel
+    {
+        [Required]
+        public string? Subject { get; set; }
+
+        [Required]
+        public string? Body { get; set; }
+    }
+
+    private sealed class MeetingFormModel
+    {
+        [Required]
+        public string? Title { get; set; }
+
+        [Required]
+        public DateTimeOffset Start { get; set; }
+
+        [Required]
+        public DateTimeOffset End { get; set; }
+
+        public string? Description { get; set; }
+    }
+
+    private sealed class ContactFormModel
+    {
+        [Required]
+        public string? FirstName { get; set; }
+
+        [Required]
+        public string? LastName { get; set; }
+
+        [EmailAddress]
+        public string? Email { get; set; }
+
+        [Phone]
+        public string? PhoneNumber { get; set; }
+
+        public string? Company { get; set; }
+
+        public string? Title { get; set; }
+    }
+
+    private sealed class DealFormModel
+    {
+        [Required]
+        public string? Name { get; set; }
+
+        [Required]
+        public int? StageId { get; set; }
+
+        [Range(0, double.MaxValue)]
+        public decimal? Amount { get; set; }
+
+        public string? Company { get; set; }
+
+        public string? ContactName { get; set; }
+
+        public string? Owner { get; set; }
+
+        [Required]
+        public DateTime? ExpectedCloseDate { get; set; }
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Shared/GlobalActionHost.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/GlobalActionHost.razor
@@ -254,7 +254,7 @@
         ActionService.ActionRequested += HandleActionRequested;
     }
 
-    private Task HandleActionRequested(GlobalActionContext context)
+    private System.Threading.Tasks.Task HandleActionRequested(GlobalActionContext context)
     {
         return InvokeAsync(async () =>
         {
@@ -267,7 +267,7 @@
         });
     }
 
-    private async Task ObserveCompletionAsync(GlobalActionContext context)
+    private async System.Threading.Tasks.Task ObserveCompletionAsync(GlobalActionContext context)
     {
         try
         {
@@ -288,7 +288,7 @@
         }
     }
 
-    private async Task LoadContextDataAsync(GlobalActionRequest request)
+    private async System.Threading.Tasks.Task LoadContextDataAsync(GlobalActionRequest request)
     {
         errorMessage = null;
         successMessage = null;
@@ -346,7 +346,7 @@
         }
     }
 
-    private async Task EnsureContactsLoadedAsync()
+    private async System.Threading.Tasks.Task EnsureContactsLoadedAsync()
     {
         if (contacts.Count > 0)
         {
@@ -401,7 +401,7 @@
         return parts.Count == 0 ? Localize("NoContactDetails") : string.Join(" · ", parts);
     }
 
-    private async Task LaunchCallAsync()
+    private async System.Threading.Tasks.Task LaunchCallAsync()
     {
         if (selectedContact is null || string.IsNullOrWhiteSpace(selectedContact.PhoneNumber))
         {
@@ -414,7 +414,7 @@
         activeContext?.Complete(GlobalActionResult.Completed);
     }
 
-    private async Task CopySelectedPhoneAsync()
+    private async System.Threading.Tasks.Task CopySelectedPhoneAsync()
     {
         if (selectedContact is null || string.IsNullOrWhiteSpace(selectedContact.PhoneNumber))
         {
@@ -425,7 +425,7 @@
         successMessage = Localize("CopiedToClipboard");
     }
 
-    private async Task LaunchEmailAsync()
+    private async System.Threading.Tasks.Task LaunchEmailAsync()
     {
         if (selectedContact is null || string.IsNullOrWhiteSpace(selectedContact.Email))
         {
@@ -441,7 +441,7 @@
         activeContext?.Complete(GlobalActionResult.Completed);
     }
 
-    private async Task ScheduleMeetingAsync()
+    private async System.Threading.Tasks.Task ScheduleMeetingAsync()
     {
         if (meetingForm.End <= meetingForm.Start)
         {
@@ -469,7 +469,7 @@
         activeContext?.Complete(GlobalActionResult.Completed);
     }
 
-    private async Task SaveContactAsync()
+    private async System.Threading.Tasks.Task SaveContactAsync()
     {
         try
         {
@@ -500,7 +500,7 @@
         }
     }
 
-    private async Task SaveDealAsync()
+    private async System.Threading.Tasks.Task SaveDealAsync()
     {
         try
         {

--- a/src/Web/NexaCRM.WebClient/Shared/GlobalActionHost.razor.css
+++ b/src/Web/NexaCRM.WebClient/Shared/GlobalActionHost.razor.css
@@ -1,0 +1,217 @@
+.global-action-overlay {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(12, 18, 28, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1100;
+    padding: 1.5rem;
+}
+
+.global-action-dialog {
+    background: #fff;
+    border-radius: 16px;
+    box-shadow: 0 20px 60px rgba(11, 27, 51, 0.25);
+    max-width: min(720px, 100%);
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    max-height: 90vh;
+}
+
+.global-action-dialog__header,
+.global-action-dialog__footer {
+    padding: 1.25rem 1.5rem;
+    border-bottom: 1px solid #e1e8f5;
+}
+
+.global-action-dialog__footer {
+    border-top: 1px solid #e1e8f5;
+    border-bottom: none;
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+}
+
+.global-action-dialog__header h2 {
+    margin: 0;
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: #0e131b;
+}
+
+.global-action-dialog__close {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    color: #4d6a99;
+}
+
+.global-action-dialog__body {
+    padding: 1.5rem;
+    overflow-y: auto;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.global-action-alert {
+    padding: 0.875rem 1rem;
+    border-radius: 12px;
+    font-size: 0.95rem;
+}
+
+.global-action-alert--error {
+    background: #ffe1e1;
+    color: #a11a1a;
+}
+
+.global-action-alert--success {
+    background: #e6f6ed;
+    color: #176437;
+}
+
+.global-action-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.global-action-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    font-size: 0.95rem;
+    color: #0e131b;
+}
+
+.global-action-input,
+.global-action-textarea,
+.global-action-field input,
+.global-action-field select {
+    border: 1px solid #cdd6e6;
+    border-radius: 12px;
+    padding: 0.6rem 0.8rem;
+    font-size: 0.95rem;
+    font-family: inherit;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.global-action-input:focus,
+.global-action-textarea:focus,
+.global-action-field input:focus,
+.global-action-field select:focus {
+    outline: none;
+    border-color: #4072ee;
+    box-shadow: 0 0 0 3px rgba(64, 114, 238, 0.18);
+}
+
+.global-action-textarea {
+    resize: vertical;
+}
+
+.global-action-contact-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.6rem;
+}
+
+.global-action-contact-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    padding: 0.85rem 1rem;
+    border: 1px solid #dde5f5;
+    border-radius: 12px;
+    cursor: pointer;
+    transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.global-action-contact-item:hover,
+.global-action-contact-item.is-active {
+    border-color: #4072ee;
+    background: #f1f5ff;
+}
+
+.global-action-contact-name {
+    font-weight: 600;
+    color: #0e131b;
+}
+
+.global-action-contact-meta {
+    font-size: 0.85rem;
+    color: #4d6a99;
+}
+
+.global-action-actions {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: flex-end;
+}
+
+.global-action-primary,
+.global-action-secondary {
+    border-radius: 999px;
+    padding: 0.6rem 1.2rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    border: none;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.global-action-primary {
+    background: linear-gradient(135deg, #4072ee, #324ad2);
+    color: #fff;
+    box-shadow: 0 12px 20px rgba(64, 114, 238, 0.24);
+}
+
+.global-action-secondary {
+    background: #f2f6ff;
+    color: #234073;
+}
+
+.global-action-primary:hover,
+.global-action-secondary:hover {
+    transform: translateY(-1px);
+}
+
+.global-action-context {
+    margin: 0;
+    font-size: 0.9rem;
+    color: #4d6a99;
+}
+
+.global-action-date-grid {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+@media (max-width: 720px) {
+    .global-action-dialog {
+        border-radius: 0;
+        height: 100vh;
+        max-height: 100vh;
+    }
+
+    .global-action-dialog__body {
+        padding: 1.25rem;
+    }
+
+    .global-action-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .global-action-primary,
+    .global-action-secondary {
+        width: 100%;
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Shared/MainLayout.razor
+++ b/src/Web/NexaCRM.WebClient/Shared/MainLayout.razor
@@ -114,6 +114,8 @@
             </div>
         </Authorized>
     </AuthorizeView>
+
+    <GlobalActionHost />
 </div>
 
 @code {

--- a/src/Web/NexaCRM.WebClient/_Imports.razor
+++ b/src/Web/NexaCRM.WebClient/_Imports.razor
@@ -14,3 +14,4 @@
 @using NexaCRM.WebClient.Components.Organization
 @using NexaCRM.WebClient.Models.Organization
 @using NexaCRM.WebClient.Services.Interfaces
+@using NexaCRM.WebClient.Services

--- a/src/Web/NexaCRM.WebClient/wwwroot/js/actions.js
+++ b/src/Web/NexaCRM.WebClient/wwwroot/js/actions.js
@@ -1,0 +1,260 @@
+const noop = () => {};
+let fabOutsideHandlerRegistered = false;
+let mobileDashboardInitialized = false;
+
+function ensureNavigator() {
+    if (typeof navigator === 'undefined') {
+        return {};
+    }
+
+    return navigator;
+}
+
+export function vibrate(duration) {
+    const vib = ensureNavigator().vibrate;
+    if (typeof vib === 'function') {
+        try {
+            vib.call(navigator, duration);
+        } catch (err) {
+            console.warn('Vibration failed', err);
+        }
+    }
+}
+
+export function openTel(phoneNumber) {
+    if (!phoneNumber) {
+        return;
+    }
+
+    try {
+        window.location.href = `tel:${encodeURIComponent(phoneNumber)}`;
+    } catch (err) {
+        console.warn('Telephone deep link failed', err);
+    }
+}
+
+export function openMailto(mailtoUrl) {
+    if (!mailtoUrl) {
+        return;
+    }
+
+    try {
+        window.location.href = mailtoUrl;
+    } catch (err) {
+        console.warn('Mailto deep link failed', err);
+    }
+}
+
+export async function copyText(value) {
+    if (!value) {
+        return false;
+    }
+
+    const nav = ensureNavigator();
+    if (nav.clipboard && typeof nav.clipboard.writeText === 'function') {
+        try {
+            await nav.clipboard.writeText(value);
+            return true;
+        } catch (err) {
+            console.warn('Clipboard write failed', err);
+        }
+    }
+
+    try {
+        const textarea = document.createElement('textarea');
+        textarea.value = value;
+        textarea.setAttribute('readonly', '');
+        textarea.style.position = 'absolute';
+        textarea.style.left = '-9999px';
+        document.body.appendChild(textarea);
+        textarea.select();
+        const succeeded = document.execCommand('copy');
+        document.body.removeChild(textarea);
+        return succeeded;
+    } catch (err) {
+        console.warn('Fallback clipboard copy failed', err);
+        return false;
+    }
+}
+
+export function triggerDownload(base64Data, fileName, contentType) {
+    if (!base64Data || !fileName) {
+        return;
+    }
+
+    const mime = contentType || 'application/octet-stream';
+    const link = document.createElement('a');
+    link.href = `data:${mime};base64,${base64Data}`;
+    link.download = fileName;
+    link.rel = 'noopener';
+    link.style.display = 'none';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+}
+
+export function smoothScrollToId(elementId) {
+    if (!elementId) {
+        return;
+    }
+
+    const element = document.getElementById(elementId);
+    if (element) {
+        element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+}
+
+export function focusSelector(selector) {
+    if (!selector) {
+        return;
+    }
+
+    const element = document.querySelector(selector);
+    if (element instanceof HTMLElement) {
+        element.focus();
+    }
+}
+
+export function isMobileViewport() {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+        return false;
+    }
+
+    try {
+        return window.matchMedia('(max-width: 767px)').matches;
+    } catch (err) {
+        console.warn('Failed to evaluate mobile viewport query', err);
+        return false;
+    }
+}
+
+export function registerFabOutsideHandler() {
+    if (fabOutsideHandlerRegistered || typeof document === 'undefined') {
+        return;
+    }
+
+    document.addEventListener('click', (event) => {
+        const target = event.target;
+        if (target instanceof Element && target.closest('.fab-container')) {
+            return;
+        }
+
+        const expanded = document.querySelector('.fab-container.expanded .fab-main');
+        if (expanded instanceof HTMLElement) {
+            expanded.click();
+        }
+    });
+
+    fabOutsideHandlerRegistered = true;
+}
+
+export function setupMobileDashboard() {
+    if (typeof document === 'undefined') {
+        return;
+    }
+
+    if (mobileDashboardInitialized) {
+        return;
+    }
+
+    try {
+        if (window.navigationHelper && typeof window.navigationHelper.setupMobileDashboardNavigation === 'function') {
+            window.navigationHelper.setupMobileDashboardNavigation();
+        }
+    } catch (err) {
+        console.warn('navigationHelper.setupMobileDashboardNavigation failed', err);
+    }
+
+    try {
+        const mobileHeader = document.querySelector('.mobile-header');
+        if (mobileHeader instanceof HTMLElement) {
+            mobileHeader.classList.add('mobile-header--active');
+        }
+
+        const handleBackdropClick = (event) => {
+            const target = event.target;
+            if (!(target instanceof Element)) {
+                return;
+            }
+
+            if (target.classList.contains('mobile-search-bar') && target.classList.contains('expanded')) {
+                const closeSearch = document.querySelector('.mobile-search-close');
+                if (closeSearch instanceof HTMLElement) {
+                    closeSearch.click();
+                }
+            }
+
+            if (target.classList.contains('mobile-notifications-panel') && target.classList.contains('expanded')) {
+                const closeNotifications = document.querySelector('.mobile-notifications-close');
+                if (closeNotifications instanceof HTMLElement) {
+                    closeNotifications.click();
+                }
+            }
+        };
+
+        document.addEventListener('click', handleBackdropClick);
+
+        let touchStartY = 0;
+        document.addEventListener(
+            'touchstart',
+            (event) => {
+                if (event.touches && event.touches[0]) {
+                    touchStartY = event.touches[0].clientY;
+                }
+            },
+            { passive: true }
+        );
+
+        document.addEventListener(
+            'touchend',
+            (event) => {
+                if (!event.changedTouches || !event.changedTouches[0]) {
+                    return;
+                }
+
+                const touchEndY = event.changedTouches[0].clientY;
+                const diff = touchStartY - touchEndY;
+
+                if (diff > 50) {
+                    document.querySelectorAll('.mobile-search-bar.expanded, .mobile-notifications-panel.expanded').forEach((panel) => {
+                        const closeBtn = panel.querySelector('.mobile-search-close, .mobile-notifications-close');
+                        if (closeBtn instanceof HTMLElement) {
+                            closeBtn.click();
+                        }
+                    });
+                }
+            },
+            { passive: true }
+        );
+    } catch (err) {
+        console.warn('setupMobileDashboard failed', err);
+    }
+
+    mobileDashboardInitialized = true;
+}
+
+export function setLocation(href) {
+    if (!href) {
+        return;
+    }
+
+    try {
+        window.location.href = href;
+    } catch (err) {
+        console.warn('Failed to navigate to href', err);
+    }
+}
+
+export default {
+    vibrate,
+    openTel,
+    openMailto,
+    copyText,
+    triggerDownload,
+    smoothScrollToId,
+    focusSelector,
+    isMobileViewport,
+    registerFabOutsideHandler,
+    setupMobileDashboard,
+    setLocation
+};


### PR DESCRIPTION
## Summary
- add a reusable JS interop module and `ActionInterop` service for vibration, deep links, viewport detection, and mobile dashboard helpers
- introduce the global quick-action orchestration layer with Supabase-backed contact/deal creation forms and wire it into the main layout
- refactor dashboard and sample pages to consume live notification data, shared mobile state, and global action launches instead of placeholder alerts

## Testing
- `dotnet build --configuration Release` *(fails: dotnet CLI is not available in the execution environment)*
- `dotnet test ./tests/BlazorWebApp.Tests --configuration Release` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d423d7f1ac832c955c909014ac44b8