### PR TITLE
fix: guard duplicate monitor startup

### DIFF
--- a/WEB_CLIENT_DOCUMENTATION.md
+++ b/WEB_CLIENT_DOCUMENTATION.md
@@ -159,6 +159,10 @@ All services currently use mock implementations to enable rapid development and 
 - **Performance**: Async/await patterns maintained for future API compatibility
 - **Error Simulation**: Capability to simulate various error conditions for testing
 
+## Runtime Reliability Enhancements
+
+- **Duplicate Monitor Startup Guard**: The `DuplicateMonitorService` now starts through a guarded helper inside `Program.cs`, ensuring that missing Supabase configuration or other initialization issues do not prevent the Blazor WebAssembly host from rendering. Failures are logged via `ILogger` without crashing the application startup.
+
 **Service Registration in Program.cs:**
 ```csharp
 builder.Services.AddScoped<IContactService, MockContactService>();

--- a/src/Web/NexaCRM.WebClient/Program.cs
+++ b/src/Web/NexaCRM.WebClient/Program.cs
@@ -7,6 +7,8 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using NexaCRM.WebClient;
 // using NexaCRM.WebClient.Pages; // App.razor은 프로젝트 루트에 있으므로 필요 없음
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NexaCRM.WebClient.Services;
 using NexaCRM.WebClient.Services.Interfaces;
@@ -100,7 +102,21 @@ CultureInfo.DefaultThreadCurrentCulture = culture;
 CultureInfo.DefaultThreadCurrentUICulture = culture;
 
 var host = builder.Build();
-// Kick off duplicate monitor
-var monitor = host.Services.GetRequiredService<IDuplicateMonitorService>();
-await monitor.StartAsync();
+
+await StartDuplicateMonitorAsync(host.Services);
 await host.RunAsync();
+
+static async Task StartDuplicateMonitorAsync(IServiceProvider services)
+{
+    try
+    {
+        var monitor = services.GetRequiredService<IDuplicateMonitorService>();
+        await monitor.StartAsync();
+    }
+    catch (Exception ex)
+    {
+        var loggerFactory = services.GetService<ILoggerFactory>();
+        var logger = loggerFactory?.CreateLogger("Startup");
+        logger?.LogError(ex, "Failed to start the duplicate monitor service.");
+    }
+}


### PR DESCRIPTION
## Summary
- guard the duplicate monitor startup in Program.cs so initialization issues do not break the app shell
- add logging for startup failures and describe the runtime reliability enhancement in the documentation

## Testing
- dotnet test ./tests/BlazorWebApp.Tests --configuration Release *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d4a2ae386c832cb9a1eeeba50877d4