### PR TITLE
feat: add startup configuration for web server

### DIFF
--- a/src/NexaCRM.WebServer/Pages/_Host.cshtml
+++ b/src/NexaCRM.WebServer/Pages/_Host.cshtml
@@ -1,0 +1,18 @@
+@page "/"
+@namespace NexaCRM.WebServer.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@using Microsoft.AspNetCore.Components.Web
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NexaCRM</title>
+    <base href="~/" />
+    <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
+</head>
+<body>
+    <component type="typeof(App)" render-mode="ServerPrerendered" />
+    <script src="_framework/blazor.server.js"></script>
+</body>
+</html>

--- a/src/NexaCRM.WebServer/Program.cs
+++ b/src/NexaCRM.WebServer/Program.cs
@@ -1,77 +1,19 @@
-using Microsoft.AspNetCore.Components.Authorization;
-using NexaCRM.Service.DependencyInjection;
-using NexaCRM.Services.Admin.Interfaces;
-using NexaCRM.UI.Services;
-using NexaCRM.UI.Services.Interfaces;
-using NexaCRM.UI.Services.Mock;
-using NexaCRM.WebServer.Services;
-using NexaCRM.WebServer;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
-var builder = WebApplication.CreateBuilder(args);
+namespace NexaCRM.WebServer;
 
-builder.WebHost.UseStaticWebAssets();
-
-builder.Services.AddRazorComponents()
-    .AddInteractiveServerComponents()
-    .AddInteractiveWebAssemblyComponents();
-
-builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
-builder.Services.AddAuthorizationCore();
-
-builder.Services.AddNexaCrmAdminServices();
-
-builder.Services.AddScoped<ActionInterop>();
-builder.Services.AddScoped<IMobileInteractionService, MobileInteractionService>();
-builder.Services.AddScoped<IGlobalActionService, GlobalActionService>();
-builder.Services.AddScoped<INavigationStateService, NavigationStateService>();
-builder.Services.AddScoped<IDeviceService, DeviceService>();
-builder.Services.AddScoped<IUserFavoritesService, UserFavoritesService>();
-builder.Services.AddSingleton<ISyncOrchestrationService, MockSyncOrchestrationService>();
-builder.Services.AddSingleton<ICommunicationHubService, MockCommunicationHubService>();
-builder.Services.AddSingleton<IFileHubService, MockFileHubService>();
-builder.Services.AddSingleton<ISettingsCustomizationService, MockSettingsCustomizationService>();
-builder.Services.AddSingleton<IUserGovernanceService, MockUserGovernanceService>();
-
-builder.Services.AddScoped<IContactService, MockContactService>();
-builder.Services.AddScoped<IDealService, MockDealService>();
-builder.Services.AddScoped<ITaskService, MockTaskService>();
-builder.Services.AddScoped<ISupportTicketService, MockSupportTicketService>();
-builder.Services.AddScoped<IAgentService, MockAgentService>();
-builder.Services.AddScoped<IMarketingCampaignService, MockMarketingCampaignService>();
-builder.Services.AddScoped<IReportService, MockReportService>();
-builder.Services.AddScoped<IActivityService, MockActivityService>();
-builder.Services.AddScoped<ISalesManagementService, MockSalesManagementService>();
-builder.Services.AddScoped<IEmailTemplateService, MockEmailTemplateService>();
-builder.Services.AddScoped<ITeamService, MockTeamService>();
-
-builder.Services.AddScoped<ServerAuthenticationStateProvider>();
-builder.Services.AddScoped<AuthenticationStateProvider>(sp => sp.GetRequiredService<ServerAuthenticationStateProvider>());
-builder.Services.AddScoped<IAuthenticationService>(sp => sp.GetRequiredService<ServerAuthenticationStateProvider>());
-
-var app = builder.Build();
-
-if (!app.Environment.IsDevelopment())
+public static class Program
 {
-    app.UseExceptionHandler("/Error");
-    app.UseHsts();
-}
+    public static void Main(string[] args)
+    {
+        CreateHostBuilder(args).Build().Run();
+    }
 
-app.UseHttpsRedirection();
-app.UseStaticFiles();
-app.UseAntiforgery();
-
-app.MapRazorComponents<App>()
-    .AddInteractiveServerRenderMode()
-    .AddInteractiveWebAssemblyRenderMode()
-    .AddAdditionalAssemblies(typeof(NexaCRM.UI.Shared.MainLayout).Assembly);
-
-await StartDuplicateMonitorAsync(app.Services);
-
-app.Run();
-
-static async Task StartDuplicateMonitorAsync(IServiceProvider services)
-{
-    await using var scope = services.CreateAsyncScope();
-    var monitor = scope.ServiceProvider.GetRequiredService<IDuplicateMonitorService>();
-    await monitor.StartAsync();
+    public static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseStartup<Startup>();
+            });
 }

--- a/src/NexaCRM.WebServer/Startup.cs
+++ b/src/NexaCRM.WebServer/Startup.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NexaCRM.Service.DependencyInjection;
+using NexaCRM.Services.Admin.Interfaces;
+using NexaCRM.UI.Services;
+using NexaCRM.UI.Services.Interfaces;
+using NexaCRM.UI.Services.Mock;
+using NexaCRM.WebServer.Services;
+
+namespace NexaCRM.WebServer;
+
+public sealed class Startup
+{
+    public Startup(IConfiguration configuration)
+    {
+        Configuration = configuration;
+    }
+
+    private IConfiguration Configuration { get; }
+
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddLocalization(options => options.ResourcesPath = "Resources");
+        services.AddAuthorizationCore();
+
+        services.AddRazorPages();
+        services.AddServerSideBlazor();
+
+        services.AddNexaCrmAdminServices();
+
+        services.AddScoped<ActionInterop>();
+        services.AddScoped<IMobileInteractionService, MobileInteractionService>();
+        services.AddScoped<IGlobalActionService, GlobalActionService>();
+        services.AddScoped<INavigationStateService, NavigationStateService>();
+        services.AddScoped<IDeviceService, DeviceService>();
+        services.AddScoped<IUserFavoritesService, UserFavoritesService>();
+        services.AddSingleton<ISyncOrchestrationService, MockSyncOrchestrationService>();
+        services.AddSingleton<ICommunicationHubService, MockCommunicationHubService>();
+        services.AddSingleton<IFileHubService, MockFileHubService>();
+        services.AddSingleton<ISettingsCustomizationService, MockSettingsCustomizationService>();
+        services.AddSingleton<IUserGovernanceService, MockUserGovernanceService>();
+
+        services.AddScoped<IContactService, MockContactService>();
+        services.AddScoped<IDealService, MockDealService>();
+        services.AddScoped<ITaskService, MockTaskService>();
+        services.AddScoped<ISupportTicketService, MockSupportTicketService>();
+        services.AddScoped<IAgentService, MockAgentService>();
+        services.AddScoped<IMarketingCampaignService, MockMarketingCampaignService>();
+        services.AddScoped<IReportService, MockReportService>();
+        services.AddScoped<IActivityService, MockActivityService>();
+        services.AddScoped<ISalesManagementService, MockSalesManagementService>();
+        services.AddScoped<IEmailTemplateService, MockEmailTemplateService>();
+        services.AddScoped<ITeamService, MockTeamService>();
+
+        services.AddScoped<ServerAuthenticationStateProvider>();
+        services.AddScoped<AuthenticationStateProvider>(sp => sp.GetRequiredService<ServerAuthenticationStateProvider>());
+        services.AddScoped<IAuthenticationService>(sp => sp.GetRequiredService<ServerAuthenticationStateProvider>());
+    }
+
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IServiceProvider services, IHostApplicationLifetime lifetime)
+    {
+        if (!env.IsDevelopment())
+        {
+            app.UseExceptionHandler("/Error");
+            app.UseHsts();
+        }
+        else
+        {
+            app.UseDeveloperExceptionPage();
+        }
+
+        app.UseHttpsRedirection();
+        app.UseStaticFiles();
+
+        app.UseRouting();
+
+        app.UseAntiforgery();
+
+        app.UseAuthentication();
+        app.UseAuthorization();
+
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapBlazorHub();
+            endpoints.MapFallbackToPage("/_Host");
+        });
+
+        lifetime.ApplicationStarted.Register(() =>
+        {
+            _ = StartDuplicateMonitorAsync(services);
+        });
+    }
+
+    private static async Task StartDuplicateMonitorAsync(IServiceProvider services)
+    {
+        await using var scope = services.CreateAsyncScope();
+        var monitor = scope.ServiceProvider.GetRequiredService<IDuplicateMonitorService>();
+        await monitor.StartAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- restore a traditional Program entry point for the web server that bootstraps Startup
- introduce Startup with the service registrations and middleware pipeline previously handled in Program
- add the legacy Blazor Server _Host page required by the Startup-based layout

## Testing
- dotnet build NexaCrmSolution.sln --configuration Release *(fails: `dotnet` CLI unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d7691d9590832c86285c9800630391