### PR TITLE
feat: add supabase enterprise services and tests

### DIFF
--- a/docs/supabase-enterprise-services.md
+++ b/docs/supabase-enterprise-services.md
@@ -1,0 +1,28 @@
+# Supabase Enterprise Services Overview
+
+이 문서는 NexaCRM WebClient에서 Supabase 기반 거버넌스, 파일/커뮤니케이션 허브, 개인화, 동기화 모듈을 어떻게 구성했는지 요약합니다.
+
+## 공통 설계
+- `SupabaseClientProvider`를 통해 Supabase 초기화를 단일 지점에서 수행하고, WebAssembly 환경에서 Realtime 미지원 시 graceful fallback을 제공합니다.
+- 실제 Supabase 백엔드 연결이 어려운 개발 환경을 위해 `SupabaseEnterpriseDataStore`를 싱글톤으로 등록하여 인메모리 저장소를 제공합니다. 해당 저장소는 런타임 중 Supabase 테이블을 모사하며, 이후 실 서비스에 맞춰 PostgREST 호출로 교체할 수 있습니다.
+- 모든 서비스는 `EnsureClientAsync` 도우미를 호출해 Supabase 초기화 시도 후, 실패 시 경고 로그를 남기고 인메모리 경로로 계속 동작합니다.
+
+## 사용자/보안 거버넌스 (`IUserGovernanceService`)
+- 사용자 생성, 역할 할당, 비활성화, 비밀번호 재설정 티켓, 보안 정책 저장/조회, 감사 로그 조회를 제공합니다.
+- 감사 로그는 `SecurityAuditLogEntry` 모델로 관리하며, 조직 단위로 역순 정렬된 히스토리를 제공합니다.
+
+## 개인화/대시보드 (`ISettingsCustomizationService`)
+- 조직 기본 설정, 사용자 선호도, 대시보드 위젯 레이아웃, KPI 스냅샷을 CRUD 방식으로 지원합니다.
+- 대시보드 위젯은 순서를 강제하기 위해 저장 시 자동으로 인덱싱합니다.
+
+## 파일·커뮤니케이션 허브 (`IFileHubService`, `ICommunicationHubService`)
+- 문서 등록과 버전 관리, 문서 별 스레드 생성, 멀티 채널 메시지 기록을 제공합니다.
+- 일반 커뮤니케이션 스레드는 `ICommunicationHubService`로 분리해 파일 외 시나리오(영업/지원 등)에 재사용할 수 있습니다.
+
+## 동기화 (`ISyncOrchestrationService`)
+- 오프라인 envelope 등록, 미적용 envelope 조회, 적용 처리, 충돌 기록/조회 기능을 제공합니다.
+- 충돌 정보는 envelope-organization 조합으로 그룹화되어 모바일/데스크톱 클라이언트가 쉽게 수집할 수 있습니다.
+
+## 테스트 전략
+- `SupabaseEnterpriseDataStore`는 순수 C# 인메모리 컬렉션을 사용하므로 단위 테스트에서 별도의 외부 의존성을 요구하지 않습니다.
+- 서비스별 동작은 `NexaCRM.WebClient.UnitTests` 프로젝트에서 검증하며, 향후 실 Supabase 연동 시에는 통합 테스트를 추가할 수 있습니다.

--- a/src/Web/NexaCRM.WebClient/Models/Customization/CustomizationModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Customization/CustomizationModels.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+
+namespace NexaCRM.WebClient.Models.Customization;
+
+/// <summary>
+/// Settings applied to all users in a specific organization.
+/// </summary>
+public sealed record OrganizationSettings
+{
+    public Guid OrganizationId { get; init; }
+
+    public string TimeZone { get; init; } = "UTC";
+
+    public string Locale { get; init; } = "en-US";
+
+    public bool EnableAuditTrail { get; init; }
+
+    public IReadOnlyDictionary<string, bool> FeatureFlags { get; init; } =
+        new Dictionary<string, bool>();
+}
+
+/// <summary>
+/// User level personalization captured from the settings panel.
+/// </summary>
+public sealed record UserPreferences
+{
+    public Guid UserId { get; init; }
+
+    public Guid OrganizationId { get; init; }
+
+    public string Theme { get; init; } = "light";
+
+    public IReadOnlyDictionary<string, string> Preferences { get; init; } =
+        new Dictionary<string, string>();
+}
+
+/// <summary>
+/// Captures the layout of dashboard widgets for a user.
+/// </summary>
+public sealed record DashboardWidget
+{
+    public Guid WidgetId { get; init; }
+
+    public Guid UserId { get; init; }
+
+    public string WidgetType { get; init; } = string.Empty;
+
+    public int Order { get; init; }
+
+    public IReadOnlyDictionary<string, string> Settings { get; init; } =
+        new Dictionary<string, string>();
+}
+
+/// <summary>
+/// Records a KPI snapshot for trend analysis dashboards.
+/// </summary>
+public sealed record KpiSnapshot
+{
+    public Guid Id { get; init; }
+
+    public Guid OrganizationId { get; init; }
+
+    public string KpiName { get; init; } = string.Empty;
+
+    public decimal Value { get; init; }
+
+    public DateTime CapturedAtUtc { get; init; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/FileHub/FileHubModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/FileHub/FileHubModels.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+
+namespace NexaCRM.WebClient.Models.FileHub;
+
+/// <summary>
+/// Represents a document registered inside the file hub.
+/// </summary>
+public sealed record FileDocument
+{
+    public Guid DocumentId { get; init; }
+
+    public Guid OrganizationId { get; init; }
+
+    public Guid OwnerId { get; init; }
+
+    public string Name { get; init; } = string.Empty;
+
+    public string Category { get; init; } = string.Empty;
+
+    public DateTime CreatedAtUtc { get; init; }
+
+    public DateTime UpdatedAtUtc { get; init; }
+
+    public IReadOnlyDictionary<string, string> Tags { get; init; } =
+        new Dictionary<string, string>();
+}
+
+/// <summary>
+/// Represents a single stored version of a document.
+/// </summary>
+public sealed record FileVersion
+{
+    public Guid VersionId { get; init; }
+
+    public Guid DocumentId { get; init; }
+
+    public string StoragePath { get; init; } = string.Empty;
+
+    public string ContentHash { get; init; } = string.Empty;
+
+    public long SizeInBytes { get; init; }
+
+    public DateTime CreatedAtUtc { get; init; }
+
+    public Guid CreatedBy { get; init; }
+}
+
+/// <summary>
+/// Represents a collaboration thread tied to a document or workflow.
+/// </summary>
+public sealed record CommunicationThread
+{
+    public Guid ThreadId { get; init; }
+
+    public Guid OrganizationId { get; init; }
+
+    public string Topic { get; init; } = string.Empty;
+
+    public IReadOnlyCollection<Guid> ParticipantIds { get; init; } = Array.Empty<Guid>();
+
+    public DateTime CreatedAtUtc { get; init; }
+}
+
+/// <summary>
+/// Represents a message delivered through one of the supported channels.
+/// </summary>
+public sealed record ThreadMessage
+{
+    public Guid MessageId { get; init; }
+
+    public Guid ThreadId { get; init; }
+
+    public Guid AuthorId { get; init; }
+
+    public string Body { get; init; } = string.Empty;
+
+    public string Channel { get; init; } = "internal";
+
+    public DateTime SentAtUtc { get; init; }
+}

--- a/src/Web/NexaCRM.WebClient/Models/Governance/UserAccount.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Governance/UserAccount.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+
+namespace NexaCRM.WebClient.Models.Governance;
+
+/// <summary>
+/// Represents a managed user account inside NexaCRM.
+/// </summary>
+public sealed record UserAccount
+{
+    public Guid Id { get; init; }
+
+    public Guid OrganizationId { get; init; }
+
+    public string Email { get; init; } = string.Empty;
+
+    public string DisplayName { get; init; } = string.Empty;
+
+    public bool IsActive { get; init; }
+
+    public DateTime CreatedAtUtc { get; init; }
+
+    public DateTime? LastSignInAtUtc { get; init; }
+
+    public IReadOnlyCollection<string> Roles { get; init; } = Array.Empty<string>();
+
+    public IReadOnlyDictionary<string, string> Metadata { get; init; } =
+        new Dictionary<string, string>();
+}
+
+/// <summary>
+/// Optional query parameters when enumerating users for an organization.
+/// </summary>
+public sealed record UserQueryOptions
+{
+    public Guid? OrganizationId { get; init; }
+
+    public string? SearchTerm { get; init; }
+
+    public bool IncludeInactive { get; init; }
+
+    public IReadOnlyCollection<string>? RoleFilter { get; init; }
+
+    public int PageNumber { get; init; } = 1;
+
+    public int PageSize { get; init; } = 50;
+}
+
+/// <summary>
+/// Captures the outcome of a password reset flow.
+/// </summary>
+public sealed record PasswordResetTicket
+{
+    public Guid TicketId { get; init; }
+
+    public Guid UserId { get; init; }
+
+    public DateTime ExpiresAtUtc { get; init; }
+
+    public string ResetUrl { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// Describes an audit log entry produced by the governance pipeline.
+/// </summary>
+public sealed record SecurityAuditLogEntry
+{
+    public Guid Id { get; init; }
+
+    public Guid OrganizationId { get; init; }
+
+    public Guid? ActorId { get; init; }
+
+    public string Action { get; init; } = string.Empty;
+
+    public string EntityType { get; init; } = string.Empty;
+
+    public string? EntityId { get; init; }
+
+    public string? PayloadJson { get; init; }
+
+    public DateTime OccurredAtUtc { get; init; }
+}
+
+/// <summary>
+/// Defines security controls that should be enforced for end-users.
+/// </summary>
+public sealed record SecurityPolicy
+{
+    public bool RequireMfa { get; init; }
+
+    public int SessionTimeoutMinutes { get; init; } = 60;
+
+    public int PasswordExpiryDays { get; init; } = 90;
+
+    public IReadOnlyCollection<string> IpAllowList { get; init; } = Array.Empty<string>();
+}

--- a/src/Web/NexaCRM.WebClient/Models/Sync/SyncModels.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Sync/SyncModels.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+
+namespace NexaCRM.WebClient.Models.Sync;
+
+/// <summary>
+/// Represents an offline envelope grouping multiple entities for synchronization.
+/// </summary>
+public sealed record SyncEnvelope
+{
+    public Guid EnvelopeId { get; init; }
+
+    public Guid OrganizationId { get; init; }
+
+    public Guid UserId { get; init; }
+
+    public DateTime CreatedAtUtc { get; init; }
+
+    public DateTime? AppliedAtUtc { get; init; }
+
+    public IReadOnlyCollection<SyncItem> Items { get; init; } = Array.Empty<SyncItem>();
+}
+
+/// <summary>
+/// Represents a single item inside a sync envelope.
+/// </summary>
+public sealed record SyncItem
+{
+    public Guid ItemId { get; init; }
+
+    public Guid EnvelopeId { get; init; }
+
+    public string EntityType { get; init; } = string.Empty;
+
+    public string EntityId { get; init; } = string.Empty;
+
+    public string PayloadJson { get; init; } = string.Empty;
+
+    public DateTime UpdatedAtUtc { get; init; }
+}
+
+/// <summary>
+/// Describes a conflict detected during synchronization.
+/// </summary>
+public sealed record SyncConflict
+{
+    public Guid ConflictId { get; init; }
+
+    public Guid EnvelopeId { get; init; }
+
+    public string EntityType { get; init; } = string.Empty;
+
+    public string EntityId { get; init; } = string.Empty;
+
+    public string ResolutionState { get; init; } = "pending";
+
+    public string? ResolutionNotes { get; init; }
+
+    public DateTime DetectedAtUtc { get; init; }
+}

--- a/src/Web/NexaCRM.WebClient/Program.cs
+++ b/src/Web/NexaCRM.WebClient/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Options;
 using NexaCRM.WebClient.Services;
 using NexaCRM.WebClient.Services.Interfaces;
 using NexaCRM.WebClient.Services.Mock;
+using NexaCRM.WebClient.Services.SupabaseEnterprise;
 using NexaCRM.WebClient.Models.Db;
 using NexaCRM.WebClient.Options;
 
@@ -87,6 +88,12 @@ builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddScoped<INotificationFeedService, SupabaseNotificationFeedService>();
 builder.Services.AddScoped<ITeamService, MockTeamService>();
 builder.Services.AddScoped<INavigationStateService, NavigationStateService>();
+builder.Services.AddSingleton<SupabaseEnterpriseDataStore>();
+builder.Services.AddScoped<IUserGovernanceService, SupabaseUserGovernanceService>();
+builder.Services.AddScoped<ISettingsCustomizationService, SupabaseSettingsCustomizationService>();
+builder.Services.AddScoped<IFileHubService, SupabaseFileHubService>();
+builder.Services.AddScoped<ICommunicationHubService, SupabaseCommunicationHubService>();
+builder.Services.AddScoped<ISyncOrchestrationService, SupabaseSyncOrchestrationService>();
 
 var culture = new CultureInfo("ko-KR");
 CultureInfo.DefaultThreadCurrentCulture = culture;

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/ICommunicationHubService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/ICommunicationHubService.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NexaCRM.WebClient.Models.FileHub;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+/// <summary>
+/// Exposes multi-channel communication primitives backed by Supabase.
+/// </summary>
+public interface ICommunicationHubService
+{
+    Task<CommunicationThread> StartThreadAsync(
+        Guid organizationId,
+        string topic,
+        IEnumerable<Guid> participantIds,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<CommunicationThread>> GetThreadsForParticipantAsync(
+        Guid participantId,
+        CancellationToken cancellationToken = default);
+
+    Task<ThreadMessage> AppendMessageAsync(
+        Guid threadId,
+        Guid authorId,
+        string channel,
+        string body,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<ThreadMessage>> GetMessagesAsync(
+        Guid threadId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IFileHubService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IFileHubService.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NexaCRM.WebClient.Models.FileHub;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+/// <summary>
+/// Provides APIs for registering documents, managing versions, and collaborating around files.
+/// </summary>
+public interface IFileHubService
+{
+    Task<FileDocument> CreateDocumentAsync(
+        Guid organizationId,
+        Guid ownerId,
+        string name,
+        string category,
+        IReadOnlyDictionary<string, string>? tags,
+        CancellationToken cancellationToken = default);
+
+    Task<FileVersion> AddVersionAsync(
+        Guid documentId,
+        Guid authorId,
+        string storagePath,
+        string contentHash,
+        long sizeInBytes,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<FileDocument>> GetDocumentsAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<FileVersion>> GetDocumentVersionsAsync(
+        Guid documentId,
+        CancellationToken cancellationToken = default);
+
+    Task<CommunicationThread> StartThreadAsync(
+        Guid documentId,
+        string topic,
+        IEnumerable<Guid> participantIds,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<CommunicationThread>> GetThreadsForDocumentAsync(
+        Guid documentId,
+        CancellationToken cancellationToken = default);
+
+    Task<ThreadMessage> AppendMessageAsync(
+        Guid threadId,
+        Guid authorId,
+        string channel,
+        string body,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<ThreadMessage>> GetThreadMessagesAsync(
+        Guid threadId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/ISettingsCustomizationService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/ISettingsCustomizationService.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NexaCRM.WebClient.Models.Customization;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+/// <summary>
+/// Handles personalization data such as organization defaults and user dashboard layouts.
+/// </summary>
+public interface ISettingsCustomizationService
+{
+    Task<OrganizationSettings> GetOrganizationSettingsAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default);
+
+    Task SaveOrganizationSettingsAsync(
+        OrganizationSettings settings,
+        CancellationToken cancellationToken = default);
+
+    Task<UserPreferences> GetUserPreferencesAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default);
+
+    Task SaveUserPreferencesAsync(
+        UserPreferences preferences,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<DashboardWidget>> GetDashboardLayoutAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default);
+
+    Task SaveDashboardLayoutAsync(
+        Guid userId,
+        IEnumerable<DashboardWidget> widgets,
+        CancellationToken cancellationToken = default);
+
+    Task RecordKpiSnapshotAsync(
+        KpiSnapshot snapshot,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<KpiSnapshot>> GetKpiHistoryAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/ISyncOrchestrationService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/ISyncOrchestrationService.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NexaCRM.WebClient.Models.Sync;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+/// <summary>
+/// Coordinates offline envelopes and conflict tracking.
+/// </summary>
+public interface ISyncOrchestrationService
+{
+    Task<SyncEnvelope> RegisterEnvelopeAsync(
+        Guid envelopeId,
+        Guid organizationId,
+        Guid userId,
+        IEnumerable<SyncItem> items,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<SyncEnvelope>> GetPendingEnvelopesAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default);
+
+    Task MarkEnvelopeAsAppliedAsync(
+        Guid envelopeId,
+        DateTime appliedAtUtc,
+        CancellationToken cancellationToken = default);
+
+    Task<SyncConflict> RegisterConflictAsync(
+        SyncConflict conflict,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<SyncConflict>> GetConflictsAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Web/NexaCRM.WebClient/Services/Interfaces/IUserGovernanceService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Interfaces/IUserGovernanceService.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NexaCRM.WebClient.Models.Governance;
+
+namespace NexaCRM.WebClient.Services.Interfaces;
+
+/// <summary>
+/// Provides a Supabase backed abstraction for account governance and audit features.
+/// </summary>
+public interface IUserGovernanceService
+{
+    Task<UserAccount> CreateUserAsync(
+        Guid organizationId,
+        string email,
+        string displayName,
+        IEnumerable<string> roles,
+        CancellationToken cancellationToken = default);
+
+    Task<UserAccount?> GetUserAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<UserAccount>> GetUsersAsync(
+        UserQueryOptions query,
+        CancellationToken cancellationToken = default);
+
+    Task AssignRolesAsync(
+        Guid userId,
+        IEnumerable<string> roles,
+        CancellationToken cancellationToken = default);
+
+    Task<PasswordResetTicket> CreatePasswordResetTicketAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default);
+
+    Task DisableUserAsync(
+        Guid userId,
+        string reason,
+        CancellationToken cancellationToken = default);
+
+    Task<SecurityPolicy> GetSecurityPolicyAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default);
+
+    Task SaveSecurityPolicyAsync(
+        Guid organizationId,
+        SecurityPolicy policy,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<SecurityAuditLogEntry>> GetAuditTrailAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Web/NexaCRM.WebClient/Services/Supabase/SupabaseCommunicationHubService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Supabase/SupabaseCommunicationHubService.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NexaCRM.WebClient.Models.FileHub;
+using NexaCRM.WebClient.Services.Interfaces;
+
+namespace NexaCRM.WebClient.Services.SupabaseEnterprise;
+
+/// <summary>
+/// Lightweight multi-channel hub storing conversation metadata through the shared Supabase store.
+/// </summary>
+public sealed class SupabaseCommunicationHubService : ICommunicationHubService
+{
+    private readonly SupabaseClientProvider _clientProvider;
+    private readonly SupabaseEnterpriseDataStore _store;
+    private readonly ILogger<SupabaseCommunicationHubService> _logger;
+
+    public SupabaseCommunicationHubService(
+        SupabaseClientProvider clientProvider,
+        SupabaseEnterpriseDataStore store,
+        ILogger<SupabaseCommunicationHubService> logger)
+    {
+        _clientProvider = clientProvider;
+        _store = store;
+        _logger = logger;
+    }
+
+    public async Task<CommunicationThread> StartThreadAsync(
+        Guid organizationId,
+        string topic,
+        IEnumerable<Guid> participantIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (organizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(organizationId));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+        ArgumentNullException.ThrowIfNull(participantIds);
+
+        await EnsureClientAsync(cancellationToken).ConfigureAwait(false);
+
+        var participants = participantIds
+            .Where(id => id != Guid.Empty)
+            .Distinct()
+            .ToArray();
+
+        var thread = new CommunicationThread
+        {
+            ThreadId = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            Topic = topic,
+            ParticipantIds = participants,
+            CreatedAtUtc = DateTime.UtcNow
+        };
+
+        _store.Threads[thread.ThreadId] = thread;
+        _store.ThreadMessages.TryAdd(thread.ThreadId, new List<ThreadMessage>());
+
+        return thread;
+    }
+
+    public Task<IReadOnlyList<CommunicationThread>> GetThreadsForParticipantAsync(
+        Guid participantId,
+        CancellationToken cancellationToken = default)
+    {
+        if (participantId == Guid.Empty)
+        {
+            throw new ArgumentException("Participant id cannot be empty.", nameof(participantId));
+        }
+
+        var threads = _store.Threads.Values
+            .Where(thread => thread.ParticipantIds.Contains(participantId))
+            .OrderByDescending(thread => thread.CreatedAtUtc)
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<CommunicationThread>>(threads);
+    }
+
+    public Task<ThreadMessage> AppendMessageAsync(
+        Guid threadId,
+        Guid authorId,
+        string channel,
+        string body,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_store.Threads.ContainsKey(threadId))
+        {
+            throw new InvalidOperationException($"Thread {threadId} was not found.");
+        }
+
+        if (authorId == Guid.Empty)
+        {
+            throw new ArgumentException("Author id cannot be empty.", nameof(authorId));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(channel);
+        ArgumentException.ThrowIfNullOrWhiteSpace(body);
+
+        var message = new ThreadMessage
+        {
+            MessageId = Guid.NewGuid(),
+            ThreadId = threadId,
+            AuthorId = authorId,
+            Channel = channel,
+            Body = body,
+            SentAtUtc = DateTime.UtcNow
+        };
+
+        var list = _store.ThreadMessages.GetOrAdd(threadId, _ => new List<ThreadMessage>());
+        list.Add(message);
+
+        return Task.FromResult(message);
+    }
+
+    public Task<IReadOnlyList<ThreadMessage>> GetMessagesAsync(
+        Guid threadId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_store.ThreadMessages.TryGetValue(threadId, out var messages))
+        {
+            return Task.FromResult<IReadOnlyList<ThreadMessage>>(Array.Empty<ThreadMessage>());
+        }
+
+        var ordered = messages
+            .OrderBy(message => message.SentAtUtc)
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<ThreadMessage>>(ordered);
+    }
+
+    private async Task EnsureClientAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _clientProvider.GetClientAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Supabase client unavailable; operating against in-memory store.");
+        }
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Services/Supabase/SupabaseEnterpriseDataStore.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Supabase/SupabaseEnterpriseDataStore.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using NexaCRM.WebClient.Models.Customization;
+using NexaCRM.WebClient.Models.FileHub;
+using NexaCRM.WebClient.Models.Governance;
+using NexaCRM.WebClient.Models.Sync;
+
+namespace NexaCRM.WebClient.Services.SupabaseEnterprise;
+
+/// <summary>
+/// Thread-safe in-memory data store that simulates Supabase persistence for offline development.
+/// </summary>
+public sealed class SupabaseEnterpriseDataStore
+{
+    public ConcurrentDictionary<Guid, UserAccount> Users { get; } = new();
+
+    public ConcurrentDictionary<Guid, HashSet<string>> UserRoles { get; } = new();
+
+    public ConcurrentDictionary<Guid, List<SecurityAuditLogEntry>> AuditLogs { get; } = new();
+
+    public ConcurrentDictionary<Guid, SecurityPolicy> SecurityPolicies { get; } = new();
+
+    public ConcurrentDictionary<Guid, PasswordResetTicket> PasswordResetTickets { get; } = new();
+
+    public ConcurrentDictionary<Guid, OrganizationSettings> OrganizationSettings { get; } = new();
+
+    public ConcurrentDictionary<Guid, UserPreferences> UserPreferences { get; } = new();
+
+    public ConcurrentDictionary<Guid, List<DashboardWidget>> DashboardLayouts { get; } = new();
+
+    public ConcurrentDictionary<Guid, List<KpiSnapshot>> KpiSnapshots { get; } = new();
+
+    public ConcurrentDictionary<Guid, FileDocument> Documents { get; } = new();
+
+    public ConcurrentDictionary<Guid, List<FileVersion>> DocumentVersions { get; } = new();
+
+    public ConcurrentDictionary<Guid, CommunicationThread> Threads { get; } = new();
+
+    public ConcurrentDictionary<Guid, List<ThreadMessage>> ThreadMessages { get; } = new();
+
+    public ConcurrentDictionary<Guid, List<Guid>> DocumentThreads { get; } = new();
+
+    public ConcurrentDictionary<Guid, SyncEnvelope> SyncEnvelopes { get; } = new();
+
+    public ConcurrentDictionary<Guid, List<SyncConflict>> SyncConflicts { get; } = new();
+}

--- a/src/Web/NexaCRM.WebClient/Services/Supabase/SupabaseFileHubService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Supabase/SupabaseFileHubService.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NexaCRM.WebClient.Models.FileHub;
+using NexaCRM.WebClient.Services.Interfaces;
+
+namespace NexaCRM.WebClient.Services.SupabaseEnterprise;
+
+/// <summary>
+/// Provides document registration and collaboration features backed by a Supabase style store.
+/// </summary>
+public sealed class SupabaseFileHubService : IFileHubService
+{
+    private readonly SupabaseClientProvider _clientProvider;
+    private readonly SupabaseEnterpriseDataStore _store;
+    private readonly ILogger<SupabaseFileHubService> _logger;
+
+    public SupabaseFileHubService(
+        SupabaseClientProvider clientProvider,
+        SupabaseEnterpriseDataStore store,
+        ILogger<SupabaseFileHubService> logger)
+    {
+        _clientProvider = clientProvider;
+        _store = store;
+        _logger = logger;
+    }
+
+    public async Task<FileDocument> CreateDocumentAsync(
+        Guid organizationId,
+        Guid ownerId,
+        string name,
+        string category,
+        IReadOnlyDictionary<string, string>? tags,
+        CancellationToken cancellationToken = default)
+    {
+        if (organizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(organizationId));
+        }
+
+        if (ownerId == Guid.Empty)
+        {
+            throw new ArgumentException("Owner id cannot be empty.", nameof(ownerId));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(category);
+
+        await EnsureClientAsync(cancellationToken).ConfigureAwait(false);
+
+        var now = DateTime.UtcNow;
+        var document = new FileDocument
+        {
+            DocumentId = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            OwnerId = ownerId,
+            Name = name,
+            Category = category,
+            CreatedAtUtc = now,
+            UpdatedAtUtc = now,
+            Tags = tags ?? new Dictionary<string, string>()
+        };
+
+        _store.Documents[document.DocumentId] = document;
+        _store.DocumentVersions.TryAdd(document.DocumentId, new List<FileVersion>());
+        _store.DocumentThreads.TryAdd(document.DocumentId, new List<Guid>());
+
+        return document;
+    }
+
+    public async Task<FileVersion> AddVersionAsync(
+        Guid documentId,
+        Guid authorId,
+        string storagePath,
+        string contentHash,
+        long sizeInBytes,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_store.Documents.TryGetValue(documentId, out var document))
+        {
+            throw new InvalidOperationException($"Document {documentId} was not found.");
+        }
+
+        if (authorId == Guid.Empty)
+        {
+            throw new ArgumentException("Author id cannot be empty.", nameof(authorId));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(storagePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(contentHash);
+
+        await EnsureClientAsync(cancellationToken).ConfigureAwait(false);
+
+        var version = new FileVersion
+        {
+            VersionId = Guid.NewGuid(),
+            DocumentId = documentId,
+            CreatedBy = authorId,
+            StoragePath = storagePath,
+            ContentHash = contentHash,
+            SizeInBytes = sizeInBytes,
+            CreatedAtUtc = DateTime.UtcNow
+        };
+
+        var versions = _store.DocumentVersions.GetOrAdd(documentId, _ => new List<FileVersion>());
+        versions.Add(version);
+        _store.Documents[documentId] = document with { UpdatedAtUtc = version.CreatedAtUtc };
+
+        return version;
+    }
+
+    public Task<IReadOnlyList<FileDocument>> GetDocumentsAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (organizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(organizationId));
+        }
+
+        var documents = _store.Documents.Values
+            .Where(d => d.OrganizationId == organizationId)
+            .OrderByDescending(d => d.UpdatedAtUtc)
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<FileDocument>>(documents);
+    }
+
+    public Task<IReadOnlyList<FileVersion>> GetDocumentVersionsAsync(
+        Guid documentId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_store.DocumentVersions.TryGetValue(documentId, out var versions))
+        {
+            return Task.FromResult<IReadOnlyList<FileVersion>>(Array.Empty<FileVersion>());
+        }
+
+        return Task.FromResult<IReadOnlyList<FileVersion>>(versions
+            .OrderByDescending(v => v.CreatedAtUtc)
+            .ToList());
+    }
+
+    public async Task<CommunicationThread> StartThreadAsync(
+        Guid documentId,
+        string topic,
+        IEnumerable<Guid> participantIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(participantIds);
+        if (!_store.Documents.ContainsKey(documentId))
+        {
+            throw new InvalidOperationException($"Document {documentId} was not found.");
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+        await EnsureClientAsync(cancellationToken).ConfigureAwait(false);
+
+        var document = _store.Documents[documentId];
+        var participants = participantIds
+            .Where(id => id != Guid.Empty)
+            .Distinct()
+            .ToArray();
+
+        var thread = new CommunicationThread
+        {
+            ThreadId = Guid.NewGuid(),
+            OrganizationId = document.OrganizationId,
+            Topic = topic,
+            ParticipantIds = participants,
+            CreatedAtUtc = DateTime.UtcNow
+        };
+
+        _store.Threads[thread.ThreadId] = thread;
+        _store.ThreadMessages.TryAdd(thread.ThreadId, new List<ThreadMessage>());
+
+        var list = _store.DocumentThreads.GetOrAdd(documentId, _ => new List<Guid>());
+        list.Add(thread.ThreadId);
+
+        return thread;
+    }
+
+    public Task<IReadOnlyList<CommunicationThread>> GetThreadsForDocumentAsync(
+        Guid documentId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_store.DocumentThreads.TryGetValue(documentId, out var threadIds))
+        {
+            return Task.FromResult<IReadOnlyList<CommunicationThread>>(Array.Empty<CommunicationThread>());
+        }
+
+        var threads = threadIds
+            .Where(id => _store.Threads.ContainsKey(id))
+            .Select(id => _store.Threads[id])
+            .OrderByDescending(t => t.CreatedAtUtc)
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<CommunicationThread>>(threads);
+    }
+
+    public Task<ThreadMessage> AppendMessageAsync(
+        Guid threadId,
+        Guid authorId,
+        string channel,
+        string body,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_store.Threads.TryGetValue(threadId, out _))
+        {
+            throw new InvalidOperationException($"Thread {threadId} was not found.");
+        }
+
+        if (authorId == Guid.Empty)
+        {
+            throw new ArgumentException("Author id cannot be empty.", nameof(authorId));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(channel);
+        ArgumentException.ThrowIfNullOrWhiteSpace(body);
+
+        var message = new ThreadMessage
+        {
+            MessageId = Guid.NewGuid(),
+            ThreadId = threadId,
+            AuthorId = authorId,
+            Channel = channel,
+            Body = body,
+            SentAtUtc = DateTime.UtcNow
+        };
+
+        var list = _store.ThreadMessages.GetOrAdd(threadId, _ => new List<ThreadMessage>());
+        list.Add(message);
+
+        return Task.FromResult(message);
+    }
+
+    public Task<IReadOnlyList<ThreadMessage>> GetThreadMessagesAsync(
+        Guid threadId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_store.ThreadMessages.TryGetValue(threadId, out var messages))
+        {
+            return Task.FromResult<IReadOnlyList<ThreadMessage>>(Array.Empty<ThreadMessage>());
+        }
+
+        var ordered = messages
+            .OrderBy(m => m.SentAtUtc)
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<ThreadMessage>>(ordered);
+    }
+
+    private async Task EnsureClientAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _clientProvider.GetClientAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Supabase client unavailable; operating against in-memory store.");
+        }
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Services/Supabase/SupabaseSettingsCustomizationService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Supabase/SupabaseSettingsCustomizationService.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NexaCRM.WebClient.Models.Customization;
+using NexaCRM.WebClient.Services.Interfaces;
+
+namespace NexaCRM.WebClient.Services.SupabaseEnterprise;
+
+/// <summary>
+/// Stores organization and user personalization metadata in a Supabase backed cache.
+/// </summary>
+public sealed class SupabaseSettingsCustomizationService : ISettingsCustomizationService
+{
+    private readonly SupabaseClientProvider _clientProvider;
+    private readonly SupabaseEnterpriseDataStore _store;
+    private readonly ILogger<SupabaseSettingsCustomizationService> _logger;
+
+    public SupabaseSettingsCustomizationService(
+        SupabaseClientProvider clientProvider,
+        SupabaseEnterpriseDataStore store,
+        ILogger<SupabaseSettingsCustomizationService> logger)
+    {
+        _clientProvider = clientProvider;
+        _store = store;
+        _logger = logger;
+    }
+
+    public async Task<OrganizationSettings> GetOrganizationSettingsAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (organizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(organizationId));
+        }
+
+        await EnsureClientAsync(cancellationToken).ConfigureAwait(false);
+
+        if (_store.OrganizationSettings.TryGetValue(organizationId, out var settings))
+        {
+            return settings;
+        }
+
+        var defaults = new OrganizationSettings
+        {
+            OrganizationId = organizationId,
+            FeatureFlags = new Dictionary<string, bool>
+            {
+                ["files.enabled"] = true,
+                ["communications.enabled"] = true
+            }
+        };
+
+        _store.OrganizationSettings.TryAdd(organizationId, defaults);
+        return defaults;
+    }
+
+    public Task SaveOrganizationSettingsAsync(
+        OrganizationSettings settings,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        if (settings.OrganizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(settings.OrganizationId));
+        }
+
+        _store.OrganizationSettings[settings.OrganizationId] = settings;
+        return Task.CompletedTask;
+    }
+
+    public async Task<UserPreferences> GetUserPreferencesAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        await EnsureClientAsync(cancellationToken).ConfigureAwait(false);
+
+        if (_store.UserPreferences.TryGetValue(userId, out var preferences))
+        {
+            return preferences;
+        }
+
+        var defaultPreferences = new UserPreferences
+        {
+            UserId = userId,
+            OrganizationId = Guid.Empty,
+            Theme = "light"
+        };
+
+        _store.UserPreferences.TryAdd(userId, defaultPreferences);
+        return defaultPreferences;
+    }
+
+    public Task SaveUserPreferencesAsync(
+        UserPreferences preferences,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(preferences);
+        if (preferences.UserId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(preferences.UserId));
+        }
+
+        _store.UserPreferences[preferences.UserId] = preferences;
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<DashboardWidget>> GetDashboardLayoutAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        var widgets = _store.DashboardLayouts.TryGetValue(userId, out var layout)
+            ? layout.OrderBy(w => w.Order).ToList()
+            : new List<DashboardWidget>();
+
+        return Task.FromResult<IReadOnlyList<DashboardWidget>>(widgets);
+    }
+
+    public Task SaveDashboardLayoutAsync(
+        Guid userId,
+        IEnumerable<DashboardWidget> widgets,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(widgets);
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        var ordered = widgets
+            .Select((widget, index) => widget with { Order = index })
+            .ToList();
+
+        _store.DashboardLayouts[userId] = ordered;
+        return Task.CompletedTask;
+    }
+
+    public Task RecordKpiSnapshotAsync(
+        KpiSnapshot snapshot,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        if (snapshot.OrganizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(snapshot.OrganizationId));
+        }
+
+        var snapshots = _store.KpiSnapshots.GetOrAdd(snapshot.OrganizationId, _ => new List<KpiSnapshot>());
+        snapshots.Add(snapshot);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<KpiSnapshot>> GetKpiHistoryAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (organizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(organizationId));
+        }
+
+        var snapshots = _store.KpiSnapshots.TryGetValue(organizationId, out var list)
+            ? list.OrderByDescending(s => s.CapturedAtUtc).ToList()
+            : new List<KpiSnapshot>();
+
+        return Task.FromResult<IReadOnlyList<KpiSnapshot>>(snapshots);
+    }
+
+    private async Task EnsureClientAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _clientProvider.GetClientAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Supabase client unavailable; operating against in-memory store.");
+        }
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Services/Supabase/SupabaseSyncOrchestrationService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Supabase/SupabaseSyncOrchestrationService.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NexaCRM.WebClient.Models.Sync;
+using NexaCRM.WebClient.Services.Interfaces;
+
+namespace NexaCRM.WebClient.Services.SupabaseEnterprise;
+
+/// <summary>
+/// Coordinates offline envelopes and conflict tracking using the in-memory Supabase store.
+/// </summary>
+public sealed class SupabaseSyncOrchestrationService : ISyncOrchestrationService
+{
+    private readonly SupabaseClientProvider _clientProvider;
+    private readonly SupabaseEnterpriseDataStore _store;
+    private readonly ILogger<SupabaseSyncOrchestrationService> _logger;
+
+    public SupabaseSyncOrchestrationService(
+        SupabaseClientProvider clientProvider,
+        SupabaseEnterpriseDataStore store,
+        ILogger<SupabaseSyncOrchestrationService> logger)
+    {
+        _clientProvider = clientProvider;
+        _store = store;
+        _logger = logger;
+    }
+
+    public async Task<SyncEnvelope> RegisterEnvelopeAsync(
+        Guid envelopeId,
+        Guid organizationId,
+        Guid userId,
+        IEnumerable<SyncItem> items,
+        CancellationToken cancellationToken = default)
+    {
+        if (organizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(organizationId));
+        }
+
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        ArgumentNullException.ThrowIfNull(items);
+
+        await EnsureClientAsync(cancellationToken).ConfigureAwait(false);
+
+        var resolvedId = envelopeId == Guid.Empty ? Guid.NewGuid() : envelopeId;
+        var materializedItems = items
+            .Select(item => item with { ItemId = item.ItemId == Guid.Empty ? Guid.NewGuid() : item.ItemId })
+            .ToList();
+
+        var envelope = new SyncEnvelope
+        {
+            EnvelopeId = resolvedId,
+            OrganizationId = organizationId,
+            UserId = userId,
+            CreatedAtUtc = DateTime.UtcNow,
+            Items = materializedItems
+        };
+
+        _store.SyncEnvelopes[resolvedId] = envelope;
+        return envelope;
+    }
+
+    public Task<IReadOnlyList<SyncEnvelope>> GetPendingEnvelopesAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (organizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(organizationId));
+        }
+
+        var envelopes = _store.SyncEnvelopes.Values
+            .Where(envelope => envelope.OrganizationId == organizationId && envelope.AppliedAtUtc is null)
+            .OrderBy(envelope => envelope.CreatedAtUtc)
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<SyncEnvelope>>(envelopes);
+    }
+
+    public Task MarkEnvelopeAsAppliedAsync(
+        Guid envelopeId,
+        DateTime appliedAtUtc,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_store.SyncEnvelopes.TryGetValue(envelopeId, out var envelope))
+        {
+            throw new InvalidOperationException($"Envelope {envelopeId} could not be found.");
+        }
+
+        _store.SyncEnvelopes[envelopeId] = envelope with { AppliedAtUtc = appliedAtUtc };
+        return Task.CompletedTask;
+    }
+
+    public Task<SyncConflict> RegisterConflictAsync(
+        SyncConflict conflict,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(conflict);
+        if (conflict.EnvelopeId == Guid.Empty)
+        {
+            throw new ArgumentException("Envelope id cannot be empty.", nameof(conflict.EnvelopeId));
+        }
+
+        var resolved = conflict with
+        {
+            ConflictId = conflict.ConflictId == Guid.Empty ? Guid.NewGuid() : conflict.ConflictId,
+            DetectedAtUtc = conflict.DetectedAtUtc == default ? DateTime.UtcNow : conflict.DetectedAtUtc
+        };
+
+        var list = _store.SyncConflicts.GetOrAdd(resolved.EnvelopeId, _ => new List<SyncConflict>());
+        list.Add(resolved);
+
+        return Task.FromResult(resolved);
+    }
+
+    public Task<IReadOnlyList<SyncConflict>> GetConflictsAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (organizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(organizationId));
+        }
+
+        var conflicts = _store.SyncEnvelopes.Values
+            .Where(envelope => envelope.OrganizationId == organizationId)
+            .SelectMany(envelope => _store.SyncConflicts.TryGetValue(envelope.EnvelopeId, out var list)
+                ? (IEnumerable<SyncConflict>)list
+                : Array.Empty<SyncConflict>())
+            .OrderByDescending(conflict => conflict.DetectedAtUtc)
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<SyncConflict>>(conflicts);
+    }
+
+    private async Task EnsureClientAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _clientProvider.GetClientAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Supabase client unavailable; operating against in-memory store.");
+        }
+    }
+}

--- a/src/Web/NexaCRM.WebClient/Services/Supabase/SupabaseUserGovernanceService.cs
+++ b/src/Web/NexaCRM.WebClient/Services/Supabase/SupabaseUserGovernanceService.cs
@@ -1,0 +1,329 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NexaCRM.WebClient.Models.Governance;
+using NexaCRM.WebClient.Services.Interfaces;
+
+namespace NexaCRM.WebClient.Services.SupabaseEnterprise;
+
+/// <summary>
+/// In-memory Supabase backed implementation of <see cref="IUserGovernanceService"/> used for development scenarios.
+/// </summary>
+public sealed class SupabaseUserGovernanceService : IUserGovernanceService
+{
+    private readonly SupabaseClientProvider _clientProvider;
+    private readonly SupabaseEnterpriseDataStore _store;
+    private readonly ILogger<SupabaseUserGovernanceService> _logger;
+    private readonly object _auditLock = new();
+
+    public SupabaseUserGovernanceService(
+        SupabaseClientProvider clientProvider,
+        SupabaseEnterpriseDataStore store,
+        ILogger<SupabaseUserGovernanceService> logger)
+    {
+        _clientProvider = clientProvider;
+        _store = store;
+        _logger = logger;
+    }
+
+    public async Task<UserAccount> CreateUserAsync(
+        Guid organizationId,
+        string email,
+        string displayName,
+        IEnumerable<string> roles,
+        CancellationToken cancellationToken = default)
+    {
+        if (organizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(organizationId));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(email);
+        ArgumentException.ThrowIfNullOrWhiteSpace(displayName);
+        ArgumentNullException.ThrowIfNull(roles);
+
+        await EnsureClientAsync(cancellationToken).ConfigureAwait(false);
+
+        var normalizedRoles = roles
+            .Where(r => !string.IsNullOrWhiteSpace(r))
+            .Select(r => r.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var now = DateTime.UtcNow;
+        var account = new UserAccount
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            Email = email,
+            DisplayName = displayName,
+            IsActive = true,
+            CreatedAtUtc = now,
+            Roles = normalizedRoles,
+            Metadata = new Dictionary<string, string>
+            {
+                ["provisioned_at"] = now.ToString("O"),
+                ["source"] = "supabase-dev"
+            }
+        };
+
+        _store.Users[account.Id] = account;
+        _store.UserRoles[account.Id] = new HashSet<string>(normalizedRoles, StringComparer.OrdinalIgnoreCase);
+
+        LogAudit(account.OrganizationId, account.Id, "user.create", new { account.Email, account.DisplayName });
+
+        return account;
+    }
+
+    public Task<UserAccount?> GetUserAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        if (_store.Users.TryGetValue(userId, out var account))
+        {
+            var roles = ResolveRoles(userId);
+            return Task.FromResult<UserAccount?>(account with { Roles = roles });
+        }
+
+        return Task.FromResult<UserAccount?>(null);
+    }
+
+    public Task<IReadOnlyList<UserAccount>> GetUsersAsync(
+        UserQueryOptions query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var users = _store.Users.Values.AsEnumerable();
+
+        if (query.OrganizationId.HasValue)
+        {
+            users = users.Where(u => u.OrganizationId == query.OrganizationId.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(query.SearchTerm))
+        {
+            var term = query.SearchTerm.Trim();
+            users = users.Where(u =>
+                u.Email.Contains(term, StringComparison.OrdinalIgnoreCase) ||
+                u.DisplayName.Contains(term, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!query.IncludeInactive)
+        {
+            users = users.Where(u => u.IsActive);
+        }
+
+        if (query.RoleFilter is { Count: > 0 })
+        {
+            var filter = query.RoleFilter.Select(r => r.Trim()).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            users = users.Where(u => ResolveRoles(u.Id).Any(filter.Contains));
+        }
+
+        var pageSize = Math.Clamp(query.PageSize, 1, 200);
+        var pageNumber = Math.Max(query.PageNumber, 1);
+        users = users
+            .OrderByDescending(u => u.CreatedAtUtc)
+            .Skip((pageNumber - 1) * pageSize)
+            .Take(pageSize)
+            .Select(u => u with { Roles = ResolveRoles(u.Id) });
+
+        IReadOnlyList<UserAccount> result = users.ToList();
+        return Task.FromResult(result);
+    }
+
+    public Task AssignRolesAsync(
+        Guid userId,
+        IEnumerable<string> roles,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(roles);
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        if (!_store.Users.TryGetValue(userId, out var account))
+        {
+            throw new InvalidOperationException($"User {userId} could not be found.");
+        }
+
+        var normalizedRoles = roles
+            .Where(r => !string.IsNullOrWhiteSpace(r))
+            .Select(r => r.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        _store.UserRoles[userId] = new HashSet<string>(normalizedRoles, StringComparer.OrdinalIgnoreCase);
+        _store.Users[userId] = account with { Roles = normalizedRoles };
+
+        LogAudit(account.OrganizationId, userId, "user.roles.update", new { Roles = normalizedRoles });
+
+        return Task.CompletedTask;
+    }
+
+    public Task<PasswordResetTicket> CreatePasswordResetTicketAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        if (!_store.Users.TryGetValue(userId, out var account))
+        {
+            throw new InvalidOperationException($"User {userId} could not be found.");
+        }
+
+        var ticket = new PasswordResetTicket
+        {
+            TicketId = Guid.NewGuid(),
+            UserId = userId,
+            ExpiresAtUtc = DateTime.UtcNow.AddHours(1),
+            ResetUrl = $"/accounts/reset/{Guid.NewGuid():N}"
+        };
+
+        _store.PasswordResetTickets[ticket.TicketId] = ticket;
+        LogAudit(account.OrganizationId, userId, "user.password.reset", new { ticket.TicketId });
+
+        return Task.FromResult(ticket);
+    }
+
+    public Task DisableUserAsync(
+        Guid userId,
+        string reason,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("User id cannot be empty.", nameof(userId));
+        }
+
+        if (!_store.Users.TryGetValue(userId, out var account))
+        {
+            throw new InvalidOperationException($"User {userId} could not be found.");
+        }
+
+        var metadata = account.Metadata
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.OrdinalIgnoreCase);
+        metadata["disabled_reason"] = reason;
+        metadata["disabled_at"] = DateTime.UtcNow.ToString("O");
+
+        var updated = account with
+        {
+            IsActive = false,
+            Metadata = metadata
+        };
+
+        _store.Users[userId] = updated;
+        LogAudit(account.OrganizationId, userId, "user.disable", new { reason });
+
+        return Task.CompletedTask;
+    }
+
+    public Task<SecurityPolicy> GetSecurityPolicyAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (organizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(organizationId));
+        }
+
+        if (_store.SecurityPolicies.TryGetValue(organizationId, out var policy))
+        {
+            return Task.FromResult(policy);
+        }
+
+        return Task.FromResult(new SecurityPolicy());
+    }
+
+    public Task SaveSecurityPolicyAsync(
+        Guid organizationId,
+        SecurityPolicy policy,
+        CancellationToken cancellationToken = default)
+    {
+        if (organizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(organizationId));
+        }
+
+        ArgumentNullException.ThrowIfNull(policy);
+
+        _store.SecurityPolicies[organizationId] = policy;
+        LogAudit(organizationId, null, "security.policy.update", policy);
+
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<SecurityAuditLogEntry>> GetAuditTrailAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (organizationId == Guid.Empty)
+        {
+            throw new ArgumentException("Organization id cannot be empty.", nameof(organizationId));
+        }
+
+        if (_store.AuditLogs.TryGetValue(organizationId, out var list))
+        {
+            return Task.FromResult<IReadOnlyList<SecurityAuditLogEntry>>(list
+                .OrderByDescending(x => x.OccurredAtUtc)
+                .ToList());
+        }
+
+        return Task.FromResult<IReadOnlyList<SecurityAuditLogEntry>>(Array.Empty<SecurityAuditLogEntry>());
+    }
+
+    private async Task EnsureClientAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _clientProvider.GetClientAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Supabase client unavailable; operating against in-memory store.");
+        }
+    }
+
+    private IReadOnlyCollection<string> ResolveRoles(Guid userId)
+    {
+        if (_store.UserRoles.TryGetValue(userId, out var roles))
+        {
+            return roles.ToArray();
+        }
+
+        return Array.Empty<string>();
+    }
+
+    private void LogAudit(Guid organizationId, Guid? entityId, string action, object payload)
+    {
+        var entry = new SecurityAuditLogEntry
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            ActorId = null,
+            Action = action,
+            EntityType = entityId.HasValue ? "user" : "system",
+            EntityId = entityId?.ToString(),
+            PayloadJson = JsonSerializer.Serialize(payload),
+            OccurredAtUtc = DateTime.UtcNow
+        };
+
+        lock (_auditLock)
+        {
+            var log = _store.AuditLogs.GetOrAdd(organizationId, _ => new List<SecurityAuditLogEntry>());
+            log.Add(entry);
+        }
+    }
+}

--- a/tests/NexaCRM.WebClient.UnitTests/SupabaseEnterpriseServicesTests.cs
+++ b/tests/NexaCRM.WebClient.UnitTests/SupabaseEnterpriseServicesTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using NexaCRM.WebClient.Models.Customization;
+using NexaCRM.WebClient.Models.FileHub;
+using NexaCRM.WebClient.Models.Governance;
+using NexaCRM.WebClient.Models.Sync;
+using NexaCRM.WebClient.Services;
+using NexaCRM.WebClient.Services.SupabaseEnterprise;
+using Xunit;
+
+namespace NexaCRM.WebClient.UnitTests;
+
+public sealed class SupabaseEnterpriseServicesTests
+{
+    [Fact]
+    public async Task UserGovernance_CreateUser_AssignsRolesAndLogs()
+    {
+        // Arrange
+        var store = new SupabaseEnterpriseDataStore();
+        var provider = CreateClientProvider();
+        var service = new SupabaseUserGovernanceService(provider, store, NullLogger<SupabaseUserGovernanceService>.Instance);
+        var organizationId = Guid.NewGuid();
+        var roles = new[] { "admin", "sales", "Admin" };
+
+        // Act
+        var account = await service.CreateUserAsync(organizationId, "user@example.com", "Demo User", roles);
+        var auditTrail = await service.GetAuditTrailAsync(organizationId);
+
+        // Assert
+        Assert.Equal("Demo User", account.DisplayName);
+        Assert.Contains(account.Roles, role => string.Equals(role, "admin", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(account.Roles, role => string.Equals(role, "sales", StringComparison.OrdinalIgnoreCase));
+        Assert.Single(auditTrail.Where(entry => entry.Action == "user.create"));
+    }
+
+    [Fact]
+    public async Task SettingsCustomization_SavesDashboardInOrder()
+    {
+        // Arrange
+        var store = new SupabaseEnterpriseDataStore();
+        var service = new SupabaseSettingsCustomizationService(
+            CreateClientProvider(),
+            store,
+            NullLogger<SupabaseSettingsCustomizationService>.Instance);
+        var userId = Guid.NewGuid();
+
+        var widgets = new List<DashboardWidget>
+        {
+            new() { WidgetId = Guid.NewGuid(), UserId = userId, WidgetType = "kpi" },
+            new() { WidgetId = Guid.NewGuid(), UserId = userId, WidgetType = "tasks" },
+            new() { WidgetId = Guid.NewGuid(), UserId = userId, WidgetType = "activity" }
+        };
+
+        // Act
+        await service.SaveDashboardLayoutAsync(userId, widgets);
+        var ordered = await service.GetDashboardLayoutAsync(userId);
+
+        // Assert
+        Assert.Equal(3, ordered.Count);
+        Assert.Equal(new[] { 0, 1, 2 }, ordered.Select(w => w.Order));
+    }
+
+    [Fact]
+    public async Task FileHub_CreatesDocumentAndThreads()
+    {
+        // Arrange
+        var store = new SupabaseEnterpriseDataStore();
+        var service = new SupabaseFileHubService(
+            CreateClientProvider(),
+            store,
+            NullLogger<SupabaseFileHubService>.Instance);
+        var organizationId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+
+        // Act
+        var document = await service.CreateDocumentAsync(
+            organizationId,
+            ownerId,
+            "Proposal.pdf",
+            "sales",
+            new Dictionary<string, string> { ["region"] = "APAC" });
+
+        await service.AddVersionAsync(document.DocumentId, ownerId, "/storage/proposal/v1", "hash", 2048);
+        var thread = await service.StartThreadAsync(document.DocumentId, "Feedback", new[] { ownerId });
+        await service.AppendMessageAsync(thread.ThreadId, ownerId, "internal", "Looks good!");
+
+        var threads = await service.GetThreadsForDocumentAsync(document.DocumentId);
+        var messages = await service.GetThreadMessagesAsync(thread.ThreadId);
+
+        // Assert
+        Assert.Single(threads);
+        Assert.Single(messages);
+        Assert.Equal("Looks good!", messages[0].Body);
+    }
+
+    [Fact]
+    public async Task SyncOrchestration_RegistersEnvelopeAndConflict()
+    {
+        // Arrange
+        var store = new SupabaseEnterpriseDataStore();
+        var service = new SupabaseSyncOrchestrationService(
+            CreateClientProvider(),
+            store,
+            NullLogger<SupabaseSyncOrchestrationService>.Instance);
+        var organizationId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var items = new[]
+        {
+            new SyncItem { EnvelopeId = Guid.Empty, EntityType = "contact", EntityId = "42", PayloadJson = "{}" }
+        };
+
+        // Act
+        var envelope = await service.RegisterEnvelopeAsync(Guid.Empty, organizationId, userId, items);
+        await service.RegisterConflictAsync(new SyncConflict
+        {
+            EnvelopeId = envelope.EnvelopeId,
+            EntityType = "contact",
+            EntityId = "42",
+            ResolutionState = "pending"
+        });
+
+        var pending = await service.GetPendingEnvelopesAsync(organizationId);
+        var conflicts = await service.GetConflictsAsync(organizationId);
+
+        // Assert
+        Assert.Single(pending);
+        Assert.Single(conflicts);
+        Assert.Equal(envelope.EnvelopeId, conflicts[0].EnvelopeId);
+    }
+
+    private static SupabaseClientProvider CreateClientProvider()
+    {
+        var options = new Supabase.SupabaseOptions
+        {
+            AutoConnectRealtime = false,
+            AutoRefreshToken = false
+        };
+
+        var client = new Supabase.Client("https://example.supabase.co", "supabase-test-key", options);
+        return new SupabaseClientProvider(client, NullLogger<SupabaseClientProvider>.Instance);
+    }
+}


### PR DESCRIPTION
## Summary
- add Supabase-backed governance, personalization, file hub, communication, and sync services with in-memory data store
- document the Supabase enterprise layer and extend the service interface reference with new contracts
- stabilize MobileDashboard BUnit tests and add unit coverage for the new Supabase enterprise services

## Testing
- `~/.dotnet/dotnet build NexaCrmSolution.sln --configuration Release`
- `~/.dotnet/dotnet test NexaCrmSolution.sln --configuration Release --no-build`


------
https://chatgpt.com/codex/tasks/task_b_68d46f382bf0832cb13f3bcb2f56fe48