### PR TITLE
fix: block login for unapproved supabase accounts

### DIFF
--- a/src/Web/NexaCRM.WebClient/Pages/LoginPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/LoginPage.razor
@@ -214,6 +214,10 @@
                 NavigationManager.NavigateTo("/main-dashboard");
             }
         }
+        catch (UnauthorizedAccessException)
+        {
+            errorMessage = "관리자 승인 대기 중인 계정입니다. 승인이 완료된 후 다시 시도해주세요.";
+        }
         catch (Exception ex)
         {
             await JSRuntime.InvokeVoidAsync("console.error", $"Error during login: {ex.Message}");


### PR DESCRIPTION
## Summary
- prevent Supabase sign-in sessions from being kept when the organization user has not been approved
- log helpful messages for failed approval checks and surface a user-friendly message on the login screen

## Testing
- `dotnet build --configuration Release` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d64fb121fc832c86586dac73fedd4f