### PR TITLE
feat: integrate supabase governance and personalization services

### DIFF
--- a/docs/supabase-enterprise-services.md
+++ b/docs/supabase-enterprise-services.md
@@ -1,0 +1,40 @@
+# Supabase Enterprise Services Overview
+
+## Purpose
+이 문서는 NexaCRM에서 Supabase 기반으로 구현된 핵심 엔터프라이즈 서비스(거버넌스, 개인화, 파일/커뮤니케이션 허브, 동기화)의 아키텍처와 사용 기술을 정리합니다. 향후 확장 시 참조용 베이스라인을 제공합니다.
+
+## 사용 기술 요약
+- **Supabase Auth & PostgREST**: 사용자 계정, 역할, 감사 로그, 보안 정책, 동기화 메타데이터 저장.
+- **Supabase Storage**: `crm-documents` 버킷에 파일 업로드, 버전 관리, 스레드 메시지 첨부 지원.
+- **Supabase Realtime (Event Streams)**: `IntegrationEventRecord` 테이블을 통해 이메일/SMS/푸시 등 비동기 처리 파이프라인과 연동.
+- **Blazor WebAssembly (.NET 8)**: 모든 서비스는 `SupabaseClientProvider`를 통해 단일 커넥션을 재사용하며 비동기 API 패턴으로 설계됨.
+- **Newtonsoft.Json**: 가변적인 메타데이터(위젯 설정, 기능 플래그, 커뮤니케이션 페이로드 등)를 직렬화.
+
+## 서비스 개요
+### 사용자/보안 거버넌스
+- `SupabaseUserGovernanceService`는 `user_accounts`, `user_roles`, `security_policies`, `audit_logs` 테이블을 기반으로 사용자 생성/비활성화, 역할 부여, 비밀번호 재설정 토큰 발급, 감사 로그 조회를 수행합니다.
+- 모든 변경 사항은 감사 로그에 기록되어 추적 가능성을 확보합니다.
+
+### 설정·테마·대시보드 개인화
+- `SupabaseSettingsCustomizationService`는 조직 및 사용자별 설정(`organization_settings`, `user_preferences`)을 관리하고, 대시보드 위젯/레이아웃(`dashboard_widgets`)과 KPI 스냅샷(`kpi_snapshots`)을 제공합니다.
+- 위젯/기능 플래그는 JSON 기반으로 저장되어 유연한 확장이 가능합니다.
+
+### 파일·커뮤니케이션 허브
+- `SupabaseFileHubService`는 업로드 URL 발급, 파일 메타데이터 등록(`file_documents`), 버전 관리(`file_versions`)를 담당합니다.
+- `communication_threads`, `thread_messages` 테이블을 통해 채널별 협업 스레드를 유지하고, 통합 이벤트를 생성하여 이메일/SMS/푸시 워커로 전달합니다.
+- `SupabaseCommunicationHubService`는 이메일·SMS·푸시 요청을 이벤트 스트림에 큐잉하여 외부 채널과의 연동을 단순화합니다.
+
+### 데이터 동기화 및 오프라인 전략
+- `SupabaseSyncOrchestrationService`는 `sync_envelopes`, `sync_items`, `sync_conflicts` 테이블을 활용해 모바일/현장 단말의 오프라인 캐시와 충돌 해결 정책을 관리합니다.
+- Sync 정책(`SyncPolicy`)에 따라 엔티티 범위와 새로고침 주기를 제어할 수 있으며, `sync.conflict.resolved` 이벤트로 후속 처리를 트리거합니다.
+
+## 운영 권장 사항
+1. **보안 키 관리**: 서비스 롤 키와 anon 키는 Azure Key Vault 등 비밀 저장소에서 로딩하고, RLS 정책으로 테이블 접근을 제한합니다.
+2. **실시간 확장**: 향후 WebSocket 환경이 허용될 경우 `Supabase.Client`의 Realtime 구독을 활성화해 대시보드/커뮤니케이션 변화를 즉시 반영하십시오.
+3. **모니터링**: `audit_logs` 및 `integration_events`는 운영 분석에 중요한 데이터이므로, Supabase Logflare 또는 BigQuery 연동을 고려합니다.
+4. **백업 전략**: 파일 버킷과 Postgres 스키마에 대해 주기적인 스냅샷을 구성하여 규제 요구사항을 충족합니다.
+
+## 다음 단계
+- 관리자 UI에서 새로운 서비스 메서드를 호출하는 Form 및 Dashboard 컴포넌트를 추가합니다.
+- Background Worker(예: Azure Functions, Supabase Edge Functions)를 통해 통합 이벤트를 처리하고 외부 채널과 실제 연동을 완료합니다.
+- 모바일 앱/오프라인 모드 지원을 위해 `SyncEnvelope` 스키마와 충돌 정책을 세분화합니다.

--- a/src/Web/NexaCRM.WebClient/Models/Customization/CustomizationModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Customization/CustomizationModels.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+
+namespace NexaCRM.WebClient.Models.Customization;
+
+public sealed class OrganizationSettings
+{
+    public Guid OrganizationId { get; init; }
+
+    public string Locale { get; init; } = "ko-KR";
+
+    public string Timezone { get; init; } = "Asia/Seoul";
+
+    public string Theme { get; init; } = "light";
+
+    public IReadOnlyDictionary<string, bool> FeatureFlags { get; init; }
+        = new Dictionary<string, bool>();
+}
+
+public sealed class UserPreferences
+{
+    public Guid UserId { get; init; }
+
+    public string Theme { get; init; } = "system";
+
+    public string DateFormat { get; init; } = "yyyy-MM-dd";
+
+    public bool EnableNotifications { get; init; } = true;
+
+    public IReadOnlyDictionary<string, string> WidgetPreferences { get; init; }
+        = new Dictionary<string, string>();
+}
+
+public sealed class DashboardWidget
+{
+    public Guid WidgetId { get; init; }
+
+    public string Type { get; init; } = string.Empty;
+
+    public int Order { get; init; }
+
+    public IReadOnlyDictionary<string, string> Configuration { get; init; }
+        = new Dictionary<string, string>();
+}
+
+public sealed class DashboardLayout
+{
+    public Guid UserId { get; init; }
+
+    public IReadOnlyList<DashboardWidget> Widgets { get; init; } = Array.Empty<DashboardWidget>();
+}
+
+public sealed class KpiSnapshot
+{
+    public Guid Id { get; init; }
+
+    public string Metric { get; init; } = string.Empty;
+
+    public decimal Value { get; init; }
+
+    public DateTime CapturedAt { get; init; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/FileHub/FileHubModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/FileHub/FileHubModels.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+
+namespace NexaCRM.WebClient.Models.FileHub;
+
+public sealed class FileUploadRequest
+{
+    public Guid OwnerId { get; init; }
+
+    public string EntityType { get; init; } = string.Empty;
+
+    public string EntityId { get; init; } = string.Empty;
+
+    public string FileName { get; init; } = string.Empty;
+
+    public string ContentType { get; init; } = "application/octet-stream";
+
+    public long ContentLength { get; init; }
+
+    public IReadOnlyDictionary<string, string> Metadata { get; init; }
+        = new Dictionary<string, string>();
+}
+
+public sealed class FileUploadUrl
+{
+    public Uri UploadUrl { get; init; } = new("https://localhost/upload");
+
+    public string ObjectPath { get; init; } = string.Empty;
+
+    public IReadOnlyDictionary<string, string> RequiredHeaders { get; init; }
+        = new Dictionary<string, string>();
+}
+
+public sealed class FileMetadata
+{
+    public Guid FileId { get; init; }
+
+    public string FileName { get; init; } = string.Empty;
+
+    public string ContentType { get; init; } = string.Empty;
+
+    public long Size { get; init; }
+
+    public DateTime UploadedAt { get; init; }
+
+    public Guid UploadedBy { get; init; }
+
+    public string StoragePath { get; init; } = string.Empty;
+
+    public IReadOnlyList<FileVersion> Versions { get; init; } = Array.Empty<FileVersion>();
+}
+
+public sealed class FileVersion
+{
+    public Guid VersionId { get; init; }
+
+    public string StoragePath { get; init; } = string.Empty;
+
+    public DateTime CreatedAt { get; init; }
+
+    public Guid CreatedBy { get; init; }
+
+    public string Notes { get; init; } = string.Empty;
+}
+
+public sealed class CommunicationThread
+{
+    public Guid ThreadId { get; init; }
+
+    public string Channel { get; init; } = string.Empty;
+
+    public IReadOnlyList<ThreadMessage> Messages { get; init; } = Array.Empty<ThreadMessage>();
+}
+
+public sealed class ThreadMessage
+{
+    public Guid MessageId { get; init; }
+
+    public Guid SenderId { get; init; }
+
+    public string Body { get; init; } = string.Empty;
+
+    public DateTime SentAt { get; init; }
+
+    public IReadOnlyCollection<string> DeliveryChannels { get; init; }
+        = Array.Empty<string>();
+}

--- a/src/Web/NexaCRM.WebClient/Models/Governance/UserAccount.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Governance/UserAccount.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+
+namespace NexaCRM.WebClient.Models.Governance;
+
+/// <summary>
+/// Represents a managed user account inside NexaCRM.
+/// </summary>
+public sealed class UserAccount
+{
+    public Guid Id { get; init; }
+
+    public string Email { get; init; } = string.Empty;
+
+    public string DisplayName { get; init; } = string.Empty;
+
+    public bool IsActive { get; init; }
+
+    public DateTime CreatedAt { get; init; }
+
+    public DateTime? LastSignInAt { get; init; }
+
+    public IReadOnlyCollection<string> Roles { get; init; } = Array.Empty<string>();
+
+    public IReadOnlyDictionary<string, string> Metadata { get; init; } =
+        new Dictionary<string, string>();
+}
+
+/// <summary>
+/// Optional query parameters when enumerating users for an organization.
+/// </summary>
+public sealed class UserQueryOptions
+{
+    public string? SearchTerm { get; init; }
+
+    public bool IncludeInactive { get; init; }
+
+    public int PageSize { get; init; } = 50;
+
+    public int PageNumber { get; init; } = 1;
+
+    public IReadOnlyCollection<string>? RoleFilter { get; init; }
+}
+
+/// <summary>
+/// Describes an audit log entry produced by the governance pipeline.
+/// </summary>
+public sealed class SecurityAuditLogEntry
+{
+    public Guid Id { get; init; }
+
+    public Guid? ActorId { get; init; }
+
+    public string Action { get; init; } = string.Empty;
+
+    public string EntityType { get; init; } = string.Empty;
+
+    public string? EntityId { get; init; }
+
+    public string? PayloadJson { get; init; }
+
+    public DateTime OccurredAt { get; init; }
+}
+
+/// <summary>
+/// Captures the outcome of a password reset or recovery flow.
+/// </summary>
+public sealed class PasswordResetTicket
+{
+    public Guid TicketId { get; init; }
+
+    public Guid UserId { get; init; }
+
+    public DateTime ExpiresAt { get; init; }
+
+    public string ResetUrl { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// Defines security controls that should be enforced for end-users.
+/// </summary>
+public sealed class SecurityPolicy
+{
+    public bool RequireMfa { get; init; }
+
+    public int SessionTimeoutMinutes { get; init; } = 60;
+
+    public IReadOnlyCollection<string> IpAllowList { get; init; } = Array.Empty<string>();
+
+    public int PasswordExpiryDays { get; init; } = 90;
+}

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/CommunicationThreadRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/CommunicationThreadRecord.cs
@@ -1,0 +1,24 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("communication_threads")]
+public sealed class CommunicationThreadRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("entity_type")]
+    public string EntityType { get; set; } = string.Empty;
+
+    [Column("entity_id")]
+    public string EntityId { get; set; } = string.Empty;
+
+    [Column("channel")]
+    public string Channel { get; set; } = string.Empty;
+
+    [Column("created_at")]
+    public DateTime CreatedAt { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/DashboardWidgetRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/DashboardWidgetRecord.cs
@@ -1,0 +1,24 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("dashboard_widgets")]
+public sealed class DashboardWidgetRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("user_id")]
+    public Guid UserId { get; set; }
+
+    [Column("widget_type")]
+    public string WidgetType { get; set; } = string.Empty;
+
+    [Column("display_order")]
+    public int DisplayOrder { get; set; }
+
+    [Column("configuration_json")]
+    public string? ConfigurationJson { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/FileDocumentRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/FileDocumentRecord.cs
@@ -1,0 +1,39 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("file_documents")]
+public sealed class FileDocumentRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("owner_id")]
+    public Guid OwnerId { get; set; }
+
+    [Column("entity_type")]
+    public string EntityType { get; set; } = string.Empty;
+
+    [Column("entity_id")]
+    public string EntityId { get; set; } = string.Empty;
+
+    [Column("file_name")]
+    public string FileName { get; set; } = string.Empty;
+
+    [Column("content_type")]
+    public string ContentType { get; set; } = string.Empty;
+
+    [Column("size")]
+    public long Size { get; set; }
+
+    [Column("storage_path")]
+    public string StoragePath { get; set; } = string.Empty;
+
+    [Column("uploaded_by")]
+    public Guid UploadedBy { get; set; }
+
+    [Column("uploaded_at")]
+    public DateTime UploadedAt { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/FileVersionRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/FileVersionRecord.cs
@@ -1,0 +1,27 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("file_versions")]
+public sealed class FileVersionRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("file_id")]
+    public Guid FileId { get; set; }
+
+    [Column("storage_path")]
+    public string StoragePath { get; set; } = string.Empty;
+
+    [Column("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    [Column("created_by")]
+    public Guid CreatedBy { get; set; }
+
+    [Column("notes")]
+    public string? Notes { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/KpiSnapshotRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/KpiSnapshotRecord.cs
@@ -1,0 +1,21 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("kpi_snapshots")]
+public sealed class KpiSnapshotRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("metric")]
+    public string Metric { get; set; } = string.Empty;
+
+    [Column("value")]
+    public decimal Value { get; set; }
+
+    [Column("captured_at")]
+    public DateTime CapturedAt { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/OrganizationSettingsRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/OrganizationSettingsRecord.cs
@@ -1,0 +1,27 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("organization_settings")]
+public sealed class OrganizationSettingsRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("organization_id")]
+    public Guid OrganizationId { get; set; }
+
+    [Column("locale")]
+    public string Locale { get; set; } = "ko-KR";
+
+    [Column("timezone")]
+    public string Timezone { get; set; } = "Asia/Seoul";
+
+    [Column("theme")]
+    public string Theme { get; set; } = "light";
+
+    [Column("feature_flags_json")]
+    public string? FeatureFlagsJson { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/PasswordResetTicketRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/PasswordResetTicketRecord.cs
@@ -1,0 +1,21 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("password_reset_tickets")]
+public sealed class PasswordResetTicketRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("user_id")]
+    public Guid UserId { get; set; }
+
+    [Column("expires_at")]
+    public DateTime ExpiresAt { get; set; }
+
+    [Column("reset_url")]
+    public string ResetUrl { get; set; } = string.Empty;
+}

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/SecurityPolicyRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/SecurityPolicyRecord.cs
@@ -1,0 +1,27 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("security_policies")]
+public sealed class SecurityPolicyRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("organization_id")]
+    public Guid OrganizationId { get; set; }
+
+    [Column("require_mfa")]
+    public bool RequireMfa { get; set; }
+
+    [Column("session_timeout_minutes")]
+    public int SessionTimeoutMinutes { get; set; }
+
+    [Column("ip_allow_list")]
+    public string? IpAllowList { get; set; }
+
+    [Column("password_expiry_days")]
+    public int PasswordExpiryDays { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/SyncConflictRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/SyncConflictRecord.cs
@@ -1,0 +1,30 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("sync_conflicts")]
+public sealed class SyncConflictRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("user_id")]
+    public Guid UserId { get; set; }
+
+    [Column("entity_type")]
+    public string EntityType { get; set; } = string.Empty;
+
+    [Column("entity_id")]
+    public string EntityId { get; set; } = string.Empty;
+
+    [Column("resolution_strategy")]
+    public string ResolutionStrategy { get; set; } = "ServerWins";
+
+    [Column("payload_json")]
+    public string PayloadJson { get; set; } = string.Empty;
+
+    [Column("created_at")]
+    public DateTime CreatedAt { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/SyncEnvelopeRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/SyncEnvelopeRecord.cs
@@ -1,0 +1,18 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("sync_envelopes")]
+public sealed class SyncEnvelopeRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("user_id")]
+    public Guid UserId { get; set; }
+
+    [Column("generated_at")]
+    public DateTime GeneratedAt { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/SyncItemRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/SyncItemRecord.cs
@@ -1,0 +1,27 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("sync_items")]
+public sealed class SyncItemRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("envelope_id")]
+    public Guid EnvelopeId { get; set; }
+
+    [Column("entity_type")]
+    public string EntityType { get; set; } = string.Empty;
+
+    [Column("entity_id")]
+    public string EntityId { get; set; } = string.Empty;
+
+    [Column("last_modified_at")]
+    public DateTime LastModifiedAt { get; set; }
+
+    [Column("payload_json")]
+    public string PayloadJson { get; set; } = string.Empty;
+}

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/ThreadMessageRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/ThreadMessageRecord.cs
@@ -1,0 +1,27 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("thread_messages")]
+public sealed class ThreadMessageRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("thread_id")]
+    public Guid ThreadId { get; set; }
+
+    [Column("sender_id")]
+    public Guid SenderId { get; set; }
+
+    [Column("body")]
+    public string Body { get; set; } = string.Empty;
+
+    [Column("sent_at")]
+    public DateTime SentAt { get; set; }
+
+    [Column("channels")]
+    public string? Channels { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/UserAccountRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/UserAccountRecord.cs
@@ -1,0 +1,30 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("user_accounts")]
+public sealed class UserAccountRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("email")]
+    public string Email { get; set; } = string.Empty;
+
+    [Column("display_name")]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [Column("is_active")]
+    public bool? IsActive { get; set; }
+
+    [Column("created_at")]
+    public DateTime? CreatedAt { get; set; }
+
+    [Column("last_sign_in_at")]
+    public DateTime? LastSignInAt { get; set; }
+
+    [Column("metadata_json")]
+    public string? MetadataJson { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/UserPreferenceRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/UserPreferenceRecord.cs
@@ -1,0 +1,27 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("user_preferences")]
+public sealed class UserPreferenceRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("user_id")]
+    public Guid UserId { get; set; }
+
+    [Column("theme")]
+    public string Theme { get; set; } = "system";
+
+    [Column("date_format")]
+    public string DateFormat { get; set; } = "yyyy-MM-dd";
+
+    [Column("enable_notifications")]
+    public bool EnableNotifications { get; set; }
+
+    [Column("widget_preferences_json")]
+    public string? WidgetPreferencesJson { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/Sync/SyncModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Sync/SyncModels.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+
+namespace NexaCRM.WebClient.Models.Sync;
+
+public sealed class SyncEnvelope
+{
+    public Guid EnvelopeId { get; init; }
+
+    public Guid UserId { get; init; }
+
+    public DateTime GeneratedAt { get; init; }
+
+    public IReadOnlyCollection<SyncItem> Items { get; init; } = Array.Empty<SyncItem>();
+}
+
+public sealed class SyncItem
+{
+    public string EntityType { get; init; } = string.Empty;
+
+    public string EntityId { get; init; } = string.Empty;
+
+    public DateTime LastModifiedAt { get; init; }
+
+    public string PayloadJson { get; init; } = string.Empty;
+}
+
+public sealed class SyncPlan
+{
+    public Guid PlanId { get; init; }
+
+    public DateTime CreatedAt { get; init; }
+
+    public IReadOnlyCollection<SyncItem> PendingItems { get; init; } = Array.Empty<SyncItem>();
+}
+
+public sealed class SyncConflict
+{
+    public Guid ConflictId { get; init; }
+
+    public string EntityType { get; init; } = string.Empty;
+
+    public string EntityId { get; init; } = string.Empty;
+
+    public string ResolutionStrategy { get; init; } = "ServerWins";
+
+    public string PayloadJson { get; init; } = string.Empty;
+}
+
+public sealed class SyncPolicy
+{
+    public TimeSpan RefreshInterval { get; init; } = TimeSpan.FromMinutes(5);
+
+    public int MaxOfflineHours { get; init; } = 12;
+
+    public IReadOnlyCollection<string> Entities { get; init; } = Array.Empty<string>();
+}

--- a/src/Web/NexaCRM.WebClient/Program.cs
+++ b/src/Web/NexaCRM.WebClient/Program.cs
@@ -73,6 +73,7 @@ builder.Services.AddSingleton<IDedupeConfigService, DedupeConfigService>();
 builder.Services.AddScoped<IDuplicateMonitorService, DuplicateMonitorService>();
 builder.Services.AddScoped<IDeviceService, DeviceService>();
 builder.Services.AddScoped<ISettingsService, SettingsService>();
+builder.Services.AddScoped<ISettingsCustomizationService, SupabaseSettingsCustomizationService>();
 builder.Services.AddScoped<IOrganizationService, OrganizationService>();
 builder.Services.AddScoped<IDbAdminService, DbAdminService>();
 builder.Services.AddScoped<IStatisticsService, StatisticsService>();
@@ -87,6 +88,10 @@ builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddScoped<INotificationFeedService, SupabaseNotificationFeedService>();
 builder.Services.AddScoped<ITeamService, MockTeamService>();
 builder.Services.AddScoped<INavigationStateService, NavigationStateService>();
+builder.Services.AddScoped<IUserGovernanceService, SupabaseUserGovernanceService>();
+builder.Services.AddScoped<IFileHubService, SupabaseFileHubService>();
+builder.Services.AddScoped<ICommunicationHubService, SupabaseCommunicationHubService>();
+builder.Services.AddScoped<ISyncOrchestrationService, SupabaseSyncOrchestrationService>();
 
 var culture = new CultureInfo("ko-KR");
 CultureInfo.DefaultThreadCurrentCulture = culture;

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/ICommunicationHubService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/ICommunicationHubService.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+public interface ICommunicationHubService
+{
+    Task SendEmailAsync(
+        Guid senderId,
+        IEnumerable<string> recipients,
+        string subject,
+        string body,
+        CancellationToken cancellationToken = default);
+
+    Task SendSmsAsync(
+        Guid senderId,
+        IEnumerable<string> recipients,
+        string message,
+        CancellationToken cancellationToken = default);
+
+    Task EnqueuePushNotificationAsync(
+        Guid userId,
+        string title,
+        string message,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IFileHubService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IFileHubService.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NexaCRM.WebClient.Models.FileHub;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+public interface IFileHubService
+{
+    Task<FileUploadUrl> CreateUploadUrlAsync(
+        FileUploadRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task<FileMetadata> RegisterUploadAsync(
+        Guid userId,
+        string objectPath,
+        FileUploadRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<FileVersion>> GetFileVersionsAsync(
+        Guid fileId,
+        CancellationToken cancellationToken = default);
+
+    Task<CommunicationThread> EnsureThreadAsync(
+        string entityType,
+        string entityId,
+        string channel,
+        CancellationToken cancellationToken = default);
+
+    Task<ThreadMessage> SendThreadMessageAsync(
+        Guid threadId,
+        Guid senderId,
+        string body,
+        IEnumerable<string> channels,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/ISettingsCustomizationService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/ISettingsCustomizationService.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NexaCRM.WebClient.Models.Customization;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+public interface ISettingsCustomizationService
+{
+    Task<OrganizationSettings> GetOrganizationSettingsAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default);
+
+    Task SaveOrganizationSettingsAsync(
+        OrganizationSettings settings,
+        CancellationToken cancellationToken = default);
+
+    Task<UserPreferences> GetUserPreferencesAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default);
+
+    Task SaveUserPreferencesAsync(
+        UserPreferences preferences,
+        CancellationToken cancellationToken = default);
+
+    Task<DashboardLayout> GetDashboardLayoutAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default);
+
+    Task SaveDashboardLayoutAsync(
+        DashboardLayout layout,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<KpiSnapshot>> GetKpiSnapshotsAsync(
+        string metric,
+        DateTime since,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/ISyncOrchestrationService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/ISyncOrchestrationService.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NexaCRM.WebClient.Models.Sync;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+public interface ISyncOrchestrationService
+{
+    Task<SyncPlan> BuildSyncPlanAsync(
+        Guid userId,
+        SyncPolicy policy,
+        CancellationToken cancellationToken = default);
+
+    Task RecordClientEnvelopeAsync(
+        SyncEnvelope envelope,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<SyncConflict>> GetConflictsAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default);
+
+    Task ResolveConflictsAsync(
+        IReadOnlyCollection<SyncConflict> conflicts,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IUserGovernanceService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IUserGovernanceService.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NexaCRM.WebClient.Models.Governance;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+public interface IUserGovernanceService
+{
+    Task<UserAccount> CreateUserAsync(
+        string email,
+        string displayName,
+        IEnumerable<string> roles,
+        CancellationToken cancellationToken = default);
+
+    Task<UserAccount?> GetUserAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<UserAccount>> GetUsersAsync(
+        UserQueryOptions query,
+        CancellationToken cancellationToken = default);
+
+    Task AssignRolesAsync(
+        Guid userId,
+        IEnumerable<string> roles,
+        CancellationToken cancellationToken = default);
+
+    Task<PasswordResetTicket> CreatePasswordResetTicketAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default);
+
+    Task DisableUserAsync(
+        Guid userId,
+        string reason,
+        CancellationToken cancellationToken = default);
+
+    Task<SecurityPolicy> GetSecurityPolicyAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default);
+
+    Task SaveSecurityPolicyAsync(
+        Guid organizationId,
+        SecurityPolicy policy,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<SecurityAuditLogEntry>> GetAuditTrailAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Web/NexaCRM.WebClient/Services/SupabaseCommunicationHubService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SupabaseCommunicationHubService.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using NexaCRM.WebClient.Models.Supabase;
+using NexaCRM.WebClient.Services.Interfaces;
+
+namespace NexaCRM.WebClient.Services;
+
+public sealed class SupabaseCommunicationHubService : ICommunicationHubService
+{
+    private readonly SupabaseClientProvider _clientProvider;
+    private readonly ILogger<SupabaseCommunicationHubService> _logger;
+
+    public SupabaseCommunicationHubService(
+        SupabaseClientProvider clientProvider,
+        ILogger<SupabaseCommunicationHubService> logger)
+    {
+        _clientProvider = clientProvider;
+        _logger = logger;
+    }
+
+    public async Task SendEmailAsync(
+        Guid senderId,
+        IEnumerable<string> recipients,
+        string subject,
+        string body,
+        CancellationToken cancellationToken = default)
+    {
+        await EnqueueCommunicationAsync(
+            senderId,
+            recipients,
+            "email",
+            new { subject, body },
+            cancellationToken);
+    }
+
+    public async Task SendSmsAsync(
+        Guid senderId,
+        IEnumerable<string> recipients,
+        string message,
+        CancellationToken cancellationToken = default)
+    {
+        await EnqueueCommunicationAsync(
+            senderId,
+            recipients,
+            "sms",
+            new { message },
+            cancellationToken);
+    }
+
+    public async Task EnqueuePushNotificationAsync(
+        Guid userId,
+        string title,
+        string message,
+        CancellationToken cancellationToken = default)
+    {
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var record = new IntegrationEventRecord
+            {
+                Id = Guid.NewGuid(),
+                EventType = "notification.push",
+                PayloadJson = JsonConvert.SerializeObject(new
+                {
+                    UserId = userId,
+                    Title = title,
+                    Message = message,
+                    ScheduledAt = DateTime.UtcNow
+                }),
+                CreatedAt = DateTime.UtcNow
+            };
+
+            await client.From<IntegrationEventRecord>().Insert(record, cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to enqueue push notification for {UserId}.", userId);
+            throw;
+        }
+    }
+
+    private async Task EnqueueCommunicationAsync(
+        Guid senderId,
+        IEnumerable<string> recipients,
+        string channel,
+        object payload,
+        CancellationToken cancellationToken)
+    {
+        if (senderId == Guid.Empty)
+        {
+            throw new ArgumentException("Sender id cannot be empty.", nameof(senderId));
+        }
+
+        ArgumentNullException.ThrowIfNull(recipients);
+        var recipientList = recipients
+            .Where(recipient => !string.IsNullOrWhiteSpace(recipient))
+            .Select(recipient => recipient.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (recipientList.Length == 0)
+        {
+            throw new ArgumentException("At least one recipient is required.", nameof(recipients));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var record = new IntegrationEventRecord
+            {
+                Id = Guid.NewGuid(),
+                EventType = $"communication.{channel}",
+                PayloadJson = JsonConvert.SerializeObject(new
+                {
+                    SenderId = senderId,
+                    Recipients = recipientList,
+                    Payload = payload,
+                    RequestedAt = DateTime.UtcNow
+                }),
+                CreatedAt = DateTime.UtcNow
+            };
+
+            await client.From<IntegrationEventRecord>().Insert(record, cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to enqueue {Channel} communication.", channel);
+            throw;
+        }
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Services/SupabaseFileHubService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SupabaseFileHubService.cs
@@ -1,0 +1,386 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using NexaCRM.WebClient.Models.FileHub;
+using NexaCRM.WebClient.Models.Supabase;
+using NexaCRM.WebClient.Options;
+using NexaCRM.WebClient.Services.Interfaces;
+using PostgrestOrdering = Supabase.Postgrest.Constants.Ordering;
+using PostgrestOperator = Supabase.Postgrest.Constants.Operator;
+
+namespace NexaCRM.WebClient.Services;
+
+public sealed class SupabaseFileHubService : IFileHubService
+{
+    private const string StorageBucket = "crm-documents";
+    private readonly SupabaseClientProvider _clientProvider;
+    private readonly ILogger<SupabaseFileHubService> _logger;
+    private readonly string _storageBaseUrl;
+    private readonly string _anonKey;
+
+    public SupabaseFileHubService(
+        SupabaseClientProvider clientProvider,
+        ILogger<SupabaseFileHubService> logger,
+        IOptions<SupabaseClientOptions> optionsAccessor)
+    {
+        _clientProvider = clientProvider;
+        _logger = logger;
+
+        ArgumentNullException.ThrowIfNull(optionsAccessor);
+        var options = optionsAccessor.Value;
+        if (string.IsNullOrWhiteSpace(options.Url))
+        {
+            throw new InvalidOperationException("Supabase Url must be configured to use the file hub service.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.AnonKey))
+        {
+            throw new InvalidOperationException("Supabase anon key must be configured to use the file hub service.");
+        }
+
+        _storageBaseUrl = options.Url.TrimEnd('/') + "/storage/v1";
+        _anonKey = options.AnonKey;
+    }
+
+    public async Task<FileUploadUrl> CreateUploadUrlAsync(
+        FileUploadRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (string.IsNullOrWhiteSpace(request.FileName))
+        {
+            throw new ArgumentException("File name is required for uploads.", nameof(request));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var session = client.Auth.CurrentSession ?? await client.Auth.RetrieveSessionAsync();
+
+            var objectPath = BuildObjectPath(request);
+            var uploadUrl = new Uri($"{_storageBaseUrl}/object/{StorageBucket}/{objectPath}");
+
+            var headers = new Dictionary<string, string>
+            {
+                ["Authorization"] = $"Bearer {session?.AccessToken ?? _anonKey}",
+                ["x-upsert"] = "true",
+                ["Content-Type"] = request.ContentType
+            };
+
+            return new FileUploadUrl
+            {
+                UploadUrl = uploadUrl,
+                ObjectPath = objectPath,
+                RequiredHeaders = headers
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create Supabase storage upload url for {File}.", request.FileName);
+            throw;
+        }
+    }
+
+    public async Task<FileMetadata> RegisterUploadAsync(
+        Guid userId,
+        string objectPath,
+        FileUploadRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        if (string.IsNullOrWhiteSpace(objectPath))
+        {
+            throw new ArgumentException("Object path must be provided after uploading to Supabase storage.", nameof(objectPath));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var document = new FileDocumentRecord
+            {
+                Id = Guid.NewGuid(),
+                OwnerId = request.OwnerId == Guid.Empty ? userId : request.OwnerId,
+                EntityType = request.EntityType,
+                EntityId = request.EntityId,
+                FileName = request.FileName,
+                ContentType = request.ContentType,
+                Size = request.ContentLength,
+                StoragePath = objectPath,
+                UploadedBy = userId,
+                UploadedAt = DateTime.UtcNow
+            };
+
+            await client.From<FileDocumentRecord>().Insert(document, cancellationToken: cancellationToken);
+
+            var version = new FileVersionRecord
+            {
+                Id = Guid.NewGuid(),
+                FileId = document.Id,
+                StoragePath = objectPath,
+                CreatedAt = document.UploadedAt,
+                CreatedBy = userId,
+                Notes = JsonConvert.SerializeObject(request.Metadata)
+            };
+
+            await client.From<FileVersionRecord>().Insert(version, cancellationToken: cancellationToken);
+
+            await LogFileAuditAsync(client, document.Id, "file.upload", userId, cancellationToken);
+
+            return new FileMetadata
+            {
+                FileId = document.Id,
+                FileName = document.FileName,
+                ContentType = document.ContentType,
+                Size = document.Size,
+                UploadedAt = document.UploadedAt,
+                UploadedBy = document.UploadedBy,
+                StoragePath = document.StoragePath,
+                Versions = new[]
+                {
+                    new FileVersion
+                    {
+                        VersionId = version.Id,
+                        StoragePath = version.StoragePath,
+                        CreatedAt = version.CreatedAt,
+                        CreatedBy = version.CreatedBy,
+                        Notes = version.Notes ?? string.Empty
+                    }
+                }
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to register Supabase upload for {File}.", request.FileName);
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<FileVersion>> GetFileVersionsAsync(
+        Guid fileId,
+        CancellationToken cancellationToken = default)
+    {
+        if (fileId == Guid.Empty)
+        {
+            throw new ArgumentException("File id cannot be empty.", nameof(fileId));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var response = await client.From<FileVersionRecord>()
+                .Filter(x => x.FileId, PostgrestOperator.Equals, fileId)
+                .Order(x => x.CreatedAt, PostgrestOrdering.Descending)
+                .Get(cancellationToken: cancellationToken);
+
+            return response.Models
+                .Select(record => new FileVersion
+                {
+                    VersionId = record.Id,
+                    StoragePath = record.StoragePath,
+                    CreatedAt = record.CreatedAt,
+                    CreatedBy = record.CreatedBy,
+                    Notes = record.Notes ?? string.Empty
+                })
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load Supabase file versions for file {FileId}.", fileId);
+            throw;
+        }
+    }
+
+    public async Task<CommunicationThread> EnsureThreadAsync(
+        string entityType,
+        string entityId,
+        string channel,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entityType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entityId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(channel);
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var response = await client.From<CommunicationThreadRecord>()
+                .Filter(x => x.EntityType, PostgrestOperator.Equals, entityType)
+                .Filter(x => x.EntityId, PostgrestOperator.Equals, entityId)
+                .Filter(x => x.Channel, PostgrestOperator.Equals, channel)
+                .Single(cancellationToken: cancellationToken);
+
+            var thread = response.Model;
+            if (thread is null)
+            {
+                thread = new CommunicationThreadRecord
+                {
+                    Id = Guid.NewGuid(),
+                    EntityType = entityType,
+                    EntityId = entityId,
+                    Channel = channel,
+                    CreatedAt = DateTime.UtcNow
+                };
+
+                await client.From<CommunicationThreadRecord>().Insert(thread, cancellationToken: cancellationToken);
+            }
+
+            var messages = await client.From<ThreadMessageRecord>()
+                .Filter(x => x.ThreadId, PostgrestOperator.Equals, thread.Id)
+                .Order(x => x.SentAt, PostgrestOrdering.Descending)
+                .Get(cancellationToken: cancellationToken);
+
+            return new CommunicationThread
+            {
+                ThreadId = thread.Id,
+                Channel = thread.Channel,
+                Messages = messages.Models.Select(MapToThreadMessage).ToList()
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to ensure communication thread for {EntityType}:{EntityId}.", entityType, entityId);
+            throw;
+        }
+    }
+
+    public async Task<ThreadMessage> SendThreadMessageAsync(
+        Guid threadId,
+        Guid senderId,
+        string body,
+        IEnumerable<string> channels,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(body);
+        if (threadId == Guid.Empty)
+        {
+            throw new ArgumentException("Thread id cannot be empty.", nameof(threadId));
+        }
+
+        if (senderId == Guid.Empty)
+        {
+            throw new ArgumentException("Sender id cannot be empty.", nameof(senderId));
+        }
+
+        ArgumentNullException.ThrowIfNull(channels);
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var normalizedChannels = channels
+                .Where(channel => !string.IsNullOrWhiteSpace(channel))
+                .Select(channel => channel.Trim().ToLowerInvariant())
+                .Distinct()
+                .ToArray();
+
+            var record = new ThreadMessageRecord
+            {
+                Id = Guid.NewGuid(),
+                ThreadId = threadId,
+                SenderId = senderId,
+                Body = body,
+                SentAt = DateTime.UtcNow,
+                Channels = string.Join(',', normalizedChannels)
+            };
+
+            await client.From<ThreadMessageRecord>().Insert(record, cancellationToken: cancellationToken);
+            await LogFileAuditAsync(client, threadId, "thread.message", senderId, cancellationToken);
+
+            await DispatchCommunicationsAsync(client, record, normalizedChannels, cancellationToken);
+
+            return MapToThreadMessage(record);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send communication message on thread {ThreadId}.", threadId);
+            throw;
+        }
+    }
+
+    private static string BuildObjectPath(FileUploadRequest request)
+    {
+        var safeName = request.FileName
+            .Replace(' ', '-')
+            .ToLowerInvariant();
+
+        var datePart = DateTime.UtcNow.ToString("yyyy/MM/dd", CultureInfo.InvariantCulture);
+        var identifier = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
+
+        return $"{request.EntityType}/{request.EntityId}/{datePart}/{identifier}-{safeName}";
+    }
+
+    private static ThreadMessage MapToThreadMessage(ThreadMessageRecord record)
+    {
+        var channels = string.IsNullOrWhiteSpace(record.Channels)
+            ? Array.Empty<string>()
+            : record.Channels.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        return new ThreadMessage
+        {
+            MessageId = record.Id,
+            SenderId = record.SenderId,
+            Body = record.Body,
+            SentAt = record.SentAt,
+            DeliveryChannels = channels
+        };
+    }
+
+    private static async Task LogFileAuditAsync(
+        Supabase.Client client,
+        Guid entityId,
+        string action,
+        Guid actorId,
+        CancellationToken cancellationToken)
+    {
+        var auditRecord = new AuditLogRecord
+        {
+            Id = Guid.NewGuid(),
+            ActorId = actorId,
+            Action = action,
+            EntityType = "file",
+            EntityId = entityId.ToString(),
+            CreatedAt = DateTime.UtcNow
+        };
+
+        await client.From<AuditLogRecord>().Insert(auditRecord, cancellationToken: cancellationToken);
+    }
+
+    private async Task DispatchCommunicationsAsync(
+        Supabase.Client client,
+        ThreadMessageRecord record,
+        IReadOnlyCollection<string> channels,
+        CancellationToken cancellationToken)
+    {
+        if (channels.Count == 0)
+        {
+            return;
+        }
+
+        var events = channels.Select(channel => new IntegrationEventRecord
+        {
+            Id = Guid.NewGuid(),
+            EventType = $"communication.{channel}",
+            PayloadJson = JsonConvert.SerializeObject(new
+            {
+                record.ThreadId,
+                record.SenderId,
+                record.Body,
+                record.SentAt,
+                Channels = channels
+            }),
+            CreatedAt = DateTime.UtcNow
+        });
+
+        await client.From<IntegrationEventRecord>().Insert(events, cancellationToken: cancellationToken);
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Services/SupabaseSettingsCustomizationService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SupabaseSettingsCustomizationService.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using NexaCRM.WebClient.Models.Customization;
+using NexaCRM.WebClient.Models.Supabase;
+using NexaCRM.WebClient.Services.Interfaces;
+using PostgrestOrdering = Supabase.Postgrest.Constants.Ordering;
+using PostgrestOperator = Supabase.Postgrest.Constants.Operator;
+
+namespace NexaCRM.WebClient.Services;
+
+public sealed class SupabaseSettingsCustomizationService : ISettingsCustomizationService
+{
+    private readonly SupabaseClientProvider _clientProvider;
+    private readonly ILogger<SupabaseSettingsCustomizationService> _logger;
+
+    public SupabaseSettingsCustomizationService(
+        SupabaseClientProvider clientProvider,
+        ILogger<SupabaseSettingsCustomizationService> logger)
+    {
+        _clientProvider = clientProvider;
+        _logger = logger;
+    }
+
+    public async Task<OrganizationSettings> GetOrganizationSettingsAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (organizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(organizationId));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var response = await client.From<OrganizationSettingsRecord>()
+                .Filter(x => x.OrganizationId, PostgrestOperator.Equals, organizationId)
+                .Single(cancellationToken: cancellationToken);
+
+            if (response.Model is null)
+            {
+                return new OrganizationSettings { OrganizationId = organizationId };
+            }
+
+            var featureFlags = string.IsNullOrWhiteSpace(response.Model.FeatureFlagsJson)
+                ? new Dictionary<string, bool>()
+                : JsonConvert.DeserializeObject<Dictionary<string, bool>>(response.Model.FeatureFlagsJson!)
+                    ?? new Dictionary<string, bool>();
+
+            return new OrganizationSettings
+            {
+                OrganizationId = response.Model.OrganizationId,
+                Locale = response.Model.Locale,
+                Timezone = response.Model.Timezone,
+                Theme = response.Model.Theme,
+                FeatureFlags = featureFlags
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load organization settings from Supabase for {OrgId}.", organizationId);
+            throw;
+        }
+    }
+
+    public async Task SaveOrganizationSettingsAsync(
+        OrganizationSettings settings,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        if (settings.OrganizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(settings));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var existing = await client.From<OrganizationSettingsRecord>()
+                .Filter(x => x.OrganizationId, PostgrestOperator.Equals, settings.OrganizationId)
+                .Single(cancellationToken: cancellationToken);
+
+            var record = new OrganizationSettingsRecord
+            {
+                Id = existing.Model?.Id ?? Guid.NewGuid(),
+                OrganizationId = settings.OrganizationId,
+                Locale = settings.Locale,
+                Timezone = settings.Timezone,
+                Theme = settings.Theme,
+                FeatureFlagsJson = JsonConvert.SerializeObject(settings.FeatureFlags)
+            };
+
+            if (existing.Model is null)
+            {
+                await client.From<OrganizationSettingsRecord>().Insert(record, cancellationToken: cancellationToken);
+            }
+            else
+            {
+                await client.From<OrganizationSettingsRecord>().Update(record);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to persist organization settings for {OrgId}.", settings.OrganizationId);
+            throw;
+        }
+    }
+
+    public async Task<UserPreferences> GetUserPreferencesAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var response = await client.From<UserPreferenceRecord>()
+                .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+                .Single(cancellationToken: cancellationToken);
+
+            if (response.Model is null)
+            {
+                return new UserPreferences { UserId = userId };
+            }
+
+            var widgetPreferences = string.IsNullOrWhiteSpace(response.Model.WidgetPreferencesJson)
+                ? new Dictionary<string, string>()
+                : JsonConvert.DeserializeObject<Dictionary<string, string>>(response.Model.WidgetPreferencesJson!)
+                    ?? new Dictionary<string, string>();
+
+            return new UserPreferences
+            {
+                UserId = response.Model.UserId,
+                Theme = response.Model.Theme,
+                DateFormat = response.Model.DateFormat,
+                EnableNotifications = response.Model.EnableNotifications,
+                WidgetPreferences = widgetPreferences
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load user preferences from Supabase for {UserId}.", userId);
+            throw;
+        }
+    }
+
+    public async Task SaveUserPreferencesAsync(
+        UserPreferences preferences,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(preferences);
+        if (preferences.UserId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(preferences));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var existing = await client.From<UserPreferenceRecord>()
+                .Filter(x => x.UserId, PostgrestOperator.Equals, preferences.UserId)
+                .Single(cancellationToken: cancellationToken);
+
+            var record = new UserPreferenceRecord
+            {
+                Id = existing.Model?.Id ?? Guid.NewGuid(),
+                UserId = preferences.UserId,
+                Theme = preferences.Theme,
+                DateFormat = preferences.DateFormat,
+                EnableNotifications = preferences.EnableNotifications,
+                WidgetPreferencesJson = JsonConvert.SerializeObject(preferences.WidgetPreferences)
+            };
+
+            if (existing.Model is null)
+            {
+                await client.From<UserPreferenceRecord>().Insert(record, cancellationToken: cancellationToken);
+            }
+            else
+            {
+                await client.From<UserPreferenceRecord>().Update(record);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save user preferences for {UserId}.", preferences.UserId);
+            throw;
+        }
+    }
+
+    public async Task<DashboardLayout> GetDashboardLayoutAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var response = await client.From<DashboardWidgetRecord>()
+                .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+                .Order(x => x.DisplayOrder, PostgrestOrdering.Ascending)
+                .Get(cancellationToken: cancellationToken);
+
+            var widgets = response.Models
+                .Select(record => new DashboardWidget
+                {
+                    WidgetId = record.Id,
+                    Type = record.WidgetType,
+                    Order = record.DisplayOrder,
+                    Configuration = DeserializeConfiguration(record.ConfigurationJson)
+                })
+                .ToList();
+
+            return new DashboardLayout
+            {
+                UserId = userId,
+                Widgets = widgets
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load dashboard layout for {UserId}.", userId);
+            throw;
+        }
+    }
+
+    public async Task SaveDashboardLayoutAsync(
+        DashboardLayout layout,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(layout);
+        if (layout.UserId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(layout));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+
+            await client.From<DashboardWidgetRecord>()
+                .Filter(x => x.UserId, PostgrestOperator.Equals, layout.UserId)
+                .Delete(cancellationToken: cancellationToken);
+
+            var records = layout.Widgets.Select(widget => new DashboardWidgetRecord
+            {
+                Id = widget.WidgetId == Guid.Empty ? Guid.NewGuid() : widget.WidgetId,
+                UserId = layout.UserId,
+                WidgetType = widget.Type,
+                DisplayOrder = widget.Order,
+                ConfigurationJson = JsonConvert.SerializeObject(widget.Configuration)
+            });
+
+            if (records.Any())
+            {
+                await client.From<DashboardWidgetRecord>().Insert(records, cancellationToken: cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to store dashboard layout for {UserId}.", layout.UserId);
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<KpiSnapshot>> GetKpiSnapshotsAsync(
+        string metric,
+        DateTime since,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(metric);
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var response = await client.From<KpiSnapshotRecord>()
+                .Filter(x => x.Metric, PostgrestOperator.Equals, metric)
+                .Filter(x => x.CapturedAt, PostgrestOperator.GreaterThanOrEqual, since)
+                .Order(x => x.CapturedAt, PostgrestOrdering.Ascending)
+                .Get(cancellationToken: cancellationToken);
+
+            return response.Models
+                .Select(record => new KpiSnapshot
+                {
+                    Id = record.Id,
+                    Metric = record.Metric,
+                    Value = record.Value,
+                    CapturedAt = record.CapturedAt
+                })
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load KPI snapshots for metric {Metric}.", metric);
+            throw;
+        }
+    }
+
+    private static IReadOnlyDictionary<string, string> DeserializeConfiguration(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new Dictionary<string, string>();
+        }
+
+        return JsonConvert.DeserializeObject<Dictionary<string, string>>(json!)
+            ?? new Dictionary<string, string>();
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Services/SupabaseSyncOrchestrationService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SupabaseSyncOrchestrationService.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using NexaCRM.WebClient.Models.Supabase;
+using NexaCRM.WebClient.Models.Sync;
+using NexaCRM.WebClient.Services.Interfaces;
+using PostgrestOrdering = Supabase.Postgrest.Constants.Ordering;
+using PostgrestOperator = Supabase.Postgrest.Constants.Operator;
+
+namespace NexaCRM.WebClient.Services;
+
+public sealed class SupabaseSyncOrchestrationService : ISyncOrchestrationService
+{
+    private readonly SupabaseClientProvider _clientProvider;
+    private readonly ILogger<SupabaseSyncOrchestrationService> _logger;
+
+    public SupabaseSyncOrchestrationService(
+        SupabaseClientProvider clientProvider,
+        ILogger<SupabaseSyncOrchestrationService> logger)
+    {
+        _clientProvider = clientProvider;
+        _logger = logger;
+    }
+
+    public async Task<SyncPlan> BuildSyncPlanAsync(
+        Guid userId,
+        SyncPolicy policy,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var since = DateTime.UtcNow.Subtract(policy.RefreshInterval);
+
+            var query = client.From<SyncItemRecord>()
+                .Filter(x => x.LastModifiedAt, PostgrestOperator.GreaterThanOrEqual, since)
+                .Order(x => x.LastModifiedAt, PostgrestOrdering.Ascending);
+
+            if (policy.Entities is { Count: > 0 })
+            {
+                query = query.Filter(x => x.EntityType, PostgrestOperator.In, policy.Entities.ToArray());
+            }
+
+            var response = await query.Get(cancellationToken: cancellationToken);
+
+            var items = response.Models
+                .Select(record => new SyncItem
+                {
+                    EntityType = record.EntityType,
+                    EntityId = record.EntityId,
+                    LastModifiedAt = record.LastModifiedAt,
+                    PayloadJson = record.PayloadJson
+                })
+                .ToList();
+
+            return new SyncPlan
+            {
+                PlanId = Guid.NewGuid(),
+                CreatedAt = DateTime.UtcNow,
+                PendingItems = items
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to build sync plan for user {UserId}.", userId);
+            throw;
+        }
+    }
+
+    public async Task RecordClientEnvelopeAsync(
+        SyncEnvelope envelope,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+        if (envelope.UserId == Guid.Empty)
+        {
+            throw new ArgumentException("Envelope must include the user identifier.", nameof(envelope));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var envelopeRecord = new SyncEnvelopeRecord
+            {
+                Id = envelope.EnvelopeId == Guid.Empty ? Guid.NewGuid() : envelope.EnvelopeId,
+                UserId = envelope.UserId,
+                GeneratedAt = envelope.GeneratedAt == default ? DateTime.UtcNow : envelope.GeneratedAt
+            };
+
+            await client.From<SyncEnvelopeRecord>().Insert(envelopeRecord, cancellationToken: cancellationToken);
+
+            if (envelope.Items.Count > 0)
+            {
+                var itemRecords = envelope.Items.Select(item => new SyncItemRecord
+                {
+                    Id = Guid.NewGuid(),
+                    EnvelopeId = envelopeRecord.Id,
+                    EntityType = item.EntityType,
+                    EntityId = item.EntityId,
+                    LastModifiedAt = item.LastModifiedAt,
+                    PayloadJson = item.PayloadJson
+                });
+
+                await client.From<SyncItemRecord>().Insert(itemRecords, cancellationToken: cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to persist client envelope {EnvelopeId}.", envelope.EnvelopeId);
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<SyncConflict>> GetConflictsAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var response = await client.From<SyncConflictRecord>()
+                .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+                .Order(x => x.CreatedAt, PostgrestOrdering.Ascending)
+                .Get(cancellationToken: cancellationToken);
+
+            return response.Models
+                .Select(record => new SyncConflict
+                {
+                    ConflictId = record.Id,
+                    EntityType = record.EntityType,
+                    EntityId = record.EntityId,
+                    ResolutionStrategy = record.ResolutionStrategy,
+                    PayloadJson = record.PayloadJson
+                })
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to fetch sync conflicts for {UserId}.", userId);
+            throw;
+        }
+    }
+
+    public async Task ResolveConflictsAsync(
+        IReadOnlyCollection<SyncConflict> conflicts,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(conflicts);
+        if (conflicts.Count == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            foreach (var conflict in conflicts)
+            {
+                if (conflict.ConflictId == Guid.Empty)
+                {
+                    continue;
+                }
+
+                await client.From<SyncConflictRecord>()
+                    .Filter(x => x.Id, PostgrestOperator.Equals, conflict.ConflictId)
+                    .Delete(cancellationToken: cancellationToken);
+
+                var resolutionEvent = new IntegrationEventRecord
+                {
+                    Id = Guid.NewGuid(),
+                    EventType = "sync.conflict.resolved",
+                    PayloadJson = JsonConvert.SerializeObject(new
+                    {
+                        conflict.ConflictId,
+                        conflict.EntityType,
+                        conflict.EntityId,
+                        conflict.ResolutionStrategy,
+                        ResolvedAt = DateTime.UtcNow
+                    }),
+                    CreatedAt = DateTime.UtcNow
+                };
+
+                await client.From<IntegrationEventRecord>().Insert(resolutionEvent, cancellationToken: cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to resolve sync conflicts.");
+            throw;
+        }
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Services/SupabaseUserGovernanceService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/SupabaseUserGovernanceService.cs
@@ -1,0 +1,484 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using NexaCRM.WebClient.Models.Governance;
+using NexaCRM.WebClient.Models.Supabase;
+using NexaCRM.WebClient.Services.Interfaces;
+using PostgrestOrdering = Supabase.Postgrest.Constants.Ordering;
+using PostgrestOperator = Supabase.Postgrest.Constants.Operator;
+
+namespace NexaCRM.WebClient.Services;
+
+public sealed class SupabaseUserGovernanceService : IUserGovernanceService
+{
+    private readonly SupabaseClientProvider _clientProvider;
+    private readonly ILogger<SupabaseUserGovernanceService> _logger;
+
+    public SupabaseUserGovernanceService(
+        SupabaseClientProvider clientProvider,
+        ILogger<SupabaseUserGovernanceService> logger)
+    {
+        _clientProvider = clientProvider;
+        _logger = logger;
+    }
+
+    public async Task<UserAccount> CreateUserAsync(
+        string email,
+        string displayName,
+        IEnumerable<string> roles,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(email);
+        ArgumentException.ThrowIfNullOrWhiteSpace(displayName);
+        ArgumentNullException.ThrowIfNull(roles);
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+
+            var randomPassword = $"{Guid.NewGuid():N}!Aa1";
+            await client.Auth.SignUp(email, randomPassword);
+
+            var record = new UserAccountRecord
+            {
+                Id = Guid.NewGuid(),
+                Email = email,
+                DisplayName = displayName,
+                IsActive = true,
+                CreatedAt = DateTime.UtcNow,
+                MetadataJson = JsonConvert.SerializeObject(new { ProvisionedAt = DateTime.UtcNow })
+            };
+
+            await client.From<UserAccountRecord>().Insert(record, cancellationToken: cancellationToken);
+
+            await AssignRolesInternalAsync(client, record.Id, roles, cancellationToken);
+            await LogAuditAsync(client, record.Id, "user.create", cancellationToken);
+
+            return MapToDomain(record, roles.ToArray());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create Supabase user account.");
+            throw;
+        }
+    }
+
+    public async Task<UserAccount?> GetUserAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var response = await client.From<UserAccountRecord>()
+                .Filter(x => x.Id, PostgrestOperator.Equals, userId)
+                .Single(cancellationToken: cancellationToken);
+
+            if (response.Model is null)
+            {
+                return null;
+            }
+
+            var roles = await LoadRolesAsync(client, userId, cancellationToken);
+            return MapToDomain(response.Model, roles);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load user account {UserId} from Supabase.", userId);
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<UserAccount>> GetUsersAsync(
+        UserQueryOptions query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var table = client.From<UserAccountRecord>();
+
+            if (!string.IsNullOrWhiteSpace(query.SearchTerm))
+            {
+                table = table.Filter(x => x.Email, PostgrestOperator.ILike, $"%{query.SearchTerm!}%");
+            }
+
+            if (!query.IncludeInactive)
+            {
+                table = table.Filter(x => x.IsActive, PostgrestOperator.Equals, true);
+            }
+
+            var pageSize = Math.Clamp(query.PageSize, 1, 200);
+            var offset = (Math.Max(query.PageNumber, 1) - 1) * pageSize;
+
+            var response = await table
+                .Order(x => x.CreatedAt, PostgrestOrdering.Descending)
+                .Range(offset, offset + pageSize - 1)
+                .Get(cancellationToken: cancellationToken);
+
+            var records = response.Models ?? new List<UserAccountRecord>();
+            var roleMap = await LoadRolesAsync(client, records.Select(x => x.Id).ToArray(), cancellationToken);
+
+            return records
+                .Select(record =>
+                {
+                    var roles = roleMap.TryGetValue(record.Id, out var assigned)
+                        ? assigned
+                        : Array.Empty<string>();
+                    return MapToDomain(record, roles);
+                })
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to enumerate Supabase users.");
+            throw;
+        }
+    }
+
+    public async Task AssignRolesAsync(
+        Guid userId,
+        IEnumerable<string> roles,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(roles);
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            await AssignRolesInternalAsync(client, userId, roles, cancellationToken);
+            await LogAuditAsync(client, userId, "user.roles.update", cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to assign roles for user {UserId}.", userId);
+            throw;
+        }
+    }
+
+    public async Task<PasswordResetTicket> CreatePasswordResetTicketAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var ticket = new PasswordResetTicketRecord
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                ExpiresAt = DateTime.UtcNow.AddHours(1),
+                ResetUrl = $"/reset-password/{Guid.NewGuid():N}"
+            };
+
+            await client.From<PasswordResetTicketRecord>().Insert(ticket, cancellationToken: cancellationToken);
+            await LogAuditAsync(client, userId, "user.password.reset", cancellationToken);
+
+            return new PasswordResetTicket
+            {
+                TicketId = ticket.Id,
+                UserId = ticket.UserId,
+                ExpiresAt = ticket.ExpiresAt,
+                ResetUrl = ticket.ResetUrl
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create password reset ticket for {UserId}.", userId);
+            throw;
+        }
+    }
+
+    public async Task DisableUserAsync(
+        Guid userId,
+        string reason,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var response = await client.From<UserAccountRecord>()
+                .Filter(x => x.Id, PostgrestOperator.Equals, userId)
+                .Single(cancellationToken: cancellationToken);
+
+            if (response.Model is null)
+            {
+                return;
+            }
+
+            response.Model.IsActive = false;
+            response.Model.MetadataJson = JsonConvert.SerializeObject(new
+            {
+                DisabledReason = reason,
+                DisabledAt = DateTime.UtcNow
+            });
+
+            await client.From<UserAccountRecord>().Update(response.Model);
+
+            await LogAuditAsync(client, userId, "user.disable", cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to disable user {UserId}.", userId);
+            throw;
+        }
+    }
+
+    public async Task<SecurityPolicy> GetSecurityPolicyAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (organizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(organizationId));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var response = await client.From<SecurityPolicyRecord>()
+                .Filter(x => x.OrganizationId, PostgrestOperator.Equals, organizationId)
+                .Single(cancellationToken: cancellationToken);
+
+            if (response.Model is null)
+            {
+                return new SecurityPolicy();
+            }
+
+            return new SecurityPolicy
+            {
+                RequireMfa = response.Model.RequireMfa,
+                SessionTimeoutMinutes = response.Model.SessionTimeoutMinutes,
+                PasswordExpiryDays = response.Model.PasswordExpiryDays,
+                IpAllowList = DeserializeList(response.Model.IpAllowList)
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load security policy for organization {OrgId}.", organizationId);
+            throw;
+        }
+    }
+
+    public async Task SaveSecurityPolicyAsync(
+        Guid organizationId,
+        SecurityPolicy policy,
+        CancellationToken cancellationToken = default)
+    {
+        if (organizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(organizationId));
+        }
+
+        ArgumentNullException.ThrowIfNull(policy);
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var existing = await client.From<SecurityPolicyRecord>()
+                .Filter(x => x.OrganizationId, PostgrestOperator.Equals, organizationId)
+                .Single(cancellationToken: cancellationToken);
+
+            var record = new SecurityPolicyRecord
+            {
+                Id = existing.Model?.Id ?? Guid.NewGuid(),
+                OrganizationId = organizationId,
+                RequireMfa = policy.RequireMfa,
+                SessionTimeoutMinutes = policy.SessionTimeoutMinutes,
+                PasswordExpiryDays = policy.PasswordExpiryDays,
+                IpAllowList = JsonConvert.SerializeObject(policy.IpAllowList ?? Array.Empty<string>())
+            };
+
+            if (existing.Model is null)
+            {
+                await client.From<SecurityPolicyRecord>().Insert(record, cancellationToken: cancellationToken);
+            }
+            else
+            {
+                await client.From<SecurityPolicyRecord>().Update(record);
+            }
+
+            await LogAuditAsync(client, organizationId, "security.policy.update", cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to persist security policy for {OrgId}.", organizationId);
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<SecurityAuditLogEntry>> GetAuditTrailAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (organizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(organizationId));
+        }
+
+        try
+        {
+            var client = await _clientProvider.GetClientAsync();
+            var response = await client.From<AuditLogRecord>()
+                .Filter(x => x.EntityId, PostgrestOperator.Equals, organizationId.ToString())
+                .Order(x => x.CreatedAt, PostgrestOrdering.Descending)
+                .Range(0, 99)
+                .Get(cancellationToken: cancellationToken);
+
+            return response.Models
+                .Select(record => new SecurityAuditLogEntry
+                {
+                    Id = record.Id,
+                    ActorId = record.ActorId,
+                    Action = record.Action,
+                    EntityType = record.EntityType,
+                    EntityId = record.EntityId,
+                    PayloadJson = record.PayloadJson,
+                    OccurredAt = record.CreatedAt ?? DateTime.UtcNow
+                })
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load audit log for organization {OrgId}.", organizationId);
+            throw;
+        }
+    }
+
+    private static UserAccount MapToDomain(UserAccountRecord record, IReadOnlyCollection<string> roles)
+    {
+        var metadata = string.IsNullOrWhiteSpace(record.MetadataJson)
+            ? new Dictionary<string, string>()
+            : JsonConvert.DeserializeObject<Dictionary<string, string>>(record.MetadataJson!)
+                ?? new Dictionary<string, string>();
+
+        return new UserAccount
+        {
+            Id = record.Id,
+            Email = record.Email,
+            DisplayName = record.DisplayName,
+            IsActive = record.IsActive ?? true,
+            CreatedAt = record.CreatedAt ?? DateTime.UtcNow,
+            LastSignInAt = record.LastSignInAt,
+            Roles = roles,
+            Metadata = metadata
+        };
+    }
+
+    private static IReadOnlyCollection<string> DeserializeList(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return Array.Empty<string>();
+        }
+
+        return JsonConvert.DeserializeObject<List<string>>(json!) ?? new List<string>();
+    }
+
+    private static async Task LogAuditAsync(
+        Supabase.Client client,
+        Guid entityId,
+        string action,
+        CancellationToken cancellationToken)
+    {
+        var record = new AuditLogRecord
+        {
+            Id = Guid.NewGuid(),
+            EntityType = "user",
+            EntityId = entityId.ToString(),
+            Action = action,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        await client.From<AuditLogRecord>().Insert(record, cancellationToken: cancellationToken);
+    }
+
+    private static async Task AssignRolesInternalAsync(
+        Supabase.Client client,
+        Guid userId,
+        IEnumerable<string> roles,
+        CancellationToken cancellationToken)
+    {
+        var roleList = roles
+            .Where(role => !string.IsNullOrWhiteSpace(role))
+            .Select(role => role.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        await client.From<UserRoleRecord>()
+            .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+            .Delete(cancellationToken: cancellationToken);
+
+        if (roleList.Count == 0)
+        {
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        var records = roleList.Select(role => new UserRoleRecord
+        {
+            UserId = userId,
+            RoleCode = role,
+            AssignedAt = now
+        });
+
+        await client.From<UserRoleRecord>().Insert(records, cancellationToken: cancellationToken);
+    }
+
+    private static async Task<IReadOnlyCollection<string>> LoadRolesAsync(
+        Supabase.Client client,
+        Guid userId,
+        CancellationToken cancellationToken)
+    {
+        var response = await client.From<UserRoleRecord>()
+            .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+            .Get(cancellationToken: cancellationToken);
+
+        return response.Models.Select(record => record.RoleCode).ToList();
+    }
+
+    private static async Task<Dictionary<Guid, IReadOnlyCollection<string>>> LoadRolesAsync(
+        Supabase.Client client,
+        IReadOnlyCollection<Guid> userIds,
+        CancellationToken cancellationToken)
+    {
+        if (userIds.Count == 0)
+        {
+            return new Dictionary<Guid, IReadOnlyCollection<string>>();
+        }
+
+        var response = await client.From<UserRoleRecord>()
+            .Filter(x => x.UserId, PostgrestOperator.In, userIds.Select(id => id.ToString()).ToArray())
+            .Get(cancellationToken: cancellationToken);
+
+        return response.Models
+            .GroupBy(record => record.UserId)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyCollection<string>)group.Select(record => record.RoleCode).ToList());
+    }
+}

--- a/tests/NexaCRM.WebClient.UnitTests/SupabaseAdvancedServicesTests.cs
+++ b/tests/NexaCRM.WebClient.UnitTests/SupabaseAdvancedServicesTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using NexaCRM.WebClient.Models.FileHub;
+using NexaCRM.WebClient.Models.Supabase;
+using NexaCRM.WebClient.Services;
+using Xunit;
+
+namespace NexaCRM.WebClient.UnitTests;
+
+public sealed class SupabaseAdvancedServicesTests
+{
+    [Fact]
+    public void MapToDomain_ParsesMetadataDictionary()
+    {
+        var record = new UserAccountRecord
+        {
+            Id = Guid.NewGuid(),
+            Email = "user@example.com",
+            DisplayName = "User",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            MetadataJson = "{\"PreferredLanguage\":\"ko-KR\"}"
+        };
+
+        var method = typeof(SupabaseUserGovernanceService)
+            .GetMethod("MapToDomain", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var result = method!.Invoke(null, new object[] { record, new List<string> { "admin" } });
+        Assert.NotNull(result);
+
+        var metadataProperty = result!.GetType().GetProperty("Metadata");
+        Assert.NotNull(metadataProperty);
+
+        var metadata = metadataProperty!.GetValue(result) as IReadOnlyDictionary<string, string>;
+        Assert.NotNull(metadata);
+        Assert.Equal("ko-KR", metadata!["PreferredLanguage"]);
+    }
+
+    [Fact]
+    public void BuildObjectPath_ComposesDeterministicSegments()
+    {
+        var request = new FileUploadRequest
+        {
+            EntityType = "deal",
+            EntityId = "123",
+            FileName = "Quote.PDF"
+        };
+
+        var method = typeof(SupabaseFileHubService)
+            .GetMethod("BuildObjectPath", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var path = (string)method!.Invoke(null, new object[] { request })!;
+
+        Assert.Contains("deal/123", path, StringComparison.Ordinal);
+        Assert.EndsWith("quote.pdf", path, StringComparison.Ordinal);
+
+        var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        Assert.True(segments.Length >= 5);
+
+        var dateSegment = string.Join('/', segments[2], segments[3], segments[4]);
+        Assert.True(DateTime.TryParseExact(
+            dateSegment,
+            "yyyy/MM/dd",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out _));
+    }
+
+    [Fact]
+    public void DeserializeConfiguration_ReturnsDictionary()
+    {
+        const string json = "{\"widget\":\"pipeline\",\"size\":\"large\"}";
+
+        var method = typeof(SupabaseSettingsCustomizationService)
+            .GetMethod("DeserializeConfiguration", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var configuration = method!.Invoke(null, new object[] { json });
+        Assert.NotNull(configuration);
+
+        var dictionary = Assert.IsAssignableFrom<IReadOnlyDictionary<string, string>>(configuration);
+        Assert.Equal("pipeline", dictionary["widget"]);
+        Assert.Equal("large", dictionary["size"]);
+    }
+}


### PR DESCRIPTION
## Summary
- add Supabase-driven services for user governance, communication, file hub operations, and sync orchestration
- introduce governance/personalization/file/sync models, service interfaces, and dependency injection wiring
- extend service interface reference, document the technology stack, and add reflection-based unit tests

## Testing
- `dotnet build NexaCrmSolution.sln --configuration Release` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d46f382bf0832cb13f3bcb2f56fe48