### PR TITLE
Fix desktop shell offset to honor navigation tail width

### DIFF
--- a/src/NexaCRM.UI/Shared/MainLayout.razor.css
+++ b/src/NexaCRM.UI/Shared/MainLayout.razor.css
@@ -8,6 +8,7 @@
     --nav-rail-width: 80px;
     --nav-width: 320px;
     --nav-collapsed-width: 72px;
+    --navigation-tail-width: calc(var(--nav-rail-width) + var(--nav-width));
 }
 .desktop-shell {
     display: grid;
@@ -49,7 +50,7 @@
    before the main content (which matches how the layout renders the nav
    component). */
 .sidebar:not(.panel-open):not(.collapsed) ~ .desktop-shell__main {
-    --desktop-shell-offset: calc(var(--nav-rail-width) + var(--nav-width));
+    --desktop-shell-offset: var(--navigation-tail-width);
 }
 
 /* When the sidebar is an overlaying panel (panel-open), do not offset the

--- a/src/NexaCRM.UI/Shared/NavigationTail.razor.css
+++ b/src/NexaCRM.UI/Shared/NavigationTail.razor.css
@@ -7,13 +7,15 @@
     top: 0;
     z-index: 1000;
     align-items: stretch;
-    width: calc(var(--nav-rail-width, 80px) + var(--nav-width, 320px));
-    min-width: calc(var(--nav-rail-width, 80px) + var(--nav-width, 320px));
+    --sidebar-total-width: var(--navigation-tail-width, calc(var(--nav-rail-width, 80px) + var(--nav-width, 320px)));
+    width: var(--sidebar-total-width);
+    min-width: var(--sidebar-total-width);
 }
 
 .sidebar.collapsed {
-    width: var(--nav-collapsed-width, 72px);
-    min-width: var(--nav-collapsed-width, 72px);
+    --sidebar-total-width: var(--nav-collapsed-width, 72px);
+    width: var(--sidebar-total-width);
+    min-width: var(--sidebar-total-width);
 }
 
 .sidebar-mobile-header {
@@ -295,26 +297,34 @@
    these layout rules win over other scoped styles. */
 :global(.sidebar.panel-open) ~ .desktop-shell__main {
     --desktop-shell-offset: 0px !important; /* panel overlays — main should not be pushed */
-    margin-left: var(--desktop-shell-offset) !important;
-    width: max(0px, calc(100% - var(--desktop-shell-offset))) !important;
     position: relative;
     z-index: 0 !important;
 }
 
 :global(.sidebar:not(.panel-open)) ~ .desktop-shell__main {
-    --desktop-shell-offset: calc(var(--nav-rail-width, 80px) + var(--nav-width, 320px)) !important;
-    margin-left: var(--desktop-shell-offset) !important;
-    width: max(0px, calc(100% - var(--desktop-shell-offset))) !important;
+    --desktop-shell-offset: var(--sidebar-total-width, calc(var(--nav-rail-width, 80px) + var(--nav-width, 320px))) !important;
     position: relative;
     z-index: 0 !important;
 }
 
 :global(.sidebar.collapsed) ~ .desktop-shell__main {
-    --desktop-shell-offset: var(--nav-collapsed-width, 72px) !important; /* keep collapsed behavior consistent */
-    margin-left: var(--desktop-shell-offset) !important;
-    width: max(0px, calc(100% - var(--desktop-shell-offset))) !important;
+    --desktop-shell-offset: var(--sidebar-total-width, var(--nav-collapsed-width, 72px)) !important; /* keep collapsed behavior consistent */
     position: relative;
     z-index: 0 !important;
+}
+
+@media (max-width: 1023.98px) {
+    :global(.sidebar) ~ .desktop-shell__main {
+        margin-left: 0 !important;
+        width: 100% !important;
+    }
+}
+
+@media (min-width: 1024px) {
+    :global(.sidebar) ~ .desktop-shell__main {
+        margin-left: var(--desktop-shell-offset) !important;
+        width: max(0px, calc(100% - var(--desktop-shell-offset))) !important;
+    }
 }
 
 .panel-header {


### PR DESCRIPTION
## Summary
- expose a shared navigation-tail width token on the desktop shell and bind the main container margins directly to it
- drive the sidebar width and offset updates from a single custom property so the main area always accounts for the navigation tail footprint

## Testing
- `dotnet build --configuration Release` *(fails: dotnet CLI not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6911541fa918832c8a8f201ee10b7fcd)