### PR TITLE
Replace WebServer mock services with Supabase implementations

### DIFF
--- a/docs/supabase-enterprise-services.md
+++ b/docs/supabase-enterprise-services.md
@@ -23,6 +23,11 @@
 - 오프라인 envelope 등록, 미적용 envelope 조회, 적용 처리, 충돌 기록/조회 기능을 제공합니다.
 - 충돌 정보는 envelope-organization 조합으로 그룹화되어 모바일/데스크톱 클라이언트가 쉽게 수집할 수 있습니다.
 
+## WebServer 통합 현황
+- Blazor Server 기반 `NexaCRM.WebServer` 프로젝트에서도 동일한 Supabase 서비스 구성을 사용하도록 정비했습니다.
+- 서버 호스트는 `SupabaseEnterpriseDataStore`를 싱글톤으로 등록해 WebClient와 동일한 인메모리 스토어를 공유합니다.
+- 기존 Mock 서비스 의존성은 모두 `Supabase*` 구현체로 교체되어, 서버와 WebClient가 동일한 인증/동기화/거버넌스 흐름을 따릅니다.
+
 ## 테스트 전략
 - `SupabaseEnterpriseDataStore`는 순수 C# 인메모리 컬렉션을 사용하므로 단위 테스트에서 별도의 외부 의존성을 요구하지 않습니다.
 - 서비스별 동작은 `NexaCRM.WebClient.UnitTests` 프로젝트에서 검증하며, 향후 실 Supabase 연동 시에는 통합 테스트를 추가할 수 있습니다.

--- a/src/NexaCRM.WebServer/Startup.cs
+++ b/src/NexaCRM.WebServer/Startup.cs
@@ -21,8 +21,8 @@ using NexaCRM.Service.Supabase.Configuration;
 using NexaCRM.Services.Admin.Interfaces;
 using NexaCRM.UI.Services;
 using NexaCRM.UI.Services.Interfaces;
-using NexaCRM.UI.Services.Mock;
 using NexaCRM.WebServer.Services;
+using NexaCRM.Service.Supabase.Enterprise;
 
 namespace NexaCRM.WebServer;
 
@@ -78,23 +78,25 @@ public sealed class Startup
         services.AddScoped<INavigationStateService, NavigationStateService>();
         services.AddScoped<IDeviceService, DeviceService>();
         services.AddScoped<IUserFavoritesService, UserFavoritesService>();
-        services.AddSingleton<ISyncOrchestrationService, MockSyncOrchestrationService>();
-        services.AddSingleton<ICommunicationHubService, MockCommunicationHubService>();
-        services.AddSingleton<IFileHubService, MockFileHubService>();
-        services.AddSingleton<ISettingsCustomizationService, MockSettingsCustomizationService>();
-        services.AddSingleton<IUserGovernanceService, MockUserGovernanceService>();
+        services.AddSingleton<SupabaseEnterpriseDataStore>();
 
-        services.AddScoped<IContactService, MockContactService>();
-        services.AddScoped<IDealService, MockDealService>();
-        services.AddScoped<ITaskService, MockTaskService>();
-        services.AddScoped<ISupportTicketService, MockSupportTicketService>();
-        services.AddScoped<IAgentService, MockAgentService>();
-        services.AddScoped<IMarketingCampaignService, MockMarketingCampaignService>();
-        services.AddScoped<IReportService, MockReportService>();
-        services.AddScoped<IActivityService, MockActivityService>();
-        services.AddScoped<ISalesManagementService, MockSalesManagementService>();
-        services.AddScoped<IEmailTemplateService, MockEmailTemplateService>();
-        services.AddScoped<ITeamService, MockTeamService>();
+        services.AddScoped<ISyncOrchestrationService, SupabaseSyncOrchestrationService>();
+        services.AddScoped<ICommunicationHubService, SupabaseCommunicationHubService>();
+        services.AddScoped<IFileHubService, SupabaseFileHubService>();
+        services.AddScoped<ISettingsCustomizationService, SupabaseSettingsCustomizationService>();
+        services.AddScoped<IUserGovernanceService, SupabaseUserGovernanceService>();
+
+        services.AddScoped<IContactService, SupabaseContactService>();
+        services.AddScoped<IDealService, SupabaseDealService>();
+        services.AddScoped<ITaskService, SupabaseTaskService>();
+        services.AddScoped<ISupportTicketService, SupabaseSupportTicketService>();
+        services.AddScoped<IAgentService, SupabaseAgentService>();
+        services.AddScoped<IMarketingCampaignService, SupabaseMarketingCampaignService>();
+        services.AddScoped<IReportService, SupabaseReportService>();
+        services.AddScoped<IActivityService, SupabaseActivityService>();
+        services.AddScoped<ISalesManagementService, SupabaseSalesManagementService>();
+        services.AddScoped<IEmailTemplateService, SupabaseEmailTemplateService>();
+        services.AddScoped<ITeamService, SupabaseTeamService>();
 
     }
 


### PR DESCRIPTION
## Summary
- update the Blazor WebServer startup pipeline to register Supabase-backed services instead of mock implementations
- share the SupabaseEnterpriseDataStore singleton so server and web client use the same in-memory persistence model
- document the WebServer alignment in the Supabase enterprise services overview

## Testing
- `dotnet build NexaCrmSolution.sln` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e0ef462ffc832cb95ee00bfb6f691f