### PR TITLE
Fix Docker build to use NexaCrmSolution and roll-forward SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Multi-stage build for NexaCRM WebServer
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+# Copy solution and source
+COPY global.json ./
+COPY NexaCrmSolution.sln ./
+COPY src ./src
+COPY tests ./tests
+
+# Restore dependencies with roll-forward support from global.json
+RUN dotnet restore "NexaCrmSolution.sln"
+
+# Publish the server host
+RUN dotnet publish "src/NexaCRM.WebServer/NexaCRM.WebServer.csproj" \
+    --configuration Release \
+    --output /app/publish \
+    /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish ./
+
+# Configure container runtime
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "NexaCRM.WebServer.dll"]

--- a/docs/dotnet-build-environment.md
+++ b/docs/dotnet-build-environment.md
@@ -2,6 +2,8 @@
 
 ## 개요
 - `NexaCrmSolution.sln`은 .NET 8 SDK를 필요로 합니다.
+- 루트에 있는 `global.json`은 `8.0.100` 기능 밴드를 기준으로 `rollForward: latestFeature` 옵션을 선언하여 `8.0.4xx`와 같이 더 최신
+  패치를 자동으로 활용합니다. CI 이미지에 보다 새로운 8.0 SDK만 설치되어 있어도 `dotnet restore`가 실패하지 않습니다.
 - 이 문서는 CI나 로컬 개발 환경에서 `dotnet build --configuration Release`를 실행하기 위한 필수 패키지 설치 절차를 정리합니다.
 
 ## 사전 준비

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## Summary
- add a repo-level global.json that rolls forward the 8.0.100 SDK request to the latest available feature band
- provide a Dockerfile that restores NexaCrmSolution.sln and publishes the NexaCRM.WebServer project
- document the new SDK roll-forward behavior in the .NET build environment guide

## Testing
- not run (dotnet CLI unavailable in execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6915c70661f4832c847609cc971856b6)