### PR TITLE
feat: align supabase auth provider with canonical users

### DIFF
--- a/src/NexaCRM.Service/Abstractions/Models/Supabase/UserAccountOverviewRecord.cs
+++ b/src/NexaCRM.Service/Abstractions/Models/Supabase/UserAccountOverviewRecord.cs
@@ -4,7 +4,7 @@ using Supabase.Postgrest.Models;
 
 namespace NexaCRM.UI.Models.Supabase;
 
-[Table("user_account_overview", ignoreOnInsert: true, ignoreOnUpdate: true)]
+[Table("user_account_overview")]
 public sealed class UserAccountOverviewRecord : BaseModel
 {
     [PrimaryKey("cuid", false)]

--- a/src/NexaCRM.Service/Abstractions/Models/Supabase/UserAccountOverviewRecord.cs
+++ b/src/NexaCRM.Service/Abstractions/Models/Supabase/UserAccountOverviewRecord.cs
@@ -1,0 +1,36 @@
+using System;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace NexaCRM.UI.Models.Supabase;
+
+[Table("user_account_overview", ignoreOnInsert: true, ignoreOnUpdate: true)]
+public sealed class UserAccountOverviewRecord : BaseModel
+{
+    [PrimaryKey("cuid", false)]
+    public string Cuid { get; set; } = string.Empty;
+
+    [Column("auth_user_id")]
+    public Guid AuthUserId { get; set; }
+
+    [Column("email")]
+    public string? Email { get; set; }
+
+    [Column("status")]
+    public string Status { get; set; } = "active";
+
+    [Column("username")]
+    public string? Username { get; set; }
+
+    [Column("full_name")]
+    public string? FullName { get; set; }
+
+    [Column("department")]
+    public string? Department { get; set; }
+
+    [Column("job_title")]
+    public string? JobTitle { get; set; }
+
+    [Column("role_codes")]
+    public string[] RoleCodes { get; set; } = Array.Empty<string>();
+}

--- a/src/NexaCRM.Service/Core/Supabase/Auth/ClientSupabaseAuthenticationStateProvider.cs
+++ b/src/NexaCRM.Service/Core/Supabase/Auth/ClientSupabaseAuthenticationStateProvider.cs
@@ -4,9 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NexaCRM.Service.Supabase.Configuration;
 using LoginResult = NexaCRM.UI.Models.LoginResult;
-using LoginFailureReason = NexaCRM.UI.Models.LoginFailureReason;
 using Supabase.Gotrue;
-using Supabase.Gotrue.Exceptions;
 using Supabase.Gotrue.Interfaces;
 using SupabaseAuthState = Supabase.Gotrue.Constants.AuthState;
 
@@ -28,43 +26,14 @@ public sealed class ClientSupabaseAuthenticationStateProvider : SupabaseAuthenti
 
     public override async Task<LoginResult> SignInAsync(string username, string password)
     {
-        if (string.IsNullOrWhiteSpace(username))
+        var result = await base.SignInAsync(username, password).ConfigureAwait(false);
+
+        if (result.Succeeded)
         {
-            return LoginResult.Failed(LoginFailureReason.MissingUsername, "Username is required.");
+            _logger.LogInformation("User {Username} successfully signed in via shared auth pipeline.", username);
         }
 
-        if (string.IsNullOrWhiteSpace(password))
-        {
-            return LoginResult.Failed(LoginFailureReason.MissingPassword, "Password is required.");
-        }
-
-        await EnsureInitializedAsync().ConfigureAwait(false);
-
-        var client = await ClientProvider.GetClientAsync().ConfigureAwait(false);
-
-        try
-        {
-            var session = await client.Auth.SignIn(username, password).ConfigureAwait(false);
-
-            if (session?.User is null)
-            {
-                return LoginResult.Failed(LoginFailureReason.InvalidPassword, "Invalid login credentials.");
-            }
-
-            _logger.LogInformation("User {UserId} successfully signed in via client auth.", session.User.Id);
-            await UpdateAuthenticationStateAsync(session).ConfigureAwait(false);
-            return LoginResult.Success();
-        }
-        catch (GotrueException ex)
-        {
-            _logger.LogError(ex, "Login failed for user {Username}.", username);
-            return LoginResult.Failed(LoginFailureReason.Unknown, ex.Message);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Unexpected error during sign-in for {Username}.", username);
-            return LoginResult.Failed(LoginFailureReason.Unknown, "An unexpected error occurred.");
-        }
+        return result;
     }
 
     protected override async Task HandleAuthStateChangedAsync(IGotrueClient<User, Session> sender, SupabaseAuthState state)


### PR DESCRIPTION
## Summary
- update the Supabase authentication provider to resolve logins through the user_account_overview view, refresh claims from canonical role data, and react to Supabase auth events
- add the user_account_overview record model and let the client-specific provider reuse the shared login pipeline
- seed the demo manager, sales, and develop accounts with matching username/password pairs and document the updated defaults

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68d8741f52d4832c86f81c99fdcd1f89