### PR TITLE
fix: ensure wasm debug configuration

### DIFF
--- a/WEB_CLIENT_DOCUMENTATION.md
+++ b/WEB_CLIENT_DOCUMENTATION.md
@@ -45,6 +45,17 @@ src/Web/NexaCRM.WebClient/
 | **Build Tool** | MSBuild | .NET 8 SDK |
 | **IDE Support** | Visual Studio 2022, VS Code | Latest |
 
+### Debugging Configuration
+
+To ensure that breakpoints are respected when running the Web Client in Debug mode, the project is configured with the following settings:
+
+- **Portable Debug Symbols**: Generates portable PDB files so that Visual Studio and modern editors can map breakpoints correctly during WebAssembly debugging.
+- **Disabled Linker in Debug**: Disables the Blazor WebAssembly linker for Debug builds to prevent method trimming that would otherwise interfere with debugging.
+- **Debugger Support Enabled**: Explicitly enables the WebAssembly debugger pipeline so that the runtime loads the metadata required for managed debugging sessions.
+- **No Compiler Optimizations**: Keeps optimizations disabled in Debug builds to preserve the original control flow and variable lifetimes for accurate breakpoint evaluation.
+
+These settings are defined in the `NexaCRM.WebClient.csproj` file and apply automatically when the project is built with the `Debug` configuration.
+
 ### Key Features and Capabilities
 
 **Current Implemented Features:**

--- a/src/Web/NexaCRM.WebClient/NexaCRM.WebClient.csproj
+++ b/src/Web/NexaCRM.WebClient/NexaCRM.WebClient.csproj
@@ -12,6 +12,9 @@
     <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
         <DebugSymbols>true</DebugSymbols>
         <DebugType>portable</DebugType>
+        <Optimize>false</Optimize>
+        <BlazorWebAssemblyEnableLinking>false</BlazorWebAssemblyEnableLinking>
+        <DebuggerSupport>true</DebuggerSupport>
     </PropertyGroup>
 
     <!-- net8.0 타겟에만 Blazor WebAssembly 8.0 패키지 참조 -->


### PR DESCRIPTION
## Summary
- ensure the Web Client Debug configuration explicitly disables optimization, linker trimming, and keeps debugger metadata to allow breakpoints to be hit
- document the debugging-related build settings inside the Web Client documentation for easier maintenance

## Testing
- dotnet build src/Web/NexaCRM.WebClient/NexaCRM.WebClient.csproj --configuration Debug *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d5c1000140832cadf698afcc59589f