### PR TITLE
feat: add startup loader to NexaCRM WebServer

### DIFF
--- a/docs/login-hosting-notes.md
+++ b/docs/login-hosting-notes.md
@@ -9,6 +9,7 @@
 - `App.razor` now inspects the route metadata: pages marked with `[AllowAnonymous]` render directly through `RouteView`, while all other routes continue through the `AuthorizeRouteView` pipeline with the localized `LoadingScreen` and `RedirectToLogin` components. This ensures the login layout appears immediately on first load without waiting for the authentication state provider to resolve.
 - `RedirectToLogin.razor` renders the full `LoginPage` component while it normalizes navigation to `/login`, so users immediately see the dedicated login layout even before the router finishes redirecting protected deep links.
 - `Pages/_Imports.razor` continues to apply `[Authorize]` to every page by default while the authentication flows (`LoginPage`, `FindIdPage`, `PasswordResetPage`, and `UserRegistrationPage`) opt-in to `[AllowAnonymous]`, preventing unauthenticated users from landing on internal dashboards when the app first renders.
+- `Pages/_Host.cshtml` now serves a lightweight HTML/CSS loader that listens for the `blazor:connected` lifecycle event. This guarantees the NexaCRM workspace shows a branded loading state while the SignalR circuit starts without introducing dependencies into other hosted applications.
 
 ## Testing Guidance
 - Build the solution with `dotnet build --configuration Release`.

--- a/src/NexaCRM.WebServer/Pages/_Host.cshtml
+++ b/src/NexaCRM.WebServer/Pages/_Host.cshtml
@@ -11,10 +11,15 @@
     <base href="~/" />
     <link href="_content/NexaCRM.UI/css/app.css" rel="stylesheet" />
     <link href="_content/NexaCRM.UI/css/mobile.css" rel="stylesheet" />
+    <link href="css/loading.css" rel="stylesheet" />
     <link href="NexaCRM.WebServer.styles.css" rel="stylesheet" />
     <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
 </head>
 <body>
+    <div id="nexacrm-initial-loader" role="status" aria-live="polite">
+        <div class="loader-ring" aria-hidden="true"></div>
+        <p class="loader-message">Preparing your NexaCRM workspace...</p>
+    </div>
     <component type="typeof(App)" render-mode="ServerPrerendered" />
     <div id="blazor-error-ui">
         An unhandled error has occurred.
@@ -38,6 +43,7 @@
             return false;
         };
     </script>
+    <script src="js/loader.js"></script>
     <script src="_framework/blazor.server.js"></script>
     <script src="_content/NexaCRM.UI/js/auth-manager.js"></script>
     <script src="_content/NexaCRM.UI/js/navigation.js"></script>

--- a/src/NexaCRM.WebServer/wwwroot/css/loading.css
+++ b/src/NexaCRM.WebServer/wwwroot/css/loading.css
@@ -1,0 +1,67 @@
+#nexacrm-initial-loader {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    background-color: rgba(255, 255, 255, 0.96);
+    color: #1f2937;
+    z-index: 2147483000;
+    transition: opacity 200ms ease-out, visibility 200ms ease-out;
+    opacity: 1;
+    visibility: visible;
+}
+
+html[data-theme='dark'] #nexacrm-initial-loader {
+    background-color: rgba(17, 24, 39, 0.96);
+    color: #f9fafb;
+}
+
+#nexacrm-initial-loader.is-hidden {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+}
+
+#nexacrm-initial-loader .loader-ring {
+    width: 3.5rem;
+    height: 3.5rem;
+    border-radius: 50%;
+    border: 0.35rem solid rgba(59, 130, 246, 0.35);
+    border-top-color: #3b82f6;
+    animation: nexacrm-loader-spin 0.85s linear infinite;
+    margin-bottom: 1.25rem;
+}
+
+html[data-theme='dark'] #nexacrm-initial-loader .loader-ring {
+    border: 0.35rem solid rgba(96, 165, 250, 0.35);
+    border-top-color: #60a5fa;
+}
+
+#nexacrm-initial-loader .loader-message {
+    font-size: 1rem;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+}
+
+@media (max-width: 576px) {
+    #nexacrm-initial-loader {
+        padding: 1.5rem;
+    }
+
+    #nexacrm-initial-loader .loader-message {
+        font-size: 0.95rem;
+        text-align: center;
+    }
+}
+
+@keyframes nexacrm-loader-spin {
+    from {
+        transform: rotate(0deg);
+    }
+
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/src/NexaCRM.WebServer/wwwroot/js/loader.js
+++ b/src/NexaCRM.WebServer/wwwroot/js/loader.js
@@ -1,0 +1,43 @@
+(function () {
+    'use strict';
+
+    const loaderId = 'nexacrm-initial-loader';
+    let isVisible = true;
+
+    function getLoader() {
+        return document.getElementById(loaderId);
+    }
+
+    function hideLoader() {
+        if (!isVisible) {
+            return;
+        }
+
+        const loader = getLoader();
+        if (!loader) {
+            isVisible = false;
+            return;
+        }
+
+        isVisible = false;
+        loader.setAttribute('aria-hidden', 'true');
+        loader.classList.add('is-hidden');
+    }
+
+    function showLoader() {
+        const loader = getLoader();
+        if (!loader) {
+            isVisible = true;
+            return;
+        }
+
+        isVisible = true;
+        loader.classList.remove('is-hidden');
+        loader.removeAttribute('aria-hidden');
+    }
+
+    window.addEventListener('blazor:connected', hideLoader);
+    window.addEventListener('blazor:disconnected', showLoader);
+
+    showLoader();
+})();


### PR DESCRIPTION
## Summary
- add a branded startup loader to the NexaCRM WebServer host page so users see progress while the SignalR circuit initializes
- include scoped CSS/JS assets that react to `blazor:connected`/`blazor:disconnected` events without impacting other projects
- document the new host-level loader in the login hosting notes for future maintenance

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68d83bd44a40832c9d1ece5e80bc4df4