### PR TITLE
feat: enforce secure user registration credentials

### DIFF
--- a/src/Services/Admin.Abstractions/Models/NewUser.cs
+++ b/src/Services/Admin.Abstractions/Models/NewUser.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using NexaCRM.Services.Admin.Validation;
 
 namespace NexaCRM.Services.Admin.Models;
 
@@ -12,11 +13,25 @@ public class NewUser
     public string FullName { get; set; } = string.Empty;
 
     [Required]
+    [Display(Name = "User ID")]
+    [StringLength(20, MinimumLength = 6, ErrorMessage = "User ID must be between 6 and 20 characters.")]
+    [RegularExpression(
+        "^(?=.*[A-Za-z])(?=.*[@._-])[A-Za-z0-9@._-]+$",
+        ErrorMessage = "User ID must contain letters and at least one of the following special characters: . _ @ -.")]
+    [DisallowSequentialCharacters(3, ErrorMessage = "User ID cannot contain repeated or sequential character runs of length 3 or more.")]
+    public string UserId { get; set; } = string.Empty;
+
+    [Required]
     [EmailAddress]
     public string Email { get; set; } = string.Empty;
 
     [Required]
     [DataType(DataType.Password)]
+    [StringLength(64, MinimumLength = 10, ErrorMessage = "Password must be between 10 and 64 characters.")]
+    [RegularExpression(
+        "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{10,64}$",
+        ErrorMessage = "Password must contain uppercase, lowercase, number, and special characters.")]
+    [DisallowSequentialCharacters(3, ErrorMessage = "Password cannot contain repeated or sequential character runs of length 3 or more.")]
     public string Password { get; set; } = string.Empty;
 
     [Required]

--- a/src/Services/Admin.Abstractions/Models/Organization/OrganizationModels.cs
+++ b/src/Services/Admin.Abstractions/Models/Organization/OrganizationModels.cs
@@ -17,6 +17,7 @@ public class OrganizationNode
 public class OrganizationUser
 {
     public int Id { get; set; }
+    public string? UserId { get; set; }
     public string? Name { get; set; }
     public string? Email { get; set; }
     public string? Role { get; set; }

--- a/src/Services/Admin.Abstractions/Validation/DisallowSequentialCharactersAttribute.cs
+++ b/src/Services/Admin.Abstractions/Validation/DisallowSequentialCharactersAttribute.cs
@@ -1,0 +1,105 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace NexaCRM.Services.Admin.Validation;
+
+/// <summary>
+/// Validation attribute that rejects repeated or sequential character runs beyond a configured length.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+public sealed class DisallowSequentialCharactersAttribute : ValidationAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DisallowSequentialCharactersAttribute"/> class.
+    /// </summary>
+    /// <param name="sequenceLength">Minimum length of a repeated or sequential run that should be rejected.</param>
+    public DisallowSequentialCharactersAttribute(int sequenceLength = 3)
+    {
+        if (sequenceLength < 2)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sequenceLength), sequenceLength, "Sequence length must be at least 2.");
+        }
+
+        SequenceLength = sequenceLength;
+    }
+
+    /// <summary>
+    /// Gets the minimum length of a repeated or sequential character run that triggers validation failure.
+    /// </summary>
+    public int SequenceLength { get; }
+
+    /// <inheritdoc />
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    {
+        if (value is not string text)
+        {
+            return ValidationResult.Success;
+        }
+
+        var candidate = text.Trim();
+        if (candidate.Length < SequenceLength)
+        {
+            return ValidationResult.Success;
+        }
+
+        for (var index = 0; index <= candidate.Length - SequenceLength; index++)
+        {
+            var segment = candidate.AsSpan(index, SequenceLength);
+            if (ContainsRepeatedCharacters(segment) || ContainsSequentialCharacters(segment))
+            {
+                var errorMessage = FormatErrorMessage(validationContext.DisplayName);
+                return new ValidationResult(errorMessage);
+            }
+        }
+
+        return ValidationResult.Success;
+    }
+
+    private static bool ContainsRepeatedCharacters(ReadOnlySpan<char> segment)
+    {
+        for (var index = 1; index < segment.Length; index++)
+        {
+            if (segment[index] != segment[0])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool ContainsSequentialCharacters(ReadOnlySpan<char> segment)
+    {
+        var ascending = true;
+        var descending = true;
+
+        for (var index = 1; index < segment.Length; index++)
+        {
+            var previous = segment[index - 1];
+            var current = segment[index];
+
+            if (!char.IsLetterOrDigit(previous) || !char.IsLetterOrDigit(current))
+            {
+                ascending = false;
+                descending = false;
+                continue;
+            }
+
+            var normalizedPrevious = char.ToLowerInvariant(previous);
+            var normalizedCurrent = char.ToLowerInvariant(current);
+            var difference = normalizedCurrent - normalizedPrevious;
+
+            if (difference != 1)
+            {
+                ascending = false;
+            }
+
+            if (difference != -1)
+            {
+                descending = false;
+            }
+        }
+
+        return ascending || descending;
+    }
+}

--- a/src/Services/Admin.Core/Services/OrganizationService.cs
+++ b/src/Services/Admin.Core/Services/OrganizationService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 using NexaCRM.Services.Admin.Models.Organization;
@@ -32,6 +33,7 @@ public class OrganizationService : IOrganizationService
         new()
         {
             Id = 1,
+            UserId = "alice.kim-1",
             Name = "Alice Kim",
             Email = "alice.kim@example.com",
             Role = "Admin",
@@ -45,6 +47,7 @@ public class OrganizationService : IOrganizationService
         new()
         {
             Id = 2,
+            UserId = "brian.lee-2",
             Name = "Brian Lee",
             Email = "brian.lee@example.com",
             Role = "Manager",
@@ -58,6 +61,7 @@ public class OrganizationService : IOrganizationService
         new()
         {
             Id = 3,
+            UserId = "chloe.park-3",
             Name = "Chloe Park",
             Email = "chloe.park@example.com",
             Role = "Analyst",
@@ -204,11 +208,29 @@ public class OrganizationService : IOrganizationService
     {
         ArgumentNullException.ThrowIfNull(user);
 
+        var results = new List<ValidationResult>();
+        var context = new ValidationContext(user);
+
+        if (!Validator.TryValidateObject(user, context, results, validateAllProperties: true))
+        {
+            var message = string.Join(" ", results
+                .Select(result => result.ErrorMessage)
+                .Where(error => !string.IsNullOrWhiteSpace(error)));
+
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                message = "Validation failed for user registration.";
+            }
+
+            throw new ValidationException(message);
+        }
+
         _users.Add(new OrganizationUser
         {
             Id = GenerateUserId(),
-            Name = user.FullName,
-            Email = user.Email,
+            UserId = user.UserId.Trim(),
+            Name = user.FullName.Trim(),
+            Email = user.Email.Trim(),
             Role = "Member",
             Status = "Pending",
             Department = "미지정",
@@ -240,6 +262,7 @@ public class OrganizationService : IOrganizationService
     private static OrganizationUser CloneUser(OrganizationUser source) => new()
     {
         Id = source.Id,
+        UserId = source.UserId,
         Name = source.Name,
         Email = source.Email,
         Role = source.Role,

--- a/src/Web/NexaCRM.WebClient/Pages/UserRegistrationPage.razor
+++ b/src/Web/NexaCRM.WebClient/Pages/UserRegistrationPage.razor
@@ -47,6 +47,16 @@
                   </div>
                   <div class="mb-4">
                     <label class="flex flex-col">
+                      <p class="register-form-label text-base font-medium leading-normal pb-2">@Localizer["UserId"]</p>
+                      <input @bind="newUser.UserId"
+                        placeholder="@Localizer["EnterUserId"]"
+                        class="register-form-input flex w-full resize-none overflow-hidden rounded-lg focus:outline-0 focus:ring-0 border h-12 px-4 text-base font-normal leading-normal" />
+                      <p class="text-sm text-slate-500 mt-1">@Localizer["UserIdRequirements"]</p>
+                      <ValidationMessage For="@(() => newUser.UserId)" />
+                    </label>
+                  </div>
+                  <div class="mb-4">
+                    <label class="flex flex-col">
                       <p class="register-form-label text-base font-medium leading-normal pb-2">@Localizer["Email"]</p>
                       <input @bind="newUser.Email"
                         placeholder="@Localizer["EnterEmail"]"
@@ -60,6 +70,7 @@
                       <input @bind="newUser.Password" type="password"
                         placeholder="@Localizer["EnterPassword"]"
                         class="register-form-input flex w-full resize-none overflow-hidden rounded-lg focus:outline-0 focus:ring-0 border h-12 px-4 text-base font-normal leading-normal" />
+                      <p class="text-sm text-slate-500 mt-1">@Localizer["PasswordRequirements"]</p>
                       <ValidationMessage For="@(() => newUser.Password)" />
                     </label>
                   </div>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/UserRegistrationPage.en-US.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/UserRegistrationPage.en-US.resx
@@ -66,6 +66,15 @@
   <data name="EnterFullName" xml:space="preserve">
     <value>Enter your full name</value>
   </data>
+  <data name="UserId" xml:space="preserve">
+    <value>User ID</value>
+  </data>
+  <data name="EnterUserId" xml:space="preserve">
+    <value>Create a secure user ID</value>
+  </data>
+  <data name="UserIdRequirements" xml:space="preserve">
+    <value>Use 6-20 characters with at least one of . _ @ - and avoid repeated or sequential characters.</value>
+  </data>
   <data name="Email" xml:space="preserve">
     <value>Email</value>
   </data>
@@ -77,6 +86,9 @@
   </data>
   <data name="EnterPassword" xml:space="preserve">
     <value>Enter your password</value>
+  </data>
+  <data name="PasswordRequirements" xml:space="preserve">
+    <value>Use 10-64 characters including uppercase, lowercase, numbers, special symbols, and avoid sequences.</value>
   </data>
   <data name="ConfirmPassword" xml:space="preserve">
     <value>Confirm Password</value>

--- a/src/Web/NexaCRM.WebClient/Resources/Pages/UserRegistrationPage.ko-KR.resx
+++ b/src/Web/NexaCRM.WebClient/Resources/Pages/UserRegistrationPage.ko-KR.resx
@@ -66,6 +66,15 @@
   <data name="EnterFullName" xml:space="preserve">
     <value>전체 이름을 입력하세요</value>
   </data>
+  <data name="UserId" xml:space="preserve">
+    <value>사용자 ID</value>
+  </data>
+  <data name="EnterUserId" xml:space="preserve">
+    <value>보안성 높은 사용자 ID를 입력하세요</value>
+  </data>
+  <data name="UserIdRequirements" xml:space="preserve">
+    <value>6~20자의 영문과 . _ @ - 중 하나 이상의 특수문자를 포함하고 반복 또는 연속 문자를 피하세요.</value>
+  </data>
   <data name="Email" xml:space="preserve">
     <value>이메일</value>
   </data>
@@ -77,6 +86,9 @@
   </data>
   <data name="EnterPassword" xml:space="preserve">
     <value>비밀번호를 입력하세요</value>
+  </data>
+  <data name="PasswordRequirements" xml:space="preserve">
+    <value>10~64자의 대문자, 소문자, 숫자, 특수문자를 모두 포함하고 연속 문자를 피하세요.</value>
   </data>
   <data name="ConfirmPassword" xml:space="preserve">
     <value>비밀번호 확인</value>


### PR DESCRIPTION
## Summary
- add reusable sequential character validator and apply stricter rules to user IDs and passwords
- persist the chosen user ID on registered members and validate submissions server-side
- update the registration page UI and localization strings to capture the secure ID and explain the new requirements

## Testing
- `dotnet build --configuration Release` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d65c0f90a0832c8e869ba7bd4bd581