### PR TITLE
Harden NexaCRM.WebServer startup resilience

### DIFF
--- a/docs/operations/webserver-hosting-notes.md
+++ b/docs/operations/webserver-hosting-notes.md
@@ -1,0 +1,22 @@
+# NexaCRM.WebServer Hosting Notes
+
+## Purpose
+- Capture operational considerations for running the NexaCRM server-side Blazor host.
+- Document guard rails that keep the host online even when external dependencies (such as Supabase) are unavailable.
+
+## Supabase configuration fallback
+- `Startup.ConfigureServices` now calls `AddSupabaseClientOptions` with `validateOnStart: false`, allowing the site to boot even when Supabase secrets are absent in the configuration source.
+- The scoped `Supabase.Client` factory checks whether both the Supabase URL and anon key are present. When either is missing, the factory logs a warning and swaps in a loopback endpoint (`https://localhost`) with a deterministic key so the DI graph is satisfied.
+- Blazor UI services that rely on Supabase continue to receive a client instance. Runtime operations that require the real backend will fail gracefully while the application shell keeps rendering.
+
+## Duplicate monitor resilience
+- `Startup.Configure` registers the duplicate monitor inside an asynchronous scope. Any exception thrown during startup is now caught and logged instead of crashing the host.
+- Logging uses the shared ASP.NET Core logging infrastructure so the failure reason surfaces in console output and any centralized log sinks.
+
+## Authentication middleware guard
+- The request pipeline now inspects `IAuthenticationSchemeProvider` before invoking `UseAuthentication`/`UseAuthorization`.
+- When no authentication schemes are registered (the current default for the server host), the middleware is skipped and an informational log entry is emitted. This prevents runtime crashes caused by an empty authentication configuration.
+
+## Operational checklist
+- Confirm Supabase secrets are supplied through `appsettings.json`, environment variables, or user secrets before enabling real sign-in flows.
+- Monitor logs on startup to verify whether the duplicate monitor and authentication middleware were activated.

--- a/src/NexaCRM.UI/Options/SupabaseClientServiceCollectionExtensions.cs
+++ b/src/NexaCRM.UI/Options/SupabaseClientServiceCollectionExtensions.cs
@@ -8,16 +8,21 @@ public static class SupabaseClientServiceCollectionExtensions
 {
     public static IServiceCollection AddSupabaseClientOptions(
         this IServiceCollection services,
-        IConfiguration configuration)
+        IConfiguration configuration,
+        bool validateOnStart = true)
     {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
-        services
+        var builder = services
             .AddOptions<SupabaseClientOptions>()
             .Bind(configuration.GetSection(SupabaseClientOptions.SectionName))
-            .ValidateDataAnnotations()
-            .ValidateOnStart();
+            .ValidateDataAnnotations();
+
+        if (validateOnStart)
+        {
+            builder.ValidateOnStart();
+        }
 
         return services;
     }


### PR DESCRIPTION
## Summary
- allow Supabase client options to skip startup validation so the server host can boot without secrets
- add Supabase client fallback, authentication middleware guard, and duplicate monitor error handling in the WebServer startup
- document the WebServer hosting safeguards for future operators

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_b_68d7fc7aa7e8832cbb42436e4b065b1c