### PR TITLE
chore(ui): centralize font configuration

### DIFF
--- a/docs/frontend-style-sharing.md
+++ b/docs/frontend-style-sharing.md
@@ -9,6 +9,12 @@
 - `wwwroot/css/mobile.css`: 모바일 네비게이션, 반응형 브레이크포인트, 터치 상호작용에 특화된 보조 규칙 제공.
 - `wwwroot/js/*.js`: 인증, 내비게이션, 테마, 디바이스 감지 등 공통 상호작용 로직 모음.
 
+## Typography Tokens
+- `app.css` 상단에서 `Pretendard Variable` 가변 글꼴을 `@font-face`로 선언하고, `--font-family-sans`, `--font-family-heading`, `--font-family-mono` 등
+  전역 타이포그래피 토큰을 제공합니다.
+- `--font-size-xs`부터 `--font-size-3xl`까지의 폰트 크기 토큰과 `--body-line-height`, `--heading-line-height-tight` 변수를 통해 페이지마다 일관된 타이포그래피 스케일을 적용할 수 있습니다.
+- 새로운 컴포넌트를 추가할 때는 `var(--font-family-sans)` 또는 `var(--font-family-heading)`을 사용하고, 필요 시 `--font-weight-*` 토큰으로 굵기를 설정하세요.
+
 ## Usage Guidance
 1. Razor 컴포넌트 또는 레이아웃에서 다음과 같이 정적 자산을 참조합니다.
    ```html

--- a/src/NexaCRM.UI/Pages/CustomerFeedbackAndSurveyManagementTool.razor
+++ b/src/NexaCRM.UI/Pages/CustomerFeedbackAndSurveyManagementTool.razor
@@ -2,7 +2,7 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<CustomerFeedbackAndSurveyManagementTool> Localizer
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
       <div class="layout-container flex h-full grow flex-col">
         <div class="gap-1 px-4 sm:px-6 flex flex-1 justify-center py-5 dashboard-container">
           <div class="layout-content-container flex flex-col w-full sm:w-80 dashboard-sidebar hidden lg:flex">

--- a/src/NexaCRM.UI/Pages/CustomerManagementPage.razor
+++ b/src/NexaCRM.UI/Pages/CustomerManagementPage.razor
@@ -3,7 +3,7 @@
 @attribute [Authorize(Roles = "Manager, Sales")]
 @inject IStringLocalizer<CustomerManagementPage> Localizer
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
     <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-10 py-3">
             <div class="flex items-center gap-4 text-[#0e131b]">

--- a/src/NexaCRM.UI/Pages/CustomerSegmentationTool.razor
+++ b/src/NexaCRM.UI/Pages/CustomerSegmentationTool.razor
@@ -6,7 +6,7 @@
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IRolePermissionService RolePermissionService
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
       <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-4 sm:px-6 md:px-10 py-3">
           <div class="flex items-center gap-4 sm:gap-8">

--- a/src/NexaCRM.UI/Pages/CustomerSupportDashboard.razor
+++ b/src/NexaCRM.UI/Pages/CustomerSupportDashboard.razor
@@ -2,7 +2,7 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<CustomerSupportDashboard> Localizer
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
       <div class="layout-container flex h-full grow flex-col">
         <div class="gap-1 px-4 sm:px-6 flex flex-1 justify-center py-5 dashboard-container">
           <div class="layout-content-container flex flex-col w-full sm:w-80 dashboard-sidebar hidden lg:flex">

--- a/src/NexaCRM.UI/Pages/CustomerSupportKnowledgeBase.razor
+++ b/src/NexaCRM.UI/Pages/CustomerSupportKnowledgeBase.razor
@@ -2,7 +2,7 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<CustomerSupportKnowledgeBase> Localizer
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
       <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-10 py-3">
           <div class="flex items-center gap-8">

--- a/src/NexaCRM.UI/Pages/CustomerSupportTicketManagementInterface.razor
+++ b/src/NexaCRM.UI/Pages/CustomerSupportTicketManagementInterface.razor
@@ -4,7 +4,7 @@
 
 <div
       class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden"
-      style="--select-button-svg: url('data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724px%27 height=%2724px%27 fill=%27rgb(77,106,153)%27 viewBox=%270 0 256 256%27%3e%3cpath d=%27M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48A8,8,0,0,0,85.66,85.66Z%27%3e%3c/path%3e%3c/svg%3e'); font-family: Inter, &quot;Noto Sans&quot;, sans-serif;"
+      style="--select-button-svg: url('data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724px%27 height=%2724px%27 fill=%27rgb(77,106,153)%27 viewBox=%270 0 256 256%27%3e%3cpath d=%27M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48A8,8,0,0,0,85.66,85.66Z%27%3e%3c/path%3e%3c/svg%3e')"
     >
       <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-10 py-3">

--- a/src/NexaCRM.UI/Pages/DemoContactsPage.razor
+++ b/src/NexaCRM.UI/Pages/DemoContactsPage.razor
@@ -5,7 +5,7 @@
 @inject NavigationManager NavigationManager
 @inject IGlobalActionService GlobalActionService
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
     <div class="layout-container flex h-full grow flex-col">
         <header class="contacts-header flex flex-wrap items-center justify-between gap-3 border-b border-solid border-b-[#e7ecf3] px-4 sm:px-6 md:px-10 py-3 md:flex-nowrap md:gap-0 md:whitespace-nowrap">
             <div class="flex items-center gap-4 sm:gap-8">

--- a/src/NexaCRM.UI/Pages/EmailTemplateBuilder.razor
+++ b/src/NexaCRM.UI/Pages/EmailTemplateBuilder.razor
@@ -5,7 +5,7 @@
 @inject IStringLocalizer<EmailTemplateBuilder> Localizer
 @inject IEmailTemplateService TemplateService
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
       <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-4 md:px-10 py-3">
           <div class="flex items-center gap-4 md:gap-8">

--- a/src/NexaCRM.UI/Pages/FindIdPage.razor
+++ b/src/NexaCRM.UI/Pages/FindIdPage.razor
@@ -3,7 +3,7 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<FindIdPage> Localizer
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
   <div class="layout-container flex h-full grow flex-col">
     <div class="px-4 flex flex-1 justify-center py-5">
       <div class="flex flex-col w-full max-w-md py-5">

--- a/src/NexaCRM.UI/Pages/LoginPage.razor.css
+++ b/src/NexaCRM.UI/Pages/LoginPage.razor.css
@@ -8,7 +8,7 @@
     --input-border: rgba(148, 163, 184, 0.4);
     --input-bg: rgba(248, 250, 255, 0.85);
     --divider-color: rgba(148, 163, 184, 0.45);
-    font-family: 'Pretendard Variable', 'Pretendard', 'Inter', 'Noto Sans KR', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
+    font-family: var(--font-family-sans);
     background: linear-gradient(180deg, #ffffff 0%, #f1efff 100%);
     color: var(--text-color);
     min-height: 100vh;

--- a/src/NexaCRM.UI/Pages/MainDashboard.razor
+++ b/src/NexaCRM.UI/Pages/MainDashboard.razor
@@ -17,7 +17,7 @@
 
 <a href="#mainDashboardContent" class="dashboard-skip-link">@Localizer["SkipToMainContent"]</a>
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;' data-page="main-dashboard">
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" data-page="main-dashboard">
     <!-- Mobile Header Bar -->
     <div class="mobile-header mobile-header--active">
         <div class="mobile-header-content">

--- a/src/NexaCRM.UI/Pages/MarketingCampaignManagementInterface.razor
+++ b/src/NexaCRM.UI/Pages/MarketingCampaignManagementInterface.razor
@@ -2,7 +2,7 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<MarketingCampaignManagementInterface> Localizer
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
       <div class="layout-container flex h-full grow flex-col">
         <div class="gap-1 px-6 flex flex-1 justify-center py-5">
           <div class="layout-content-container flex flex-col w-80">

--- a/src/NexaCRM.UI/Pages/MarketingInsightsReportDashboard.razor
+++ b/src/NexaCRM.UI/Pages/MarketingInsightsReportDashboard.razor
@@ -2,7 +2,7 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<MarketingInsightsReportDashboard> Localizer
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
       <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-10 py-3">
           <div class="flex items-center gap-8">

--- a/src/NexaCRM.UI/Pages/NotificationSettingsPage.razor
+++ b/src/NexaCRM.UI/Pages/NotificationSettingsPage.razor
@@ -7,7 +7,7 @@
 
 <div
       class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden"
-      style="--select-button-svg: url('data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724px%27 height=%2724px%27 fill=%27rgb(77,106,153)%27 viewBox=%270 0 256 256%27%3e%3cpath d=%27M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48A8,8,0,0,0,85.66,85.66Z%27%3e%3c/path%3e%3c/svg%3e'); font-family: Inter, &quot;Noto Sans&quot;, sans-serif;"
+      style="--select-button-svg: url('data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724px%27 height=%2724px%27 fill=%27rgb(77,106,153)%27 viewBox=%270 0 256 256%27%3e%3cpath d=%27M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48A8,8,0,0,0,85.66,85.66Z%27%3e%3c/path%3e%3c/svg%3e')"
     >
       <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-4 md:px-10 py-3">

--- a/src/NexaCRM.UI/Pages/PasswordResetPage.razor
+++ b/src/NexaCRM.UI/Pages/PasswordResetPage.razor
@@ -3,7 +3,7 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<PasswordResetPage> Localizer
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
       <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-10 py-3">
           <div class="flex items-center gap-4 text-[#0e131b]">

--- a/src/NexaCRM.UI/Pages/ProfileSettingsPage.razor
+++ b/src/NexaCRM.UI/Pages/ProfileSettingsPage.razor
@@ -5,7 +5,7 @@
 @inject IStringLocalizer<ProfileSettingsPage> Localizer
 @inject ISettingsService SettingsService
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
       <div class="layout-container flex h-full grow flex-col">
         <header class="profile-header flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-4 sm:px-6 md:px-10 py-3">
           <div class="flex items-center gap-4 text-[#0e131b]">

--- a/src/NexaCRM.UI/Pages/SalesCoachingAndTrainingModule.razor
+++ b/src/NexaCRM.UI/Pages/SalesCoachingAndTrainingModule.razor
@@ -2,7 +2,7 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<SalesCoachingAndTrainingModule> Localizer
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
       <div class="layout-container flex h-full grow flex-col">
         <div class="gap-1 px-6 flex flex-1 justify-center py-5">
           <div class="layout-content-container flex flex-col w-80">

--- a/src/NexaCRM.UI/Pages/SalesForecastingTool.razor
+++ b/src/NexaCRM.UI/Pages/SalesForecastingTool.razor
@@ -4,7 +4,7 @@
 
 <div
       class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden"
-      style="--select-button-svg: url('data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724px%27 height=%2724px%27 fill=%27rgb(77,106,153)%27 viewBox=%270 0 256 256%27%3e%3cpath d=%27M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48A8,8,0,0,0,85.66,85.66Z%27%3e%3c/path%3e%3c/svg%3e'); font-family: Inter, &quot;Noto Sans&quot;, sans-serif;"
+      style="--select-button-svg: url('data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724px%27 height=%2724px%27 fill=%27rgb(77,106,153)%27 viewBox=%270 0 256 256%27%3e%3cpath d=%27M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48A8,8,0,0,0,85.66,85.66Z%27%3e%3c/path%3e%3c/svg%3e')"
     >
       <div class="layout-container flex h-full grow flex-col">
         <div class="gap-1 px-6 flex flex-1 justify-center py-5">

--- a/src/NexaCRM.UI/Pages/SalesManagerDashboard.razor
+++ b/src/NexaCRM.UI/Pages/SalesManagerDashboard.razor
@@ -6,7 +6,7 @@
 @inject IJSRuntime JSRuntime
 @inject NavigationManager NavigationManager
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
       <div class="layout-container flex h-full grow flex-col">
         <header class="dashboard-header flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-4 sm:px-6 md:px-10 py-3">
           <div class="flex items-center gap-4 sm:gap-8">

--- a/src/NexaCRM.UI/Pages/SalesMaterialKnowledgeBase.razor
+++ b/src/NexaCRM.UI/Pages/SalesMaterialKnowledgeBase.razor
@@ -2,7 +2,7 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<SalesMaterialKnowledgeBase> Localizer
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
       <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-10 py-3">
           <div class="flex items-center gap-8">

--- a/src/NexaCRM.UI/Pages/SalesPipelinePage.razor
+++ b/src/NexaCRM.UI/Pages/SalesPipelinePage.razor
@@ -8,7 +8,7 @@
 @inject NavigationManager NavigationManager
 @inject IGlobalActionService GlobalActionService
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
     <div class="layout-container flex h-full grow flex-col">
     <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-10 py-3">
         <div class="flex items-center gap-8">

--- a/src/NexaCRM.UI/Pages/SalesTeamGoalSettingAndTrackingInterface.razor
+++ b/src/NexaCRM.UI/Pages/SalesTeamGoalSettingAndTrackingInterface.razor
@@ -4,7 +4,7 @@
 
 <div
       class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden"
-      style="--select-button-svg: url('data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724px%27 height=%2724px%27 fill=%27rgb(77,106,153)%27 viewBox=%270 0 256 256%27%3e%3cpath d=%27M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48A8,8,0,0,0,85.66,85.66Z%27%3e%3c/path%3e%3c/svg%3e'); font-family: Inter, &quot;Noto Sans&quot;, sans-serif;"
+      style="--select-button-svg: url('data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724px%27 height=%2724px%27 fill=%27rgb(77,106,153)%27 viewBox=%270 0 256 256%27%3e%3cpath d=%27M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48A8,8,0,0,0,85.66,85.66Z%27%3e%3c/path%3e%3c/svg%3e')"
     >
       <div class="layout-container flex h-full grow flex-col">
         <div class="gap-1 px-6 flex flex-1 justify-center py-5">

--- a/src/NexaCRM.UI/Pages/SettingsPage.razor
+++ b/src/NexaCRM.UI/Pages/SettingsPage.razor
@@ -6,7 +6,7 @@
 @inject IStringLocalizer<SettingsPage> Localizer
 @inject IOrganizationService OrganizationService
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
       <div class="layout-container flex h-full grow flex-col">
         <div class="gap-1 px-6 flex flex-1 justify-center py-5">
           <div class="layout-content-container flex flex-col w-80">

--- a/src/NexaCRM.UI/Pages/TasksPage.razor
+++ b/src/NexaCRM.UI/Pages/TasksPage.razor
@@ -4,7 +4,7 @@
 
 <PageTitle>@Localizer["Tasks"] - NexaCRM</PageTitle>
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
     <div class="layout-container flex h-full grow flex-col">
         <div class="px-4 md:px-40 flex flex-1 justify-center py-5">
             <div class="layout-content-container flex flex-col max-w-[960px] flex-1">

--- a/src/NexaCRM.UI/Pages/TestDashboard.razor
+++ b/src/NexaCRM.UI/Pages/TestDashboard.razor
@@ -9,7 +9,7 @@
 @inject IGlobalActionService GlobalActionService
 @implements IDisposable
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;' data-page="main-dashboard">
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" data-page="main-dashboard">
     <!-- Mobile Header Bar -->
     <div class="mobile-header">
         <div class="mobile-header-content">

--- a/src/NexaCRM.UI/Pages/ToolsPage.razor
+++ b/src/NexaCRM.UI/Pages/ToolsPage.razor
@@ -2,7 +2,7 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<ToolsPage> Localizer
 
-<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+<div class="relative flex size-full min-h-screen flex-col bg-slate-50 group/design-root overflow-x-hidden">
     <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#e7ecf3] px-10 py-3">
             <div class="flex items-center gap-8">

--- a/src/NexaCRM.UI/Pages/UserRegistrationPage.razor
+++ b/src/NexaCRM.UI/Pages/UserRegistrationPage.razor
@@ -10,7 +10,7 @@
 
 <div
       class="relative flex size-full min-h-screen flex-col group/design-root overflow-x-hidden overflow-y-auto"
-      style="--checkbox-tick-svg: url('data:image/svg+xml,%3csvg viewBox=%270 0 16 16%27 fill=%27rgb(248,250,252)%27 xmlns=%27http://www.w3.org/2000/svg%27%3e%3cpath d=%27M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.586 9.086l4.293-4.293a1 1 0 011.414 0z%27/%3e%3c/svg%3e'); font-family: Inter, &quot;Noto Sans&quot;, sans-serif;"
+      style="--checkbox-tick-svg: url('data:image/svg+xml,%3csvg viewBox=%270 0 16 16%27 fill=%27rgb(248,250,252)%27 xmlns=%27http://www.w3.org/2000/svg%27%3e%3cpath d=%27M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.586 9.086l4.293-4.293a1 1 0 011.414 0z%27/%3e%3c/svg%3e')"
     >
       <div class="layout-container flex h-full grow flex-col">
         <div class="flex flex-1 items-center justify-center py-8 px-4">

--- a/src/NexaCRM.UI/wwwroot/css/app.css
+++ b/src/NexaCRM.UI/wwwroot/css/app.css
@@ -1,5 +1,35 @@
+/* Typography */
+@font-face {
+    font-family: 'Pretendard Variable';
+    font-style: normal;
+    font-weight: 100 900;
+    font-display: swap;
+    src: url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/variable/pretendardvariable.woff2') format('woff2-variations');
+}
+
 /* CSS Custom Properties for Theme Management */
 :root {
+    /* Typography tokens */
+    --font-family-sans: 'Pretendard Variable', 'Pretendard', 'Inter', 'Noto Sans KR', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+                        'Apple SD Gothic Neo', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', sans-serif;
+    --font-family-heading: var(--font-family-sans);
+    --font-family-mono: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+    --font-weight-regular: 400;
+    --font-weight-medium: 500;
+    --font-weight-semibold: 600;
+    --font-weight-bold: 700;
+    --font-size-xs: 0.75rem;
+    --font-size-sm: 0.875rem;
+    --font-size-base: 1rem;
+    --font-size-lg: 1.125rem;
+    --font-size-xl: 1.375rem;
+    --font-size-2xl: clamp(1.75rem, 1.2rem + 1.8vw, 2.5rem);
+    --font-size-3xl: clamp(2.25rem, 1.8rem + 2.2vw, 3.125rem);
+    --body-line-height: 1.6;
+    --heading-line-height-tight: 1.2;
+    --heading-letter-spacing: -0.02em;
+    --body-letter-spacing: -0.01em;
+
     /* Design system colors */
     --color-primary: #2153C8;
     --color-secondary: #EEF2FF;
@@ -54,11 +84,18 @@
 
 /* Global typography: Prefer Pretendard Variable with robust fallbacks */
 html, body, button, input, select, textarea {
-    font-family: 'Pretendard Variable', 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-                 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', Arial,
-                 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', sans-serif;
+    font-family: var(--font-family-sans);
+    font-weight: var(--font-weight-regular);
     font-variant-numeric: tabular-nums; /* align dashboard numbers */
     font-optical-sizing: auto;
+    font-synthesis: none;
+    letter-spacing: var(--body-letter-spacing);
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+}
+
+code, pre, kbd, samp {
+    font-family: var(--font-family-mono);
 }
 
 /* Dark Theme Support */
@@ -132,7 +169,10 @@ html, body, button, input, select, textarea {
 }
 
 html, body {
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-family: var(--font-family-sans);
+    font-size: var(--font-size-base);
+    line-height: var(--body-line-height);
+    letter-spacing: var(--body-letter-spacing);
     margin: 0;
     padding: 0;
     width: 100%;
@@ -144,6 +184,40 @@ html, body {
     background-attachment: fixed;
     color: var(--text-primary);
     transition: background-color var(--transition-normal), color var(--transition-normal), background-image var(--transition-slow);
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-family-heading);
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--heading-line-height-tight);
+    letter-spacing: var(--heading-letter-spacing);
+    color: var(--text-primary);
+    margin-top: 0;
+}
+
+h1 {
+    font-size: var(--font-size-3xl);
+}
+
+h2 {
+    font-size: var(--font-size-2xl);
+}
+
+h3 {
+    font-size: var(--font-size-xl);
+}
+
+h4 {
+    font-size: var(--font-size-lg);
+}
+
+h5 {
+    font-size: var(--font-size-base);
+}
+
+h6 {
+    font-size: var(--font-size-sm);
+    letter-spacing: 0;
 }
 
 /* Force clean white background on desktop/tablet */


### PR DESCRIPTION
## Summary
- load the Pretendard Variable font in the shared UI library and expose reusable typography design tokens
- align global font defaults, heading scale, and code font families with the new tokens for consistent rendering
- document how to consume the typography tokens from `app.css` in the frontend style sharing guide
- remove scattered `font-family` overrides in UI pages so they inherit the shared typography tokens

## Testing
- dotnet build NexaCrmSolution.sln --configuration Release *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d97d3d10dc832cbabde8bd8e58f799