### PR TITLE
feat: add organization directory support tables

### DIFF
--- a/supabase/DB_ARCHITECTURE.md
+++ b/supabase/DB_ARCHITECTURE.md
@@ -14,7 +14,10 @@ graph TD
         PF[profiles]
         OU[organization_units]
         ORG_USERS[organization_users]
+        ORGCOMP[org_companies]
+        ORGBR[org_branches]
         TEAMS[teams]
+        USERDIR[user_directory_entries]
     end
     subgraph CRM Core
         CO[companies]
@@ -51,7 +54,10 @@ graph TD
 
     AU --> PF
     PF --> ORG_USERS
-    ORG_USERS --> TEAMS
+    ORG_USERS --> ORGCOMP
+    ORGCOMP --> ORGBR
+    ORGBR --> TEAMS
+    TEAMS --> USERDIR
     CO --> CT
     CT --> AC
     CT --> DB_CUS
@@ -73,8 +79,11 @@ graph TD
 | `organization_units` | 조직 트리 관리 | id, tenant_id, parent_id, name | `OrganizationUnit` 모델 반영.【F:src/Services/Admin.Abstractions/Models/Organization/OrganizationModels.cs†L6-L28】 |
 | `organization_users` | 조직 사용자 승인 흐름 | id, user_id, unit_id, role, status, approved_at, approval_memo | 사용자 승인·거절 로직 지원.【F:src/Services/Admin.Abstractions/Interfaces/IOrganizationService.cs†L9-L24】 |
 | `user_roles` | 역할 매핑 | user_id, role_code, assigned_by | 역할 기반 권한 확인에 사용.【F:src/Services/Admin.Abstractions/Interfaces/IRolePermissionService.cs†L5-L30】 |
-| `teams` | 영업/지원 팀 정의 | code, name, manager_id, is_active, registered_at | `TeamInfo` 구조 반영.【F:src/Web/NexaCRM.WebClient/Models/TeamModels.cs†L5-L27】 |
-| `team_members` | 팀 구성원 | team_id, user_id, role, allow_excel_upload, is_active | `TeamMemberInfo` 속성 대응.【F:src/Web/NexaCRM.WebClient/Models/TeamModels.cs†L16-L27】【F:src/Web/NexaCRM.WebClient/Services/Interfaces/ITeamService.cs†L7-L15】 |
+| `org_companies` | 테넌트별 내부 회사 마스터 | tenant_unit_id, code, name, contact, is_active | 관리자용 회사 기본 정보 저장.【F:supabase/migrations/schema.sql†L154-L171】 |
+| `org_branches` | 회사 지점 관리 | company_id, tenant_unit_id, code, name, manager_id, is_active | 회사-지점 계층 구조 구성.【F:supabase/migrations/schema.sql†L173-L190】 |
+| `teams` | 영업/지원 팀 정의 | tenant_unit_id, company_id, branch_id, code, name, manager_id, is_active | 팀이 소속된 회사/지점까지 추적.【F:supabase/migrations/schema.sql†L240-L253】 |
+| `team_members` | 팀 구성원 | team_id, user_id, company_id, branch_id, role, allow_excel_upload, is_active | 사용자-팀-지점 관계 저장.【F:supabase/migrations/schema.sql†L255-L271】 |
+| `user_directory_entries` | 사용자 조직 정보 | user_id, company_id, branch_id, team_id, tenant_unit_id, job_title, status | 관리자 입력 사용자 소속 데이터.【F:supabase/migrations/schema.sql†L273-L291】 |
 | `agents` | 영업·지원 에이전트 프로필 | user_id, display_name, email, role | `Agent` 모델 연계, 자동 배정 기준.【F:src/Services/Admin.Abstractions/Models/Agent.cs†L3-L9】【F:src/Web/NexaCRM.WebClient/Services/Interfaces/IAgentService.cs†L7-L10】 |
 
 Row Level Security(RLS)은 `tenant_id`(조직 ID)와 역할 정보를 조합해 조직 단위 격리를 보장합니다. 조직 관리자는 동일 테넌트 하위의 사용자·팀을 열람/수정하고, 전사 관리자는 모든 테넌트 접근 권한을 갖도록 정책을 작성합니다.

--- a/supabase/migrations/rls.sql
+++ b/supabase/migrations/rls.sql
@@ -174,6 +174,94 @@ CREATE POLICY "Users can delete tasks they created"
   USING (public.user_has_role('admin') OR auth.uid() = created_by);
 
 
+-- 8.a ORGANIZATION DIRECTORY RLS
+ALTER TABLE org_companies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE org_branches ENABLE ROW LEVEL SECURITY;
+ALTER TABLE teams ENABLE ROW LEVEL SECURITY;
+ALTER TABLE team_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_directory_entries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Approved users can view org companies"
+  ON org_companies FOR SELECT
+  USING (
+    public.user_has_role('admin')
+    OR EXISTS (
+      SELECT 1 FROM organization_users
+      WHERE organization_users.user_id = auth.uid()
+        AND organization_users.unit_id = org_companies.tenant_unit_id
+        AND organization_users.status = 'approved'
+    )
+  );
+
+CREATE POLICY "Admins manage org companies"
+  ON org_companies FOR ALL
+  USING (public.user_has_role('admin'))
+  WITH CHECK (public.user_has_role('admin'));
+
+CREATE POLICY "Approved users can view org branches"
+  ON org_branches FOR SELECT
+  USING (
+    public.user_has_role('admin')
+    OR EXISTS (
+      SELECT 1 FROM organization_users
+      WHERE organization_users.user_id = auth.uid()
+        AND organization_users.unit_id = org_branches.tenant_unit_id
+        AND organization_users.status = 'approved'
+    )
+  );
+
+CREATE POLICY "Admins manage org branches"
+  ON org_branches FOR ALL
+  USING (public.user_has_role('admin'))
+  WITH CHECK (public.user_has_role('admin'));
+
+CREATE POLICY "Approved users can view teams"
+  ON teams FOR SELECT
+  USING (
+    public.user_has_role('admin')
+    OR EXISTS (
+      SELECT 1 FROM organization_users
+      WHERE organization_users.user_id = auth.uid()
+        AND organization_users.unit_id = teams.tenant_unit_id
+        AND organization_users.status = 'approved'
+    )
+  );
+
+CREATE POLICY "Admins manage teams"
+  ON teams FOR ALL
+  USING (public.user_has_role('admin'))
+  WITH CHECK (public.user_has_role('admin'));
+
+CREATE POLICY "Users can view their team membership"
+  ON team_members FOR SELECT
+  USING (
+    public.user_has_role('admin')
+    OR (user_id IS NOT NULL AND user_id = auth.uid())
+    OR EXISTS (
+      SELECT 1
+      FROM teams
+      JOIN organization_users ON organization_users.unit_id = teams.tenant_unit_id
+      WHERE teams.id = team_members.team_id
+        AND organization_users.user_id = auth.uid()
+        AND organization_users.status = 'approved'
+    )
+  );
+
+CREATE POLICY "Admins manage team members"
+  ON team_members FOR ALL
+  USING (public.user_has_role('admin'))
+  WITH CHECK (public.user_has_role('admin'));
+
+CREATE POLICY "Users can view their directory entry"
+  ON user_directory_entries FOR SELECT
+  USING (auth.uid() = user_id OR public.user_has_role('admin'));
+
+CREATE POLICY "Admins manage user directory"
+  ON user_directory_entries FOR ALL
+  USING (public.user_has_role('admin'))
+  WITH CHECK (public.user_has_role('admin'));
+
+
 -- SUPPORT & SERVICE RLS
 ALTER TABLE support_tickets ENABLE ROW LEVEL SECURITY;
 

--- a/supabase/migrations/schema.sql
+++ b/supabase/migrations/schema.sql
@@ -151,6 +151,59 @@ CREATE TABLE user_roles (
 );
 
 
+-- 8.a ORGANIZATION DIRECTORY TABLES
+CREATE TABLE org_companies (
+  id BIGSERIAL PRIMARY KEY,
+  tenant_unit_id BIGINT NOT NULL REFERENCES organization_units(id) ON DELETE CASCADE,
+  code TEXT NOT NULL,
+  name TEXT NOT NULL,
+  registration_number TEXT,
+  phone TEXT,
+  email TEXT,
+  address TEXT,
+  memo TEXT,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (tenant_unit_id, code),
+  UNIQUE (tenant_unit_id, name)
+);
+
+CREATE TABLE org_branches (
+  id BIGSERIAL PRIMARY KEY,
+  company_id BIGINT NOT NULL REFERENCES org_companies(id) ON DELETE CASCADE,
+  tenant_unit_id BIGINT NOT NULL REFERENCES organization_units(id) ON DELETE CASCADE,
+  code TEXT NOT NULL,
+  name TEXT NOT NULL,
+  phone TEXT,
+  email TEXT,
+  address TEXT,
+  manager_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  memo TEXT,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (company_id, code),
+  UNIQUE (company_id, name)
+);
+
+CREATE TRIGGER set_timestamp_org_companies
+  BEFORE UPDATE ON org_companies
+  FOR EACH ROW
+  EXECUTE FUNCTION handle_updated_at();
+
+CREATE TRIGGER set_timestamp_org_branches
+  BEFORE UPDATE ON org_branches
+  FOR EACH ROW
+  EXECUTE FUNCTION handle_updated_at();
+
+CREATE INDEX idx_org_companies_tenant_unit ON org_companies(tenant_unit_id);
+CREATE INDEX idx_org_branches_company ON org_branches(company_id);
+CREATE INDEX idx_org_branches_tenant_unit ON org_branches(tenant_unit_id);
+
+
 -- 9. TASKS TABLE
 CREATE TABLE tasks (
   id BIGSERIAL PRIMARY KEY,
@@ -186,8 +239,12 @@ CREATE TABLE agents (
 
 CREATE TABLE teams (
   id BIGSERIAL PRIMARY KEY,
+  tenant_unit_id BIGINT NOT NULL REFERENCES organization_units(id) ON DELETE CASCADE,
+  company_id BIGINT REFERENCES org_companies(id) ON DELETE SET NULL,
+  branch_id BIGINT REFERENCES org_branches(id) ON DELETE SET NULL,
   code TEXT NOT NULL UNIQUE,
   name TEXT NOT NULL,
+  manager_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
   manager_name TEXT,
   member_count INT NOT NULL DEFAULT 0,
   is_active BOOLEAN NOT NULL DEFAULT TRUE,
@@ -198,6 +255,9 @@ CREATE TABLE teams (
 CREATE TABLE team_members (
   id BIGSERIAL PRIMARY KEY,
   team_id BIGINT REFERENCES teams(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  company_id BIGINT REFERENCES org_companies(id) ON DELETE SET NULL,
+  branch_id BIGINT REFERENCES org_branches(id) ON DELETE SET NULL,
   team_name TEXT,
   role TEXT NOT NULL,
   employee_code TEXT,
@@ -206,8 +266,51 @@ CREATE TABLE team_members (
   allow_excel_upload BOOLEAN NOT NULL DEFAULT FALSE,
   is_active BOOLEAN NOT NULL DEFAULT TRUE,
   registered_at TIMESTAMPTZ DEFAULT NOW(),
-  updated_at TIMESTAMPTZ DEFAULT NOW()
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (team_id, user_id)
 );
+
+CREATE TABLE user_directory_entries (
+  id BIGSERIAL PRIMARY KEY,
+  user_id UUID NOT NULL UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
+  company_id BIGINT REFERENCES org_companies(id) ON DELETE SET NULL,
+  branch_id BIGINT REFERENCES org_branches(id) ON DELETE SET NULL,
+  team_id BIGINT REFERENCES teams(id) ON DELETE SET NULL,
+  tenant_unit_id BIGINT REFERENCES organization_units(id) ON DELETE SET NULL,
+  job_title TEXT,
+  employee_number TEXT,
+  employment_type TEXT,
+  status TEXT NOT NULL DEFAULT 'active',
+  hired_on DATE,
+  ended_on DATE,
+  notes TEXT,
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  CHECK (status IN ('active', 'inactive', 'on_leave', 'terminated'))
+);
+
+CREATE TRIGGER set_timestamp_teams
+  BEFORE UPDATE ON teams
+  FOR EACH ROW
+  EXECUTE FUNCTION handle_updated_at();
+
+CREATE TRIGGER set_timestamp_team_members
+  BEFORE UPDATE ON team_members
+  FOR EACH ROW
+  EXECUTE FUNCTION handle_updated_at();
+
+CREATE TRIGGER set_timestamp_user_directory_entries
+  BEFORE UPDATE ON user_directory_entries
+  FOR EACH ROW
+  EXECUTE FUNCTION handle_updated_at();
+
+CREATE INDEX idx_teams_tenant_unit ON teams(tenant_unit_id);
+CREATE INDEX idx_teams_company ON teams(company_id);
+CREATE INDEX idx_team_members_user ON team_members(user_id);
+CREATE INDEX idx_team_members_company ON team_members(company_id);
+CREATE INDEX idx_user_directory_company ON user_directory_entries(company_id);
+CREATE INDEX idx_user_directory_tenant_unit ON user_directory_entries(tenant_unit_id);
 
 CREATE INDEX idx_teams_active ON teams(is_active);
 CREATE INDEX idx_team_members_team_id ON team_members(team_id);


### PR DESCRIPTION
## Summary
- add org_companies, org_branches, and user_directory_entries tables so administrators can manage company, branch, and team metadata for users
- extend teams and team_members with tenant, company, and branch relationships and automatic timestamp maintenance
- add RLS coverage and documentation updates for the new organization directory schema

## Testing
- not run (SQL/schema only)


------
https://chatgpt.com/codex/tasks/task_b_68d65bbc2bac832ca8b45135ebca03a0