### PR TITLE
fix: guard Supabase login error parsing

### DIFF
--- a/docs/auth/login-error-handling.md
+++ b/docs/auth/login-error-handling.md
@@ -1,0 +1,17 @@
+# Login Error Handling
+
+The NexaCRM Web client categorises Supabase sign-in failures so that users receive clear guidance during authentication.
+
+## Failure Categories
+
+- **Missing credentials**: Client-side validation returns immediately with guidance to enter the missing username or password.
+- **User not found**: Supabase responses that indicate an unknown account return "입력하신 아이디를 찾을 수 없습니다." and log a warning for administrators.
+- **Invalid password**: Known credential errors surface "비밀번호가 일치하지 않습니다" along with a console warning so support teams can trace repeated failures.
+- **Pending approval**: Accounts without an approved `organization_users` row are signed out and informed that administrator approval is required.
+- **Unknown errors**: Any unexpected Supabase or network issue records a structured log entry and shows the generic retry message.
+
+## Implementation Notes
+
+- `CustomAuthStateProvider.SignInAsync` now returns a `LoginResult` that includes a failure reason enum and localised message.
+- When Supabase returns ambiguous credential errors, the provider performs a lightweight profile lookup to determine whether the username exists before classifying the failure.
+- All failure paths ensure the Supabase session is cleared and log context-rich warnings for operational visibility.

--- a/src/Web/NexaCRM.WebClient/Models/Supabase/ProfileLookupRecord.cs
+++ b/src/Web/NexaCRM.WebClient/Models/Supabase/ProfileLookupRecord.cs
@@ -1,0 +1,15 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.WebClient.Models.Supabase;
+
+[Table("profiles")]
+public sealed class ProfileLookupRecord : BaseModel
+{
+    [PrimaryKey("id")]
+    public Guid Id { get; set; }
+
+    [Column("username")]
+    public string? Username { get; set; }
+}

--- a/src/Web/NexaCRM.WebClient/Pages/LoginPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/LoginPage.razor
@@ -191,10 +191,11 @@
         {
             await JSRuntime.InvokeVoidAsync("console.log", "Attempting Supabase login");
 
-            var signedIn = await AuthProvider.SignInAsync(username, password);
-            if (!signedIn)
+            var result = await AuthProvider.SignInAsync(username, password);
+            if (!result.Succeeded)
             {
-                errorMessage = "사용자 이름 또는 비밀번호가 잘못되었습니다.";
+                errorMessage = result.ErrorMessage ?? "로그인 중 오류가 발생했습니다. 다시 시도해주세요.";
+                await JSRuntime.InvokeVoidAsync("console.warn", $"Login failed for {username} with reason {result.FailureReason}.");
                 return;
             }
 

--- a/src/Web/NexaCRM.WebClient/Services/CustomAuthStateProvider.cs
+++ b/src/Web/NexaCRM.WebClient/Services/CustomAuthStateProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,7 +8,9 @@ using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.Logging;
 using NexaCRM.WebClient.Models.Supabase;
 using Supabase.Gotrue;
+using Supabase.Gotrue.Exceptions;
 using Supabase.Gotrue.Interfaces;
+using Supabase.Postgrest.Exceptions;
 using PostgrestOperator = Supabase.Postgrest.Constants.Operator;
 using SupabaseAuthState = Supabase.Gotrue.Constants.AuthState;
 
@@ -39,28 +42,50 @@ public sealed class CustomAuthStateProvider : AuthenticationStateProvider, IAsyn
         return _currentState;
     }
 
-    public async Task<bool> SignInAsync(string email, string password)
+    public async Task<LoginResult> SignInAsync(string email, string password)
     {
         if (string.IsNullOrWhiteSpace(email))
         {
-            throw new ArgumentException("Email is required.", nameof(email));
+            return LoginResult.Failed(LoginFailureReason.MissingUsername, GetFailureMessage(LoginFailureReason.MissingUsername));
         }
 
         if (string.IsNullOrWhiteSpace(password))
         {
-            throw new ArgumentException("Password is required.", nameof(password));
+            return LoginResult.Failed(LoginFailureReason.MissingPassword, GetFailureMessage(LoginFailureReason.MissingPassword));
         }
 
         var client = await _clientProvider.GetClientAsync();
 
-        var session = await client.Auth.SignInWithPassword(email, password);
-        if (session is null)
+        try
         {
-            return false;
-        }
+            var session = await client.Auth.SignInWithPassword(email, password);
+            if (session is null)
+            {
+                var fallbackReason = await DetermineCredentialFailureAsync(client, email);
+                return LoginResult.Failed(fallbackReason, GetFailureMessage(fallbackReason));
+            }
 
-        await UpdateAuthenticationStateAsync(session);
-        return true;
+            var isApproved = await IsUserApprovedAsync(client, session);
+            if (!isApproved)
+            {
+                await client.Auth.SignOut();
+                return LoginResult.Failed(LoginFailureReason.RequiresApproval, GetFailureMessage(LoginFailureReason.RequiresApproval));
+            }
+
+            await UpdateAuthenticationStateAsync(session);
+            return LoginResult.Success();
+        }
+        catch (GotrueException ex)
+        {
+            _logger.LogWarning(ex, "Supabase rejected login for {Email}.", email);
+            var reason = await MapGotrueExceptionAsync(client, ex, email);
+            return LoginResult.Failed(reason, GetFailureMessage(reason));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected Supabase login failure for {Email}.", email);
+            return LoginResult.Failed(LoginFailureReason.Unknown, GetFailureMessage(LoginFailureReason.Unknown));
+        }
     }
 
     public async Task LogoutAsync()
@@ -181,6 +206,155 @@ public sealed class CustomAuthStateProvider : AuthenticationStateProvider, IAsyn
         }
 
         return roles;
+    }
+
+    private static string GetFailureMessage(LoginFailureReason reason)
+    {
+        return reason switch
+        {
+            LoginFailureReason.MissingUsername => "아이디를 입력해주세요.",
+            LoginFailureReason.MissingPassword => "비밀번호를 입력해주세요.",
+            LoginFailureReason.UserNotFound => "입력하신 아이디를 찾을 수 없습니다.",
+            LoginFailureReason.InvalidPassword => "비밀번호가 일치하지 않습니다. 다시 확인해주세요.",
+            LoginFailureReason.RequiresApproval => "관리자 승인 대기 중인 계정입니다. 승인이 완료된 후 다시 시도해주세요.",
+            _ => "로그인 중 오류가 발생했습니다. 다시 시도해주세요."
+        };
+    }
+
+    private async Task<LoginFailureReason> MapGotrueExceptionAsync(Supabase.Client client, GotrueException exception, string email)
+    {
+        if (IsUserNotFoundError(exception))
+        {
+            return LoginFailureReason.UserNotFound;
+        }
+
+        if (IsInvalidPasswordError(exception))
+        {
+            return LoginFailureReason.InvalidPassword;
+        }
+
+        var fallback = await DetermineCredentialFailureAsync(client, email);
+        return fallback == LoginFailureReason.Unknown
+            ? LoginFailureReason.Unknown
+            : fallback;
+    }
+
+    private static bool IsUserNotFoundError(GotrueException exception)
+    {
+        if (exception is null)
+        {
+            return false;
+        }
+
+        var errorText = ExtractErrorText(exception);
+        return ContainsAny(errorText, "user_not_found", "user not found", "email not found");
+    }
+
+    private static bool IsInvalidPasswordError(GotrueException exception)
+    {
+        if (exception is null)
+        {
+            return false;
+        }
+
+        var errorText = ExtractErrorText(exception);
+        return ContainsAny(errorText, "invalid_grant", "invalid login credentials", "invalid password");
+    }
+
+    private static string? ExtractErrorText(GotrueException exception)
+    {
+        if (!string.IsNullOrWhiteSpace(exception.Message))
+        {
+            return exception.Message;
+        }
+
+        if (!string.IsNullOrWhiteSpace(exception.InnerException?.Message))
+        {
+            return exception.InnerException.Message;
+        }
+
+        return null;
+    }
+
+    private static bool ContainsAny(string? value, params string[] candidates)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        foreach (var candidate in candidates)
+        {
+            if (value.IndexOf(candidate, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private async Task<LoginFailureReason> DetermineCredentialFailureAsync(Supabase.Client client, string email)
+    {
+        try
+        {
+            var response = await client.From<ProfileLookupRecord>()
+                .Select("id, username")
+                .Filter(x => x.Username, PostgrestOperator.Equals, email)
+                .Limit(1)
+                .Get();
+
+            if (response.Models?.Any() == true)
+            {
+                return LoginFailureReason.InvalidPassword;
+            }
+
+            return LoginFailureReason.UserNotFound;
+        }
+        catch (PostgrestException ex)
+        {
+            _logger.LogWarning(ex, "Failed to determine credential failure reason for {Email} due to Postgrest exception.", email);
+            return LoginFailureReason.Unknown;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to determine credential failure reason for {Email}.", email);
+            return LoginFailureReason.Unknown;
+        }
+    }
+
+    private async Task<bool> IsUserApprovedAsync(Supabase.Client client, Session session)
+    {
+        if (session.User?.Id is null)
+        {
+            return false;
+        }
+
+        if (!Guid.TryParse(session.User.Id, out var userId))
+        {
+            _logger.LogWarning("Supabase session user id was not a valid GUID: {UserId}.", session.User.Id);
+            return false;
+        }
+
+        var response = await client.From<OrganizationUserRecord>()
+            .Filter(x => x.UserId, PostgrestOperator.Equals, userId)
+            .Limit(1)
+            .Get();
+
+        var membership = response.Models?.FirstOrDefault();
+        if (membership is null)
+        {
+            _logger.LogInformation("User {UserId} attempted login without organization membership record.", userId);
+            return false;
+        }
+
+        var isApproved = string.Equals(membership.Status, "approved", StringComparison.OrdinalIgnoreCase);
+        if (!isApproved)
+        {
+            _logger.LogInformation("User {UserId} attempted login with status {Status}.", userId, membership.Status);
+        }
+
+        return isApproved;
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Web/NexaCRM.WebClient/Services/LoginResult.cs
+++ b/src/Web/NexaCRM.WebClient/Services/LoginResult.cs
@@ -1,0 +1,19 @@
+namespace NexaCRM.WebClient.Services;
+
+public enum LoginFailureReason
+{
+    None = 0,
+    MissingUsername,
+    MissingPassword,
+    UserNotFound,
+    InvalidPassword,
+    RequiresApproval,
+    Unknown
+}
+
+public readonly record struct LoginResult(bool Succeeded, LoginFailureReason FailureReason, string? ErrorMessage)
+{
+    public static LoginResult Success() => new(true, LoginFailureReason.None, null);
+
+    public static LoginResult Failed(LoginFailureReason reason, string? message) => new(false, reason, message);
+}


### PR DESCRIPTION
## Summary
- remove references to deprecated GotrueException properties in the custom auth provider
- centralize Supabase error text parsing to keep login error classification working across SDK updates

## Testing
- `dotnet build --configuration Release` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d64fb121fc832c86586dac73fedd4f