### PR TITLE
Fix WebServer hosting pipeline for Blazor shell

### DIFF
--- a/docs/operations/webserver-hosting-notes.md
+++ b/docs/operations/webserver-hosting-notes.md
@@ -21,3 +21,4 @@
 ## Operational checklist
 - Confirm Supabase secrets are supplied through `appsettings.json`, environment variables, or user secrets before enabling real sign-in flows.
 - Monitor logs on startup to verify whether the duplicate monitor and authentication middleware were activated.
+- Ensure the host calls `UseStaticWebAssets()` and maps Razor Pages before the Blazor hub so the `_content/NexaCRM.UI` assets and the `_Host` page are served correctly during deployment.

--- a/src/NexaCRM.WebServer/Program.cs
+++ b/src/NexaCRM.WebServer/Program.cs
@@ -14,6 +14,7 @@ public static class Program
         Host.CreateDefaultBuilder(args)
             .ConfigureWebHostDefaults(webBuilder =>
             {
+                webBuilder.UseStaticWebAssets();
                 webBuilder.UseStartup<Startup>();
             });
 }

--- a/src/NexaCRM.WebServer/Startup.cs
+++ b/src/NexaCRM.WebServer/Startup.cs
@@ -168,6 +168,7 @@ public sealed class Startup
 
         app.UseEndpoints(endpoints =>
         {
+            endpoints.MapRazorPages();
             endpoints.MapBlazorHub();
             endpoints.MapFallbackToPage("/_Host");
         });


### PR DESCRIPTION
## Summary
- ensure the WebServer host advertises static web assets so shared UI resources are available when deployed
- map Razor Pages alongside the Blazor hub to guarantee the _Host page responds to initial requests
- document the hosting requirement for static web assets and Razor Page routing

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68d83d97e6c4832cab4cbd6e259abb9e